### PR TITLE
[codex] detect ghostty kitty probe replies

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -648,19 +648,23 @@ static gboolean input_response_contains_case_insensitive(const char *buffer, con
 
     gsize token_length = strlen(token);
     for (const char *cursor = buffer; *cursor != '\0'; cursor++) {
-        gsize matched = 0;
-
-        while (matched < token_length && cursor[matched] != '\0' &&
-               g_ascii_tolower((guchar)cursor[matched]) == token[matched]) {
-            matched++;
-        }
-
-        if (matched == token_length) {
+        if (g_ascii_strncasecmp(cursor, token, token_length) == 0) {
             return TRUE;
         }
+    }
 
-        if (cursor[matched] == '\0') {
-            break;
+    return FALSE;
+}
+
+static gboolean input_response_matches_any_case_insensitive(const char *buffer,
+                                                            const char *const *tokens) {
+    if (!buffer || !tokens) {
+        return FALSE;
+    }
+
+    for (gsize i = 0; tokens[i] != NULL; i++) {
+        if (input_response_contains_case_insensitive(buffer, tokens[i])) {
+            return TRUE;
         }
     }
 
@@ -668,9 +672,14 @@ static gboolean input_response_contains_case_insensitive(const char *buffer, con
 }
 
 static gboolean input_response_has_kitty(const char *buffer) {
-    return input_response_contains_case_insensitive(buffer, "kitty") ||
-           input_response_contains_case_insensitive(buffer, ">|ghostty") ||
-           input_response_contains_case_insensitive(buffer, ">|libghostty");
+    static const char *const k_kitty_affirmative_tokens[] = {
+        "kitty",
+        ">|ghostty",
+        ">|libghostty",
+        NULL,
+    };
+
+    return input_response_matches_any_case_insensitive(buffer, k_kitty_affirmative_tokens);
 }
 
 static gboolean input_response_has_iterm2(const char *buffer) {

--- a/src/input.c
+++ b/src/input.c
@@ -641,6 +641,9 @@ static gboolean input_response_has_sixel(const char *buffer) {
     return FALSE;
 }
 
+/* Probe replies are short ASCII payloads, so a simple sliding-window search
+ * keeps the matcher allocation-free while still using GLib's case-insensitive
+ * comparison helper for each candidate position. */
 static gboolean input_response_contains_case_insensitive(const char *buffer, const char *token) {
     if (!buffer || !token || token[0] == '\0') {
         return FALSE;
@@ -672,6 +675,10 @@ static gboolean input_response_matches_any_case_insensitive(const char *buffer,
 }
 
 static gboolean input_response_has_kitty(const char *buffer) {
+    /* Kitty may identify itself directly, while Ghostty/libghostty advertise
+     * kitty-compatible XTVERSION payloads with a ">|..." prefix. Keep these
+     * affirmative markers together and match them case-insensitively so future
+     * probe-format updates only need token-list changes here. */
     static const char *const k_kitty_affirmative_tokens[] = {
         "kitty",
         ">|ghostty",

--- a/src/input.c
+++ b/src/input.c
@@ -646,7 +646,17 @@ static gboolean input_response_has_kitty(const char *buffer) {
         return FALSE;
     }
 
-    return strstr(buffer, "kitty") != NULL;
+    gchar *lower = g_ascii_strdown(buffer, -1);
+    if (!lower) {
+        return FALSE;
+    }
+
+    gboolean supported = strstr(lower, "kitty") != NULL ||
+                         strstr(lower, ">|ghostty") != NULL ||
+                         strstr(lower, ">|libghostty") != NULL;
+
+    g_free(lower);
+    return supported;
 }
 
 static gboolean input_response_has_iterm2(const char *buffer) {

--- a/src/input.c
+++ b/src/input.c
@@ -641,22 +641,36 @@ static gboolean input_response_has_sixel(const char *buffer) {
     return FALSE;
 }
 
+static gboolean input_response_contains_case_insensitive(const char *buffer, const char *token) {
+    if (!buffer || !token || token[0] == '\0') {
+        return FALSE;
+    }
+
+    gsize token_length = strlen(token);
+    for (const char *cursor = buffer; *cursor != '\0'; cursor++) {
+        gsize matched = 0;
+
+        while (matched < token_length && cursor[matched] != '\0' &&
+               g_ascii_tolower((guchar)cursor[matched]) == token[matched]) {
+            matched++;
+        }
+
+        if (matched == token_length) {
+            return TRUE;
+        }
+
+        if (cursor[matched] == '\0') {
+            break;
+        }
+    }
+
+    return FALSE;
+}
+
 static gboolean input_response_has_kitty(const char *buffer) {
-    if (!buffer) {
-        return FALSE;
-    }
-
-    gchar *lower = g_ascii_strdown(buffer, -1);
-    if (!lower) {
-        return FALSE;
-    }
-
-    gboolean supported = strstr(lower, "kitty") != NULL ||
-                         strstr(lower, ">|ghostty") != NULL ||
-                         strstr(lower, ">|libghostty") != NULL;
-
-    g_free(lower);
-    return supported;
+    return input_response_contains_case_insensitive(buffer, "kitty") ||
+           input_response_contains_case_insensitive(buffer, ">|ghostty") ||
+           input_response_contains_case_insensitive(buffer, ">|libghostty");
 }
 
 static gboolean input_response_has_iterm2(const char *buffer) {

--- a/tests/test_app_cli.c
+++ b/tests/test_app_cli.c
@@ -261,6 +261,52 @@ static void app_cli_probe_fixture_disable_raw_mode(InputHandler *handler, gpoint
     fixture->disable_raw_mode_calls++;
 }
 
+static void assert_app_cli_probe_resolves_to_kitty(const gchar *response,
+                                                   const gchar *env_key,
+                                                   const gchar *env_value) {
+    static const TerminalProbeTransportHooks hooks = {
+        .stdin_is_tty = app_cli_probe_fixture_stdin_is_tty,
+        .stdout_is_tty = app_cli_probe_fixture_stdout_is_tty,
+        .tcgetattr_fn = app_cli_probe_fixture_tcgetattr,
+        .tcsetattr_fn = app_cli_probe_fixture_tcsetattr,
+        .tcflush_fn = app_cli_probe_fixture_tcflush,
+        .write_fn = app_cli_probe_fixture_write,
+        .read_char_with_timeout_fn = app_cli_probe_fixture_read_char_with_timeout,
+        .monotonic_time_us_fn = app_cli_probe_fixture_monotonic_time_us,
+    };
+    AppCliProbeFixture probe_fixture = {
+        .response = response,
+        .response_length = strlen(response),
+        .writes = g_string_new(NULL),
+    };
+    AppConfig config;
+
+    queue_terminal_protocol_env_restore_and_clear();
+    if (env_key && env_value) {
+        g_assert_true(g_setenv(env_key, env_value, TRUE));
+    }
+
+    terminal_probe_set_transport_hooks_for_test(&hooks, &probe_fixture);
+    g_test_queue_destroy(reset_app_cli_probe_hooks, NULL);
+    input_set_enable_raw_mode_observer_for_test(app_cli_probe_fixture_enable_raw_mode,
+                                                &probe_fixture);
+    input_set_disable_raw_mode_observer_for_test(app_cli_probe_fixture_disable_raw_mode,
+                                                 &probe_fixture);
+
+    app_config_init(&config);
+    app_config_resolve_protocol(&config);
+
+    g_assert_false(config.force_text);
+    g_assert_false(config.force_sixel);
+    g_assert_true(config.force_kitty);
+    g_assert_false(config.force_iterm2);
+    g_assert_cmpstr(probe_fixture.writes->str, ==, "\033[>q\033[5n");
+    g_assert_cmpint(probe_fixture.enable_raw_mode_calls, ==, 0);
+    g_assert_cmpint(probe_fixture.disable_raw_mode_calls, ==, 0);
+
+    g_string_free(probe_fixture.writes, TRUE);
+}
+
 static void queue_env_restore(const gchar *name) {
     EnvVarRestore *saved = g_new0(EnvVarRestore, 1);
     saved->name = g_strdup(name);
@@ -966,46 +1012,7 @@ static void test_cli_protocol_resolution_auto_accepts_libghostty_xtversion_as_ki
     (void)fixture;
     (void)user_data;
 
-    static const gchar k_libghostty_response[] = "\033P>|libghostty\033\\";
-    static const TerminalProbeTransportHooks hooks = {
-        .stdin_is_tty = app_cli_probe_fixture_stdin_is_tty,
-        .stdout_is_tty = app_cli_probe_fixture_stdout_is_tty,
-        .tcgetattr_fn = app_cli_probe_fixture_tcgetattr,
-        .tcsetattr_fn = app_cli_probe_fixture_tcsetattr,
-        .tcflush_fn = app_cli_probe_fixture_tcflush,
-        .write_fn = app_cli_probe_fixture_write,
-        .read_char_with_timeout_fn = app_cli_probe_fixture_read_char_with_timeout,
-        .monotonic_time_us_fn = app_cli_probe_fixture_monotonic_time_us,
-    };
-    AppCliProbeFixture probe_fixture = {
-        .response = k_libghostty_response,
-        .response_length = sizeof(k_libghostty_response) - 1,
-        .writes = g_string_new(NULL),
-    };
-    AppConfig config;
-
-    queue_terminal_protocol_env_restore_and_clear();
-    g_assert_true(g_setenv("TERM_PROGRAM", "ghostty", TRUE));
-
-    terminal_probe_set_transport_hooks_for_test(&hooks, &probe_fixture);
-    g_test_queue_destroy(reset_app_cli_probe_hooks, NULL);
-    input_set_enable_raw_mode_observer_for_test(app_cli_probe_fixture_enable_raw_mode,
-                                                &probe_fixture);
-    input_set_disable_raw_mode_observer_for_test(app_cli_probe_fixture_disable_raw_mode,
-                                                 &probe_fixture);
-
-    app_config_init(&config);
-    app_config_resolve_protocol(&config);
-
-    g_assert_false(config.force_text);
-    g_assert_false(config.force_sixel);
-    g_assert_true(config.force_kitty);
-    g_assert_false(config.force_iterm2);
-    g_assert_cmpstr(probe_fixture.writes->str, ==, "\033[>q\033[5n");
-    g_assert_cmpint(probe_fixture.enable_raw_mode_calls, ==, 0);
-    g_assert_cmpint(probe_fixture.disable_raw_mode_calls, ==, 0);
-
-    g_string_free(probe_fixture.writes, TRUE);
+    assert_app_cli_probe_resolves_to_kitty("\033P>|libghostty\033\\", "TERM_PROGRAM", "ghostty");
 }
 
 static void test_cli_protocol_resolution_auto_accepts_ghostty_xtversion_as_kitty_signal(
@@ -1014,46 +1021,7 @@ static void test_cli_protocol_resolution_auto_accepts_ghostty_xtversion_as_kitty
     (void)fixture;
     (void)user_data;
 
-    static const gchar k_ghostty_response[] = "\033P>|Ghostty 1.2.3\033\\";
-    static const TerminalProbeTransportHooks hooks = {
-        .stdin_is_tty = app_cli_probe_fixture_stdin_is_tty,
-        .stdout_is_tty = app_cli_probe_fixture_stdout_is_tty,
-        .tcgetattr_fn = app_cli_probe_fixture_tcgetattr,
-        .tcsetattr_fn = app_cli_probe_fixture_tcsetattr,
-        .tcflush_fn = app_cli_probe_fixture_tcflush,
-        .write_fn = app_cli_probe_fixture_write,
-        .read_char_with_timeout_fn = app_cli_probe_fixture_read_char_with_timeout,
-        .monotonic_time_us_fn = app_cli_probe_fixture_monotonic_time_us,
-    };
-    AppCliProbeFixture probe_fixture = {
-        .response = k_ghostty_response,
-        .response_length = sizeof(k_ghostty_response) - 1,
-        .writes = g_string_new(NULL),
-    };
-    AppConfig config;
-
-    queue_terminal_protocol_env_restore_and_clear();
-    g_assert_true(g_setenv("TERM", "xterm-ghostty", TRUE));
-
-    terminal_probe_set_transport_hooks_for_test(&hooks, &probe_fixture);
-    g_test_queue_destroy(reset_app_cli_probe_hooks, NULL);
-    input_set_enable_raw_mode_observer_for_test(app_cli_probe_fixture_enable_raw_mode,
-                                                &probe_fixture);
-    input_set_disable_raw_mode_observer_for_test(app_cli_probe_fixture_disable_raw_mode,
-                                                 &probe_fixture);
-
-    app_config_init(&config);
-    app_config_resolve_protocol(&config);
-
-    g_assert_false(config.force_text);
-    g_assert_false(config.force_sixel);
-    g_assert_true(config.force_kitty);
-    g_assert_false(config.force_iterm2);
-    g_assert_cmpstr(probe_fixture.writes->str, ==, "\033[>q\033[5n");
-    g_assert_cmpint(probe_fixture.enable_raw_mode_calls, ==, 0);
-    g_assert_cmpint(probe_fixture.disable_raw_mode_calls, ==, 0);
-
-    g_string_free(probe_fixture.writes, TRUE);
+    assert_app_cli_probe_resolves_to_kitty("\033P>|Ghostty 1.2.3\033\\", "TERM", "xterm-ghostty");
 }
 
 static void test_cli_protocol_resolution_auto_multi_protocol_hint_keeps_local_sixel_first_order(

--- a/tests/test_app_cli.c
+++ b/tests/test_app_cli.c
@@ -960,6 +960,102 @@ static void test_cli_protocol_resolution_auto_prefers_affirmative_signal_before_
     g_string_free(probe_fixture.writes, TRUE);
 }
 
+static void test_cli_protocol_resolution_auto_accepts_libghostty_xtversion_as_kitty_signal(
+    AppCliFixture *fixture,
+    gconstpointer user_data) {
+    (void)fixture;
+    (void)user_data;
+
+    static const gchar k_libghostty_response[] = "\033P>|libghostty\033\\";
+    static const TerminalProbeTransportHooks hooks = {
+        .stdin_is_tty = app_cli_probe_fixture_stdin_is_tty,
+        .stdout_is_tty = app_cli_probe_fixture_stdout_is_tty,
+        .tcgetattr_fn = app_cli_probe_fixture_tcgetattr,
+        .tcsetattr_fn = app_cli_probe_fixture_tcsetattr,
+        .tcflush_fn = app_cli_probe_fixture_tcflush,
+        .write_fn = app_cli_probe_fixture_write,
+        .read_char_with_timeout_fn = app_cli_probe_fixture_read_char_with_timeout,
+        .monotonic_time_us_fn = app_cli_probe_fixture_monotonic_time_us,
+    };
+    AppCliProbeFixture probe_fixture = {
+        .response = k_libghostty_response,
+        .response_length = sizeof(k_libghostty_response) - 1,
+        .writes = g_string_new(NULL),
+    };
+    AppConfig config;
+
+    queue_terminal_protocol_env_restore_and_clear();
+    g_assert_true(g_setenv("TERM_PROGRAM", "ghostty", TRUE));
+
+    terminal_probe_set_transport_hooks_for_test(&hooks, &probe_fixture);
+    g_test_queue_destroy(reset_app_cli_probe_hooks, NULL);
+    input_set_enable_raw_mode_observer_for_test(app_cli_probe_fixture_enable_raw_mode,
+                                                &probe_fixture);
+    input_set_disable_raw_mode_observer_for_test(app_cli_probe_fixture_disable_raw_mode,
+                                                 &probe_fixture);
+
+    app_config_init(&config);
+    app_config_resolve_protocol(&config);
+
+    g_assert_false(config.force_text);
+    g_assert_false(config.force_sixel);
+    g_assert_true(config.force_kitty);
+    g_assert_false(config.force_iterm2);
+    g_assert_cmpstr(probe_fixture.writes->str, ==, "\033[>q\033[5n");
+    g_assert_cmpint(probe_fixture.enable_raw_mode_calls, ==, 0);
+    g_assert_cmpint(probe_fixture.disable_raw_mode_calls, ==, 0);
+
+    g_string_free(probe_fixture.writes, TRUE);
+}
+
+static void test_cli_protocol_resolution_auto_accepts_ghostty_xtversion_as_kitty_signal(
+    AppCliFixture *fixture,
+    gconstpointer user_data) {
+    (void)fixture;
+    (void)user_data;
+
+    static const gchar k_ghostty_response[] = "\033P>|Ghostty 1.2.3\033\\";
+    static const TerminalProbeTransportHooks hooks = {
+        .stdin_is_tty = app_cli_probe_fixture_stdin_is_tty,
+        .stdout_is_tty = app_cli_probe_fixture_stdout_is_tty,
+        .tcgetattr_fn = app_cli_probe_fixture_tcgetattr,
+        .tcsetattr_fn = app_cli_probe_fixture_tcsetattr,
+        .tcflush_fn = app_cli_probe_fixture_tcflush,
+        .write_fn = app_cli_probe_fixture_write,
+        .read_char_with_timeout_fn = app_cli_probe_fixture_read_char_with_timeout,
+        .monotonic_time_us_fn = app_cli_probe_fixture_monotonic_time_us,
+    };
+    AppCliProbeFixture probe_fixture = {
+        .response = k_ghostty_response,
+        .response_length = sizeof(k_ghostty_response) - 1,
+        .writes = g_string_new(NULL),
+    };
+    AppConfig config;
+
+    queue_terminal_protocol_env_restore_and_clear();
+    g_assert_true(g_setenv("TERM", "xterm-ghostty", TRUE));
+
+    terminal_probe_set_transport_hooks_for_test(&hooks, &probe_fixture);
+    g_test_queue_destroy(reset_app_cli_probe_hooks, NULL);
+    input_set_enable_raw_mode_observer_for_test(app_cli_probe_fixture_enable_raw_mode,
+                                                &probe_fixture);
+    input_set_disable_raw_mode_observer_for_test(app_cli_probe_fixture_disable_raw_mode,
+                                                 &probe_fixture);
+
+    app_config_init(&config);
+    app_config_resolve_protocol(&config);
+
+    g_assert_false(config.force_text);
+    g_assert_false(config.force_sixel);
+    g_assert_true(config.force_kitty);
+    g_assert_false(config.force_iterm2);
+    g_assert_cmpstr(probe_fixture.writes->str, ==, "\033[>q\033[5n");
+    g_assert_cmpint(probe_fixture.enable_raw_mode_calls, ==, 0);
+    g_assert_cmpint(probe_fixture.disable_raw_mode_calls, ==, 0);
+
+    g_string_free(probe_fixture.writes, TRUE);
+}
+
 static void test_cli_protocol_resolution_auto_multi_protocol_hint_keeps_local_sixel_first_order(
     AppCliFixture *fixture,
     gconstpointer user_data) {
@@ -1111,6 +1207,10 @@ void register_app_cli_tests(void) {
     add_app_cli_test("/app_cli/parse/protocol", test_cli_protocol_argument_parses_supported_modes);
     add_app_cli_test("/app_cli/protocol_resolution/auto_prefers_affirmative_signal_before_generic_probe_order",
                      test_cli_protocol_resolution_auto_prefers_affirmative_signal_before_generic_probe_order);
+    add_app_cli_test("/app_cli/protocol_resolution/auto_accepts_libghostty_xtversion_as_kitty_signal",
+                     test_cli_protocol_resolution_auto_accepts_libghostty_xtversion_as_kitty_signal);
+    add_app_cli_test("/app_cli/protocol_resolution/auto_accepts_ghostty_xtversion_as_kitty_signal",
+                     test_cli_protocol_resolution_auto_accepts_ghostty_xtversion_as_kitty_signal);
     add_app_cli_test("/app_cli/protocol_resolution/auto_multi_protocol_hint_keeps_local_sixel_first_order",
                      test_cli_protocol_resolution_auto_multi_protocol_hint_keeps_local_sixel_first_order);
     add_app_cli_test("/app_cli/protocol_resolution/auto_probe_avoids_raw_mode_transitions",


### PR DESCRIPTION
## Summary
`auto` mode could fall back to text on Ghostty-based terminals even when kitty graphics were available. This was easy to reproduce in cmux because the terminal is libghostty-backed and advertises Ghostty-family XTVERSION replies rather than the literal `kitty` string.

The root cause was the kitty affirmative-signal matcher in `src/input.c`. It only treated replies containing `kitty` as successful, so valid Ghostty/libghostty XTVERSION payloads were considered inconclusive and the resolver fell through to text mode.

This change keeps the existing resolver order and SSH behavior intact, but teaches the kitty probe matcher to recognize Ghostty-family XTVERSION replies as kitty-compatible signals. That lets local `auto` mode select kitty for Ghostty/libghostty terminals without adding any environment-only overrides.

## Validation
I added regression coverage for both `libghostty` and `Ghostty 1.2.3` XTVERSION replies in the existing app CLI protocol-resolution tests.

I verified the change with:
- `bin/pixelterm-tests -p /app_cli/protocol_resolution`
- `make test`

## Summary by Sourcery

更新终端协议检测逻辑：在保持现有探测行为不变的前提下，将 Ghostty 家族的 XTVERSION 响应视为兼容 kitty 的终端。

Bug Fixes（错误修复）:
- 通过识别来自 Ghostty/libghostty 终端的 XTVERSION 响应为 kitty 信号，防止在这些终端具备 kitty 图形能力时，自动协议解析错误地回退到纯文本模式。

Enhancements（增强功能）:
- 将 kitty “肯定信号”的检测泛化为对一小组已知标记进行不区分大小写匹配，其中包含 Ghostty 变种。

Tests（测试）:
- 新增 CLI 协议解析测试，用于断言特定的 Ghostty 和 libghostty XTVERSION 响应会使自动模式选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update terminal protocol detection to treat Ghostty-family XTVERSION replies as kitty-capable while preserving existing probe behavior.

Bug Fixes:
- Prevent auto protocol resolution from falling back to text when kitty graphics are available on Ghostty/libghostty terminals by recognizing their XTVERSION replies as kitty signals.

Enhancements:
- Generalize kitty affirmative-signal detection to a case-insensitive match over a small set of known tokens, including Ghostty variants.

Tests:
- Add CLI protocol resolution tests asserting that specific Ghostty and libghostty XTVERSION responses cause auto mode to select the kitty protocol.

</details>

Bug 修复：
- 通过将 Ghostty/libghostty 支持的终端的 XTVERSION 响应识别为 kitty 信号，防止在可用 kitty 图形能力的情况下，自动协议解析却回退到纯文本模式。

增强功能：
- 将 kitty 肯定信号的检测泛化为：对一小组已知标记（包含 Ghostty 变体）进行不区分大小写匹配。

测试：
- 添加 CLI 协议解析测试，用于断言当 Ghostty 和 libghostty 返回特定 XTVERSION 响应时，自动模式会选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新终端协议检测逻辑：在保持现有探测行为不变的前提下，将 Ghostty 家族的 XTVERSION 响应视为兼容 kitty 的终端。

Bug Fixes（错误修复）:
- 通过识别来自 Ghostty/libghostty 终端的 XTVERSION 响应为 kitty 信号，防止在这些终端具备 kitty 图形能力时，自动协议解析错误地回退到纯文本模式。

Enhancements（增强功能）:
- 将 kitty “肯定信号”的检测泛化为对一小组已知标记进行不区分大小写匹配，其中包含 Ghostty 变种。

Tests（测试）:
- 新增 CLI 协议解析测试，用于断言特定的 Ghostty 和 libghostty XTVERSION 响应会使自动模式选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update terminal protocol detection to treat Ghostty-family XTVERSION replies as kitty-capable while preserving existing probe behavior.

Bug Fixes:
- Prevent auto protocol resolution from falling back to text when kitty graphics are available on Ghostty/libghostty terminals by recognizing their XTVERSION replies as kitty signals.

Enhancements:
- Generalize kitty affirmative-signal detection to a case-insensitive match over a small set of known tokens, including Ghostty variants.

Tests:
- Add CLI protocol resolution tests asserting that specific Ghostty and libghostty XTVERSION responses cause auto mode to select the kitty protocol.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新终端协议检测逻辑：在保持现有探测行为不变的前提下，将 Ghostty 家族的 XTVERSION 响应视为兼容 kitty 的终端。

Bug Fixes（错误修复）:
- 通过识别来自 Ghostty/libghostty 终端的 XTVERSION 响应为 kitty 信号，防止在这些终端具备 kitty 图形能力时，自动协议解析错误地回退到纯文本模式。

Enhancements（增强功能）:
- 将 kitty “肯定信号”的检测泛化为对一小组已知标记进行不区分大小写匹配，其中包含 Ghostty 变种。

Tests（测试）:
- 新增 CLI 协议解析测试，用于断言特定的 Ghostty 和 libghostty XTVERSION 响应会使自动模式选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update terminal protocol detection to treat Ghostty-family XTVERSION replies as kitty-capable while preserving existing probe behavior.

Bug Fixes:
- Prevent auto protocol resolution from falling back to text when kitty graphics are available on Ghostty/libghostty terminals by recognizing their XTVERSION replies as kitty signals.

Enhancements:
- Generalize kitty affirmative-signal detection to a case-insensitive match over a small set of known tokens, including Ghostty variants.

Tests:
- Add CLI protocol resolution tests asserting that specific Ghostty and libghostty XTVERSION responses cause auto mode to select the kitty protocol.

</details>

Bug 修复：
- 通过将 Ghostty/libghostty 支持的终端的 XTVERSION 响应识别为 kitty 信号，防止在可用 kitty 图形能力的情况下，自动协议解析却回退到纯文本模式。

增强功能：
- 将 kitty 肯定信号的检测泛化为：对一小组已知标记（包含 Ghostty 变体）进行不区分大小写匹配。

测试：
- 添加 CLI 协议解析测试，用于断言当 Ghostty 和 libghostty 返回特定 XTVERSION 响应时，自动模式会选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新终端协议检测逻辑：在保持现有探测行为不变的前提下，将 Ghostty 家族的 XTVERSION 响应视为兼容 kitty 的终端。

Bug Fixes（错误修复）:
- 通过识别来自 Ghostty/libghostty 终端的 XTVERSION 响应为 kitty 信号，防止在这些终端具备 kitty 图形能力时，自动协议解析错误地回退到纯文本模式。

Enhancements（增强功能）:
- 将 kitty “肯定信号”的检测泛化为对一小组已知标记进行不区分大小写匹配，其中包含 Ghostty 变种。

Tests（测试）:
- 新增 CLI 协议解析测试，用于断言特定的 Ghostty 和 libghostty XTVERSION 响应会使自动模式选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update terminal protocol detection to treat Ghostty-family XTVERSION replies as kitty-capable while preserving existing probe behavior.

Bug Fixes:
- Prevent auto protocol resolution from falling back to text when kitty graphics are available on Ghostty/libghostty terminals by recognizing their XTVERSION replies as kitty signals.

Enhancements:
- Generalize kitty affirmative-signal detection to a case-insensitive match over a small set of known tokens, including Ghostty variants.

Tests:
- Add CLI protocol resolution tests asserting that specific Ghostty and libghostty XTVERSION responses cause auto mode to select the kitty protocol.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新终端协议检测逻辑：在保持现有探测行为不变的前提下，将 Ghostty 家族的 XTVERSION 响应视为兼容 kitty 的终端。

Bug Fixes（错误修复）:
- 通过识别来自 Ghostty/libghostty 终端的 XTVERSION 响应为 kitty 信号，防止在这些终端具备 kitty 图形能力时，自动协议解析错误地回退到纯文本模式。

Enhancements（增强功能）:
- 将 kitty “肯定信号”的检测泛化为对一小组已知标记进行不区分大小写匹配，其中包含 Ghostty 变种。

Tests（测试）:
- 新增 CLI 协议解析测试，用于断言特定的 Ghostty 和 libghostty XTVERSION 响应会使自动模式选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update terminal protocol detection to treat Ghostty-family XTVERSION replies as kitty-capable while preserving existing probe behavior.

Bug Fixes:
- Prevent auto protocol resolution from falling back to text when kitty graphics are available on Ghostty/libghostty terminals by recognizing their XTVERSION replies as kitty signals.

Enhancements:
- Generalize kitty affirmative-signal detection to a case-insensitive match over a small set of known tokens, including Ghostty variants.

Tests:
- Add CLI protocol resolution tests asserting that specific Ghostty and libghostty XTVERSION responses cause auto mode to select the kitty protocol.

</details>

Bug 修复：
- 通过将 Ghostty/libghostty 支持的终端的 XTVERSION 响应识别为 kitty 信号，防止在可用 kitty 图形能力的情况下，自动协议解析却回退到纯文本模式。

增强功能：
- 将 kitty 肯定信号的检测泛化为：对一小组已知标记（包含 Ghostty 变体）进行不区分大小写匹配。

测试：
- 添加 CLI 协议解析测试，用于断言当 Ghostty 和 libghostty 返回特定 XTVERSION 响应时，自动模式会选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新终端协议检测逻辑：在保持现有探测行为不变的前提下，将 Ghostty 家族的 XTVERSION 响应视为兼容 kitty 的终端。

Bug Fixes（错误修复）:
- 通过识别来自 Ghostty/libghostty 终端的 XTVERSION 响应为 kitty 信号，防止在这些终端具备 kitty 图形能力时，自动协议解析错误地回退到纯文本模式。

Enhancements（增强功能）:
- 将 kitty “肯定信号”的检测泛化为对一小组已知标记进行不区分大小写匹配，其中包含 Ghostty 变种。

Tests（测试）:
- 新增 CLI 协议解析测试，用于断言特定的 Ghostty 和 libghostty XTVERSION 响应会使自动模式选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update terminal protocol detection to treat Ghostty-family XTVERSION replies as kitty-capable while preserving existing probe behavior.

Bug Fixes:
- Prevent auto protocol resolution from falling back to text when kitty graphics are available on Ghostty/libghostty terminals by recognizing their XTVERSION replies as kitty signals.

Enhancements:
- Generalize kitty affirmative-signal detection to a case-insensitive match over a small set of known tokens, including Ghostty variants.

Tests:
- Add CLI protocol resolution tests asserting that specific Ghostty and libghostty XTVERSION responses cause auto mode to select the kitty protocol.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新终端协议检测逻辑：在保持现有探测行为不变的前提下，将 Ghostty 家族的 XTVERSION 响应视为兼容 kitty 的终端。

Bug Fixes（错误修复）:
- 通过识别来自 Ghostty/libghostty 终端的 XTVERSION 响应为 kitty 信号，防止在这些终端具备 kitty 图形能力时，自动协议解析错误地回退到纯文本模式。

Enhancements（增强功能）:
- 将 kitty “肯定信号”的检测泛化为对一小组已知标记进行不区分大小写匹配，其中包含 Ghostty 变种。

Tests（测试）:
- 新增 CLI 协议解析测试，用于断言特定的 Ghostty 和 libghostty XTVERSION 响应会使自动模式选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update terminal protocol detection to treat Ghostty-family XTVERSION replies as kitty-capable while preserving existing probe behavior.

Bug Fixes:
- Prevent auto protocol resolution from falling back to text when kitty graphics are available on Ghostty/libghostty terminals by recognizing their XTVERSION replies as kitty signals.

Enhancements:
- Generalize kitty affirmative-signal detection to a case-insensitive match over a small set of known tokens, including Ghostty variants.

Tests:
- Add CLI protocol resolution tests asserting that specific Ghostty and libghostty XTVERSION responses cause auto mode to select the kitty protocol.

</details>

Bug 修复：
- 通过将 Ghostty/libghostty 支持的终端的 XTVERSION 响应识别为 kitty 信号，防止在可用 kitty 图形能力的情况下，自动协议解析却回退到纯文本模式。

增强功能：
- 将 kitty 肯定信号的检测泛化为：对一小组已知标记（包含 Ghostty 变体）进行不区分大小写匹配。

测试：
- 添加 CLI 协议解析测试，用于断言当 Ghostty 和 libghostty 返回特定 XTVERSION 响应时，自动模式会选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新终端协议检测逻辑：在保持现有探测行为不变的前提下，将 Ghostty 家族的 XTVERSION 响应视为兼容 kitty 的终端。

Bug Fixes（错误修复）:
- 通过识别来自 Ghostty/libghostty 终端的 XTVERSION 响应为 kitty 信号，防止在这些终端具备 kitty 图形能力时，自动协议解析错误地回退到纯文本模式。

Enhancements（增强功能）:
- 将 kitty “肯定信号”的检测泛化为对一小组已知标记进行不区分大小写匹配，其中包含 Ghostty 变种。

Tests（测试）:
- 新增 CLI 协议解析测试，用于断言特定的 Ghostty 和 libghostty XTVERSION 响应会使自动模式选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update terminal protocol detection to treat Ghostty-family XTVERSION replies as kitty-capable while preserving existing probe behavior.

Bug Fixes:
- Prevent auto protocol resolution from falling back to text when kitty graphics are available on Ghostty/libghostty terminals by recognizing their XTVERSION replies as kitty signals.

Enhancements:
- Generalize kitty affirmative-signal detection to a case-insensitive match over a small set of known tokens, including Ghostty variants.

Tests:
- Add CLI protocol resolution tests asserting that specific Ghostty and libghostty XTVERSION responses cause auto mode to select the kitty protocol.

</details>

</details>

</details>

</details>

错误修复：
- 修复在 Ghostty 系终端上可用 kitty 图形时，自动协议解析错误地回退到文本模式的问题。

测试：
- 新增 CLI 协议解析测试，覆盖将 libghostty 和 Ghostty 的 XTVERSION 响应接受为 kitty 信号的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新终端协议检测逻辑：在保持现有探测行为不变的前提下，将 Ghostty 家族的 XTVERSION 响应视为兼容 kitty 的终端。

Bug Fixes（错误修复）:
- 通过识别来自 Ghostty/libghostty 终端的 XTVERSION 响应为 kitty 信号，防止在这些终端具备 kitty 图形能力时，自动协议解析错误地回退到纯文本模式。

Enhancements（增强功能）:
- 将 kitty “肯定信号”的检测泛化为对一小组已知标记进行不区分大小写匹配，其中包含 Ghostty 变种。

Tests（测试）:
- 新增 CLI 协议解析测试，用于断言特定的 Ghostty 和 libghostty XTVERSION 响应会使自动模式选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update terminal protocol detection to treat Ghostty-family XTVERSION replies as kitty-capable while preserving existing probe behavior.

Bug Fixes:
- Prevent auto protocol resolution from falling back to text when kitty graphics are available on Ghostty/libghostty terminals by recognizing their XTVERSION replies as kitty signals.

Enhancements:
- Generalize kitty affirmative-signal detection to a case-insensitive match over a small set of known tokens, including Ghostty variants.

Tests:
- Add CLI protocol resolution tests asserting that specific Ghostty and libghostty XTVERSION responses cause auto mode to select the kitty protocol.

</details>

Bug 修复：
- 通过将 Ghostty/libghostty 支持的终端的 XTVERSION 响应识别为 kitty 信号，防止在可用 kitty 图形能力的情况下，自动协议解析却回退到纯文本模式。

增强功能：
- 将 kitty 肯定信号的检测泛化为：对一小组已知标记（包含 Ghostty 变体）进行不区分大小写匹配。

测试：
- 添加 CLI 协议解析测试，用于断言当 Ghostty 和 libghostty 返回特定 XTVERSION 响应时，自动模式会选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新终端协议检测逻辑：在保持现有探测行为不变的前提下，将 Ghostty 家族的 XTVERSION 响应视为兼容 kitty 的终端。

Bug Fixes（错误修复）:
- 通过识别来自 Ghostty/libghostty 终端的 XTVERSION 响应为 kitty 信号，防止在这些终端具备 kitty 图形能力时，自动协议解析错误地回退到纯文本模式。

Enhancements（增强功能）:
- 将 kitty “肯定信号”的检测泛化为对一小组已知标记进行不区分大小写匹配，其中包含 Ghostty 变种。

Tests（测试）:
- 新增 CLI 协议解析测试，用于断言特定的 Ghostty 和 libghostty XTVERSION 响应会使自动模式选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update terminal protocol detection to treat Ghostty-family XTVERSION replies as kitty-capable while preserving existing probe behavior.

Bug Fixes:
- Prevent auto protocol resolution from falling back to text when kitty graphics are available on Ghostty/libghostty terminals by recognizing their XTVERSION replies as kitty signals.

Enhancements:
- Generalize kitty affirmative-signal detection to a case-insensitive match over a small set of known tokens, including Ghostty variants.

Tests:
- Add CLI protocol resolution tests asserting that specific Ghostty and libghostty XTVERSION responses cause auto mode to select the kitty protocol.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新终端协议检测逻辑：在保持现有探测行为不变的前提下，将 Ghostty 家族的 XTVERSION 响应视为兼容 kitty 的终端。

Bug Fixes（错误修复）:
- 通过识别来自 Ghostty/libghostty 终端的 XTVERSION 响应为 kitty 信号，防止在这些终端具备 kitty 图形能力时，自动协议解析错误地回退到纯文本模式。

Enhancements（增强功能）:
- 将 kitty “肯定信号”的检测泛化为对一小组已知标记进行不区分大小写匹配，其中包含 Ghostty 变种。

Tests（测试）:
- 新增 CLI 协议解析测试，用于断言特定的 Ghostty 和 libghostty XTVERSION 响应会使自动模式选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update terminal protocol detection to treat Ghostty-family XTVERSION replies as kitty-capable while preserving existing probe behavior.

Bug Fixes:
- Prevent auto protocol resolution from falling back to text when kitty graphics are available on Ghostty/libghostty terminals by recognizing their XTVERSION replies as kitty signals.

Enhancements:
- Generalize kitty affirmative-signal detection to a case-insensitive match over a small set of known tokens, including Ghostty variants.

Tests:
- Add CLI protocol resolution tests asserting that specific Ghostty and libghostty XTVERSION responses cause auto mode to select the kitty protocol.

</details>

Bug 修复：
- 通过将 Ghostty/libghostty 支持的终端的 XTVERSION 响应识别为 kitty 信号，防止在可用 kitty 图形能力的情况下，自动协议解析却回退到纯文本模式。

增强功能：
- 将 kitty 肯定信号的检测泛化为：对一小组已知标记（包含 Ghostty 变体）进行不区分大小写匹配。

测试：
- 添加 CLI 协议解析测试，用于断言当 Ghostty 和 libghostty 返回特定 XTVERSION 响应时，自动模式会选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新终端协议检测逻辑：在保持现有探测行为不变的前提下，将 Ghostty 家族的 XTVERSION 响应视为兼容 kitty 的终端。

Bug Fixes（错误修复）:
- 通过识别来自 Ghostty/libghostty 终端的 XTVERSION 响应为 kitty 信号，防止在这些终端具备 kitty 图形能力时，自动协议解析错误地回退到纯文本模式。

Enhancements（增强功能）:
- 将 kitty “肯定信号”的检测泛化为对一小组已知标记进行不区分大小写匹配，其中包含 Ghostty 变种。

Tests（测试）:
- 新增 CLI 协议解析测试，用于断言特定的 Ghostty 和 libghostty XTVERSION 响应会使自动模式选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update terminal protocol detection to treat Ghostty-family XTVERSION replies as kitty-capable while preserving existing probe behavior.

Bug Fixes:
- Prevent auto protocol resolution from falling back to text when kitty graphics are available on Ghostty/libghostty terminals by recognizing their XTVERSION replies as kitty signals.

Enhancements:
- Generalize kitty affirmative-signal detection to a case-insensitive match over a small set of known tokens, including Ghostty variants.

Tests:
- Add CLI protocol resolution tests asserting that specific Ghostty and libghostty XTVERSION responses cause auto mode to select the kitty protocol.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新终端协议检测逻辑：在保持现有探测行为不变的前提下，将 Ghostty 家族的 XTVERSION 响应视为兼容 kitty 的终端。

Bug Fixes（错误修复）:
- 通过识别来自 Ghostty/libghostty 终端的 XTVERSION 响应为 kitty 信号，防止在这些终端具备 kitty 图形能力时，自动协议解析错误地回退到纯文本模式。

Enhancements（增强功能）:
- 将 kitty “肯定信号”的检测泛化为对一小组已知标记进行不区分大小写匹配，其中包含 Ghostty 变种。

Tests（测试）:
- 新增 CLI 协议解析测试，用于断言特定的 Ghostty 和 libghostty XTVERSION 响应会使自动模式选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update terminal protocol detection to treat Ghostty-family XTVERSION replies as kitty-capable while preserving existing probe behavior.

Bug Fixes:
- Prevent auto protocol resolution from falling back to text when kitty graphics are available on Ghostty/libghostty terminals by recognizing their XTVERSION replies as kitty signals.

Enhancements:
- Generalize kitty affirmative-signal detection to a case-insensitive match over a small set of known tokens, including Ghostty variants.

Tests:
- Add CLI protocol resolution tests asserting that specific Ghostty and libghostty XTVERSION responses cause auto mode to select the kitty protocol.

</details>

Bug 修复：
- 通过将 Ghostty/libghostty 支持的终端的 XTVERSION 响应识别为 kitty 信号，防止在可用 kitty 图形能力的情况下，自动协议解析却回退到纯文本模式。

增强功能：
- 将 kitty 肯定信号的检测泛化为：对一小组已知标记（包含 Ghostty 变体）进行不区分大小写匹配。

测试：
- 添加 CLI 协议解析测试，用于断言当 Ghostty 和 libghostty 返回特定 XTVERSION 响应时，自动模式会选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新终端协议检测逻辑：在保持现有探测行为不变的前提下，将 Ghostty 家族的 XTVERSION 响应视为兼容 kitty 的终端。

Bug Fixes（错误修复）:
- 通过识别来自 Ghostty/libghostty 终端的 XTVERSION 响应为 kitty 信号，防止在这些终端具备 kitty 图形能力时，自动协议解析错误地回退到纯文本模式。

Enhancements（增强功能）:
- 将 kitty “肯定信号”的检测泛化为对一小组已知标记进行不区分大小写匹配，其中包含 Ghostty 变种。

Tests（测试）:
- 新增 CLI 协议解析测试，用于断言特定的 Ghostty 和 libghostty XTVERSION 响应会使自动模式选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update terminal protocol detection to treat Ghostty-family XTVERSION replies as kitty-capable while preserving existing probe behavior.

Bug Fixes:
- Prevent auto protocol resolution from falling back to text when kitty graphics are available on Ghostty/libghostty terminals by recognizing their XTVERSION replies as kitty signals.

Enhancements:
- Generalize kitty affirmative-signal detection to a case-insensitive match over a small set of known tokens, including Ghostty variants.

Tests:
- Add CLI protocol resolution tests asserting that specific Ghostty and libghostty XTVERSION responses cause auto mode to select the kitty protocol.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新终端协议检测逻辑：在保持现有探测行为不变的前提下，将 Ghostty 家族的 XTVERSION 响应视为兼容 kitty 的终端。

Bug Fixes（错误修复）:
- 通过识别来自 Ghostty/libghostty 终端的 XTVERSION 响应为 kitty 信号，防止在这些终端具备 kitty 图形能力时，自动协议解析错误地回退到纯文本模式。

Enhancements（增强功能）:
- 将 kitty “肯定信号”的检测泛化为对一小组已知标记进行不区分大小写匹配，其中包含 Ghostty 变种。

Tests（测试）:
- 新增 CLI 协议解析测试，用于断言特定的 Ghostty 和 libghostty XTVERSION 响应会使自动模式选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update terminal protocol detection to treat Ghostty-family XTVERSION replies as kitty-capable while preserving existing probe behavior.

Bug Fixes:
- Prevent auto protocol resolution from falling back to text when kitty graphics are available on Ghostty/libghostty terminals by recognizing their XTVERSION replies as kitty signals.

Enhancements:
- Generalize kitty affirmative-signal detection to a case-insensitive match over a small set of known tokens, including Ghostty variants.

Tests:
- Add CLI protocol resolution tests asserting that specific Ghostty and libghostty XTVERSION responses cause auto mode to select the kitty protocol.

</details>

Bug 修复：
- 通过将 Ghostty/libghostty 支持的终端的 XTVERSION 响应识别为 kitty 信号，防止在可用 kitty 图形能力的情况下，自动协议解析却回退到纯文本模式。

增强功能：
- 将 kitty 肯定信号的检测泛化为：对一小组已知标记（包含 Ghostty 变体）进行不区分大小写匹配。

测试：
- 添加 CLI 协议解析测试，用于断言当 Ghostty 和 libghostty 返回特定 XTVERSION 响应时，自动模式会选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新终端协议检测逻辑：在保持现有探测行为不变的前提下，将 Ghostty 家族的 XTVERSION 响应视为兼容 kitty 的终端。

Bug Fixes（错误修复）:
- 通过识别来自 Ghostty/libghostty 终端的 XTVERSION 响应为 kitty 信号，防止在这些终端具备 kitty 图形能力时，自动协议解析错误地回退到纯文本模式。

Enhancements（增强功能）:
- 将 kitty “肯定信号”的检测泛化为对一小组已知标记进行不区分大小写匹配，其中包含 Ghostty 变种。

Tests（测试）:
- 新增 CLI 协议解析测试，用于断言特定的 Ghostty 和 libghostty XTVERSION 响应会使自动模式选择 kitty 协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update terminal protocol detection to treat Ghostty-family XTVERSION replies as kitty-capable while preserving existing probe behavior.

Bug Fixes:
- Prevent auto protocol resolution from falling back to text when kitty graphics are available on Ghostty/libghostty terminals by recognizing their XTVERSION replies as kitty signals.

Enhancements:
- Generalize kitty affirmative-signal detection to a case-insensitive match over a small set of known tokens, including Ghostty variants.

Tests:
- Add CLI protocol resolution tests asserting that specific Ghostty and libghostty XTVERSION responses cause auto mode to select the kitty protocol.

</details>

</details>

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix auto protocol detection so `Ghostty`/`libghostty` terminals are treated as kitty-capable instead of falling back to text. Resolver order and SSH behavior are unchanged.

- **Bug Fixes**
  - Accept `Ghostty`/`libghostty` XTVERSION replies as kitty signals; added tests for both forms.

- **Refactors**
  - Use an allocation-free, case-insensitive token matcher with a small list: `kitty`, `>|ghostty`, `>|libghostty`; added inline rationale comments.

<sup>Written for commit 8120ace9a52a0943b07196db7e57440812207160. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

