### PR TITLE
Add vivid color enhancement mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ PixelTerm-C is a terminal-native browser for images, video, and books. It helps 
 - Switch between single-view, grid preview, book reader, and file manager modes.
 - Use keyboard or mouse navigation across image, video, and book workflows.
 - Adjust rendering with preload, dithering, gamma, and config-based terminal overrides.
+- Optionally boost muted colors with a lightweight vivid color-enhancement mode.
 - Build from source on Linux and macOS, or install a release binary for amd64 and arm64.
 
 ## Screenshot

--- a/config.example.ini
+++ b/config.example.ini
@@ -24,6 +24,10 @@ text_symbols = auto
 # Gamma correction for image rendering (>0 and <=5).
 gamma = 1.0
 
+# Color enhancement: off, vivid.
+# vivid lightly boosts color separation before Chafa renders the image.
+color_enhance = off
+
 # Per-terminal overrides based on environment values.
 # The first matching group in TERM_PROGRAM, LC_TERMINAL, TERMINAL_NAME, TERM is applied.
 # Example group names: xterm-kitty, alacritty, WarpTerminal.

--- a/docs/guides/USAGE.md
+++ b/docs/guides/USAGE.md
@@ -53,6 +53,9 @@ pixelterm --protocol text --text-symbols quarter /path/to/image.jpg
 # Note: defaults to 1.0
 pixelterm --gamma 0.8 /path/to/image.jpg
 
+# Lightly boost color separation before rendering (off, vivid)
+pixelterm --color-enhance vivid /path/to/image.jpg
+
 # Load configuration file (default: $XDG_CONFIG_HOME/pixelterm/config.ini; falls back to $HOME/.config/pixelterm/config.ini when XDG_CONFIG_HOME is unset or empty)
 pixelterm --config ~/.config/pixelterm/config.ini /path/to/image.jpg
 
@@ -71,6 +74,7 @@ pixelterm -- --config=gallery.txt
 - CLI flags override config file values because config loading happens before argument parsing.
 - `--preload` and `--alt-screen` accept `true/false`, `yes/no`, `on/off`, and `1/0`.
 - `--text-symbols` only affects text rendering, whether selected explicitly with `--protocol text` or chosen by the automatic fallback.
+- `--color-enhance vivid` is a default-off pre-rendering color adjustment. It can make muted images look clearer in terminal text output, at a small CPU cost.
 - A missing default config file is ignored, but a missing file passed with `--config` is treated as an error.
 - Config groups are applied in this order: `[default]`, then the first matching terminal-specific group from `TERM_PROGRAM`, `LC_TERMINAL`, `TERMINAL_NAME`, or `TERM`.
 - If `PATH` is an unsupported regular file, PixelTerm-C falls back to that file's canonical parent directory and opens file manager mode there.

--- a/include/app_state.h
+++ b/include/app_state.h
@@ -44,6 +44,7 @@ typedef struct {
     gboolean force_kitty;
     gboolean force_iterm2;
     TextSymbolMode text_symbol_mode;
+    ColorEnhanceMode color_enhance;
 } AppConfig;
 
 typedef struct {
@@ -143,6 +144,7 @@ typedef struct {
     gboolean force_kitty;
     gboolean force_iterm2;
     TextSymbolMode text_symbol_mode;
+    ColorEnhanceMode color_enhance;
     gboolean needs_redraw;
     AppMode mode;  // Current UI mode (single/preview/file manager/book)
     gboolean show_hidden_files;  // Toggle visibility of dotfiles in file manager

--- a/include/common.h
+++ b/include/common.h
@@ -53,6 +53,11 @@ typedef enum {
     TEXT_SYMBOL_MODE_QUARTER
 } TextSymbolMode;
 
+typedef enum {
+    COLOR_ENHANCE_OFF = 0,
+    COLOR_ENHANCE_VIVID
+} ColorEnhanceMode;
+
 // Function declarations
 /**
  * @brief Checks if a file is an image based on its file extension.

--- a/include/preloader.h
+++ b/include/preloader.h
@@ -55,6 +55,7 @@ typedef struct {
     gboolean force_iterm2;
     TextSymbolMode text_symbol_mode;
     gdouble gamma;
+    ColorEnhanceMode color_enhance;
 } ImagePreloader;
 
 // Preloader lifecycle functions
@@ -91,7 +92,7 @@ void preloader_destroy(ImagePreloader *preloader);
  */
 ErrorCode preloader_initialize(ImagePreloader *preloader, gboolean dither_enabled, gint work_factor,
                                gboolean force_text, gboolean force_sixel, gboolean force_kitty, gboolean force_iterm2,
-                               TextSymbolMode text_symbol_mode, gdouble gamma);
+                               TextSymbolMode text_symbol_mode, gdouble gamma, ColorEnhanceMode color_enhance);
 /**
  * @brief Starts the preloader's worker thread.
  * 

--- a/include/renderer.h
+++ b/include/renderer.h
@@ -194,12 +194,6 @@ ErrorCode renderer_get_media_dimensions(const char *filepath, gint *width, gint 
  */
 void renderer_get_rendered_dimensions(ImageRenderer *renderer, gint *width, gint *height);
 gboolean renderer_is_graphics_mode(const ImageRenderer *renderer);
-guint8 *renderer_color_enhance_copy_for_test(const guint8 *pixel_data,
-                                             gint width,
-                                             gint height,
-                                             gint rowstride,
-                                             gint n_channels,
-                                             ColorEnhanceMode mode);
 
 
 

--- a/include/renderer.h
+++ b/include/renderer.h
@@ -17,6 +17,7 @@ typedef struct {
     gboolean force_iterm2;
     TextSymbolMode text_symbol_mode;
     gdouble gamma;
+    ColorEnhanceMode color_enhance;
     
     // Advanced quality settings
     ChafaDitherMode dither_mode;
@@ -193,6 +194,12 @@ ErrorCode renderer_get_media_dimensions(const char *filepath, gint *width, gint 
  */
 void renderer_get_rendered_dimensions(ImageRenderer *renderer, gint *width, gint *height);
 gboolean renderer_is_graphics_mode(const ImageRenderer *renderer);
+guint8 *renderer_color_enhance_copy_for_test(const guint8 *pixel_data,
+                                             gint width,
+                                             gint height,
+                                             gint rowstride,
+                                             gint n_channels,
+                                             ColorEnhanceMode mode);
 
 
 

--- a/include/video_player.h
+++ b/include/video_player.h
@@ -80,6 +80,7 @@ typedef struct {
     gdouble present_fps;
     gboolean present_fps_valid;
     gboolean show_stats;
+    ColorEnhanceMode color_enhance;
 
     // FFmpeg state
     struct AVFormatContext *format_context;

--- a/src/app.c
+++ b/src/app.c
@@ -273,6 +273,7 @@ ErrorCode app_initialize(PixelTermApp *app, gboolean dither_enabled) {
     if (app->video_player->renderer) {
         app->video_player->renderer->config.color_enhance = app->color_enhance;
     }
+    app->video_player->color_enhance = app->color_enhance;
 
     return ERROR_NONE;
 }

--- a/src/app.c
+++ b/src/app.c
@@ -261,11 +261,17 @@ ErrorCode app_initialize(PixelTermApp *app, gboolean dither_enabled) {
 
     // Initialize video player
     app->video_player = video_player_new(app->render_work_factor, app->force_text, app->force_sixel,
-                                         app->force_kitty, app->force_iterm2, app->text_symbol_mode, app->gamma);
+                                          app->force_kitty, app->force_iterm2, app->text_symbol_mode, app->gamma);
     if (!app->video_player) {
         gif_player_destroy(app->gif_player);
         app->gif_player = NULL;
         return ERROR_MEMORY_ALLOC;
+    }
+    if (app->gif_player->renderer) {
+        app->gif_player->renderer->config.color_enhance = app->color_enhance;
+    }
+    if (app->video_player->renderer) {
+        app->video_player->renderer->config.color_enhance = app->color_enhance;
     }
 
     return ERROR_NONE;

--- a/src/app_book_page_render.c
+++ b/src/app_book_page_render.c
@@ -65,6 +65,7 @@ static RendererConfig app_book_make_renderer_config(const PixelTermApp *app,
         .force_iterm2 = app->force_iterm2,
         .text_symbol_mode = app->text_symbol_mode,
         .gamma = app->gamma,
+        .color_enhance = app->color_enhance,
         .dither_mode = app->dither_enabled ? CHAFA_DITHER_MODE_ORDERED : CHAFA_DITHER_MODE_NONE,
         .color_extractor = CHAFA_COLOR_EXTRACTOR_AVERAGE,
         .optimizations = CHAFA_OPTIMIZATION_REUSE_ATTRIBUTES

--- a/src/app_cli.c
+++ b/src/app_cli.c
@@ -30,6 +30,7 @@ static void print_usage(const char *program_name) {
     printf("  %-29s %s\n", "--work-factor N", "Quality/speed tradeoff (1-9, default: 9)");
     printf("  %-29s %s\n", "--protocol MODE", "Output protocol: auto, text, sixel, kitty, iterm2");
     printf("  %-29s %s\n", "--text-symbols MODE", "Text symbol set: auto, half, quarter");
+    printf("  %-29s %s\n", "--color-enhance MODE", "Color enhancement: off, vivid");
     printf("  %-29s %s\n", "--config PATH",
            "Load configuration file (default: $XDG_CONFIG_HOME/pixelterm/config.ini, fallback: $HOME/.config/pixelterm/config.ini)");
     printf("  %-29s %s\n", "--gamma G",
@@ -96,6 +97,21 @@ static gboolean parse_text_symbol_mode(const char *value, TextSymbolMode *out_mo
     }
     if (g_ascii_strcasecmp(value, "quarter") == 0) {
         *out_mode = TEXT_SYMBOL_MODE_QUARTER;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static gboolean parse_color_enhance_mode(const char *value, ColorEnhanceMode *out_mode) {
+    if (!value || !out_mode) {
+        return FALSE;
+    }
+    if (g_ascii_strcasecmp(value, "off") == 0) {
+        *out_mode = COLOR_ENHANCE_OFF;
+        return TRUE;
+    }
+    if (g_ascii_strcasecmp(value, "vivid") == 0) {
+        *out_mode = COLOR_ENHANCE_VIVID;
         return TRUE;
     }
     return FALSE;
@@ -289,6 +305,25 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
             return FALSE;
         }
         config->text_symbol_mode = mode;
+        g_free(value);
+    }
+
+    if (g_key_file_has_key(key_file, group, "color_enhance", NULL)) {
+        GError *error = NULL;
+        gchar *value = g_key_file_get_string(key_file, group, "color_enhance", &error);
+        if (error) {
+            fprintf(stderr, "Invalid 'color_enhance' in config file '%s': %s\n", path, error->message);
+            g_error_free(error);
+            g_free(value);
+            return FALSE;
+        }
+        ColorEnhanceMode mode = COLOR_ENHANCE_OFF;
+        if (!parse_color_enhance_mode(value, &mode)) {
+            fprintf(stderr, "Invalid 'color_enhance' in config file '%s': %s\n", path, value);
+            g_free(value);
+            return FALSE;
+        }
+        config->color_enhance = mode;
         g_free(value);
     }
 
@@ -628,6 +663,7 @@ void app_config_init(AppConfig *config) {
     config->force_kitty = FALSE;
     config->force_iterm2 = FALSE;
     config->text_symbol_mode = TEXT_SYMBOL_MODE_AUTO;
+    config->color_enhance = COLOR_ENHANCE_OFF;
 }
 
 ErrorCode app_parse_arguments(int argc, char *argv[], char **path, AppConfig *config) {
@@ -644,6 +680,7 @@ ErrorCode app_parse_arguments(int argc, char *argv[], char **path, AppConfig *co
         {"gamma", required_argument, 0, 1006},
         {"config", required_argument, 0, 1007},
         {"text-symbols", required_argument, 0, 1008},
+        {"color-enhance", required_argument, 0, 1009},
         {0, 0, 0, 0}
     };
 
@@ -751,6 +788,15 @@ ErrorCode app_parse_arguments(int argc, char *argv[], char **path, AppConfig *co
                     return ERROR_INVALID_ARGS;
                 }
                 config->text_symbol_mode = mode;
+                break;
+            }
+            case 1009: { // --color-enhance
+                ColorEnhanceMode mode = COLOR_ENHANCE_OFF;
+                if (!parse_color_enhance_mode(optarg, &mode)) {
+                    fprintf(stderr, "Unknown color enhancement mode: %s\n", optarg ? optarg : "");
+                    return ERROR_INVALID_ARGS;
+                }
+                config->color_enhance = mode;
                 break;
             }
             case '?':

--- a/src/app_config_runtime.c
+++ b/src/app_config_runtime.c
@@ -15,4 +15,5 @@ void app_config_apply_runtime(PixelTermApp *app, const AppConfig *config) {
     app->force_kitty = config->force_kitty;
     app->force_iterm2 = config->force_iterm2;
     app->text_symbol_mode = config->text_symbol_mode;
+    app->color_enhance = config->color_enhance;
 }

--- a/src/app_preview_shared.c
+++ b/src/app_preview_shared.c
@@ -165,6 +165,7 @@ ImageRenderer* app_create_grid_renderer(const PixelTermApp *app,
         .force_iterm2 = app->force_iterm2,
         .text_symbol_mode = app->text_symbol_mode,
         .gamma = app->gamma,
+        .color_enhance = app->color_enhance,
         .dither_mode = app->dither_enabled ? CHAFA_DITHER_MODE_ORDERED : CHAFA_DITHER_MODE_NONE,
         .color_extractor = CHAFA_COLOR_EXTRACTOR_AVERAGE,
         .optimizations = CHAFA_OPTIMIZATION_REUSE_ATTRIBUTES

--- a/src/app_single_render.c
+++ b/src/app_single_render.c
@@ -680,6 +680,7 @@ ErrorCode app_render_current_image(PixelTermApp *app) {
             .force_iterm2 = app->force_iterm2,
             .text_symbol_mode = app->text_symbol_mode,
             .gamma = app->gamma,
+            .color_enhance = app->color_enhance,
             .dither_mode = app->dither_enabled ? CHAFA_DITHER_MODE_ORDERED : CHAFA_DITHER_MODE_NONE,
             .color_extractor = CHAFA_COLOR_EXTRACTOR_AVERAGE,
             .optimizations = CHAFA_OPTIMIZATION_REUSE_ATTRIBUTES
@@ -750,6 +751,7 @@ ErrorCode app_render_current_image(PixelTermApp *app) {
                 .force_iterm2 = app->force_iterm2,
                 .text_symbol_mode = app->text_symbol_mode,
                 .gamma = app->gamma,
+                .color_enhance = app->color_enhance,
                 .dither_mode = app->dither_enabled ? CHAFA_DITHER_MODE_ORDERED : CHAFA_DITHER_MODE_NONE,
                 .color_extractor = CHAFA_COLOR_EXTRACTOR_AVERAGE,
                 .optimizations = CHAFA_OPTIMIZATION_REUSE_ATTRIBUTES

--- a/src/gif_player.c
+++ b/src/gif_player.c
@@ -224,6 +224,7 @@ GifPlayer* gif_player_new(gint work_factor, gboolean force_text, gboolean force_
             .force_iterm2 = force_iterm2,
             .text_symbol_mode = text_symbol_mode,
             .gamma = gamma,
+            .color_enhance = COLOR_ENHANCE_OFF,
             .dither_mode = CHAFA_DITHER_MODE_NONE,
             .color_extractor = CHAFA_COLOR_EXTRACTOR_AVERAGE,
             .optimizations = CHAFA_OPTIMIZATION_REUSE_ATTRIBUTES

--- a/src/input_dispatch_core.c
+++ b/src/input_dispatch_core.c
@@ -215,7 +215,7 @@ static gboolean handle_key_press_common(PixelTermApp *app,
                 preloader_stop(app->preloader);
                 preloader_cache_clear(app->preloader);
                 preloader_initialize(app->preloader, app->dither_enabled, app->render_work_factor,
-                                     app->force_text, app->force_sixel, app->force_kitty, app->force_iterm2, app->text_symbol_mode, app->gamma);
+                                     app->force_text, app->force_sixel, app->force_kitty, app->force_iterm2, app->text_symbol_mode, app->gamma, app->color_enhance);
                 preloader_start(app->preloader);
             }
             app_render_by_mode(app);

--- a/src/preload_control.c
+++ b/src/preload_control.c
@@ -28,7 +28,7 @@ ErrorCode app_preloader_enable(PixelTermApp *app, gboolean queue_tasks) {
         }
         preloader_initialize(app->preloader, app->dither_enabled, app->render_work_factor,
                              app->force_text, app->force_sixel, app->force_kitty, app->force_iterm2,
-                             app->text_symbol_mode, app->gamma);
+                             app->text_symbol_mode, app->gamma, app->color_enhance);
         created = TRUE;
     }
 

--- a/src/preloader.c
+++ b/src/preloader.c
@@ -217,7 +217,7 @@ void preloader_destroy(ImagePreloader *preloader) {
 // Initialize preloader
 ErrorCode preloader_initialize(ImagePreloader *preloader, gboolean dither_enabled, gint work_factor,
                                gboolean force_text, gboolean force_sixel, gboolean force_kitty, gboolean force_iterm2,
-                               TextSymbolMode text_symbol_mode, gdouble gamma) {
+                               TextSymbolMode text_symbol_mode, gdouble gamma, ColorEnhanceMode color_enhance) {
     if (!preloader) {
         return ERROR_MEMORY_ALLOC;
     }
@@ -234,6 +234,7 @@ ErrorCode preloader_initialize(ImagePreloader *preloader, gboolean dither_enable
     preloader->force_iterm2 = force_iterm2;
     preloader->text_symbol_mode = text_symbol_mode;
     preloader->gamma = gamma;
+    preloader->color_enhance = color_enhance;
 
     return ERROR_NONE;
 }
@@ -734,6 +735,7 @@ gpointer preloader_worker_thread(gpointer data) {
         .force_iterm2 = preloader->force_iterm2,
         .text_symbol_mode = preloader->text_symbol_mode,
         .gamma = preloader->gamma,
+        .color_enhance = preloader->color_enhance,
         .dither_mode = preloader->dither_enabled ? CHAFA_DITHER_MODE_ORDERED : CHAFA_DITHER_MODE_NONE,
         .color_extractor = CHAFA_COLOR_EXTRACTOR_AVERAGE,
         .optimizations = CHAFA_OPTIMIZATION_REUSE_ATTRIBUTES

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -92,7 +92,7 @@ static gboolean renderer_should_apply_gamma(const ImageRenderer *renderer) {
 
 static guint8 *renderer_apply_gamma_copy(const guint8 *pixel_data, gint width, gint height,
                                           gint rowstride, gint n_channels, gdouble gamma) {
-    if (!pixel_data || width <= 0 || height <= 0 || rowstride <= 0) {
+    if (!pixel_data || width <= 0 || height <= 0 || rowstride <= 0 || n_channels < 3) {
         return NULL;
     }
 
@@ -142,7 +142,7 @@ static guint8 *renderer_apply_color_enhance_copy(const guint8 *pixel_data,
                                                  gint rowstride,
                                                  gint n_channels,
                                                  ColorEnhanceMode mode) {
-    if (!pixel_data || width <= 0 || height <= 0 || rowstride <= 0) {
+    if (!pixel_data || width <= 0 || height <= 0 || rowstride <= 0 || n_channels < 3) {
         return NULL;
     }
     if (mode == COLOR_ENHANCE_OFF) {

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -91,7 +91,7 @@ static gboolean renderer_should_apply_gamma(const ImageRenderer *renderer) {
 }
 
 static guint8 *renderer_apply_gamma_copy(const guint8 *pixel_data, gint width, gint height,
-                                         gint rowstride, gint n_channels, gdouble gamma) {
+                                          gint rowstride, gint n_channels, gdouble gamma) {
     if (!pixel_data || width <= 0 || height <= 0 || rowstride <= 0) {
         return NULL;
     }
@@ -126,6 +126,63 @@ static guint8 *renderer_apply_gamma_copy(const guint8 *pixel_data, gint width, g
     return adjusted;
 }
 
+static guint8 renderer_clamp_channel(double value) {
+    if (value < 0.0) {
+        return 0;
+    }
+    if (value > 255.0) {
+        return 255;
+    }
+    return (guint8)(value + 0.5);
+}
+
+static guint8 *renderer_apply_color_enhance_copy(const guint8 *pixel_data,
+                                                 gint width,
+                                                 gint height,
+                                                 gint rowstride,
+                                                 gint n_channels,
+                                                 ColorEnhanceMode mode) {
+    if (!pixel_data || width <= 0 || height <= 0 || rowstride <= 0) {
+        return NULL;
+    }
+    if (mode == COLOR_ENHANCE_OFF) {
+        return NULL;
+    }
+
+    gsize buffer_size = (gsize)height * (gsize)rowstride;
+    guint8 *adjusted = g_malloc(buffer_size);
+    if (!adjusted) {
+        return NULL;
+    }
+    memcpy(adjusted, pixel_data, buffer_size);
+
+    for (gint y = 0; y < height; y++) {
+        guint8 *row = adjusted + ((gsize)y * (gsize)rowstride);
+        for (gint x = 0; x < width; x++) {
+            guint8 *px = row + (gsize)x * (gsize)n_channels;
+            double r = px[0];
+            double g = px[1];
+            double b = px[2];
+            double luma = 0.299 * r + 0.587 * g + 0.114 * b;
+
+            px[0] = renderer_clamp_channel(luma + (r - luma) * 1.18);
+            px[1] = renderer_clamp_channel(luma + (g - luma) * 1.18);
+            px[2] = renderer_clamp_channel(luma + (b - luma) * 1.18);
+        }
+    }
+
+    return adjusted;
+}
+
+guint8 *renderer_color_enhance_copy_for_test(const guint8 *pixel_data,
+                                             gint width,
+                                             gint height,
+                                             gint rowstride,
+                                             gint n_channels,
+                                             ColorEnhanceMode mode) {
+    return renderer_apply_color_enhance_copy(pixel_data, width, height, rowstride, n_channels, mode);
+}
+
 // Create a new renderer
 ImageRenderer* renderer_create(void) {
     ImageRenderer *renderer = g_new0(ImageRenderer, 1);
@@ -153,6 +210,7 @@ ImageRenderer* renderer_create(void) {
     renderer->config.force_iterm2 = FALSE;
     renderer->config.text_symbol_mode = TEXT_SYMBOL_MODE_AUTO;
     renderer->config.gamma = 1.0;
+    renderer->config.color_enhance = COLOR_ENHANCE_OFF;
 
     // Maximize quality settings
     renderer->config.work_factor = 9; // High CPU usage for best character matching
@@ -379,6 +437,7 @@ GString* renderer_render_image_data(ImageRenderer *renderer,
 
     const guint8 *pixels_to_draw = pixel_data;
     guint8 *adjusted = NULL;
+    guint8 *enhanced = NULL;
     if (renderer_should_apply_gamma(renderer)) {
         adjusted = renderer_apply_gamma_copy(pixel_data, width, height, rowstride, n_channels,
                                              renderer->config.gamma);
@@ -386,10 +445,16 @@ GString* renderer_render_image_data(ImageRenderer *renderer,
             pixels_to_draw = adjusted;
         }
     }
+    enhanced = renderer_apply_color_enhance_copy(pixels_to_draw, width, height, rowstride,
+                                                 n_channels, renderer->config.color_enhance);
+    if (enhanced) {
+        pixels_to_draw = enhanced;
+    }
 
     // Draw pixels to canvas
     chafa_canvas_draw_all_pixels(renderer->canvas, pixel_type,
                                 pixels_to_draw, width, height, rowstride);
+    g_free(enhanced);
     g_free(adjusted);
 
     // Generate output - use NULL for term_info to force generic ANSI output with RGB

--- a/src/video_player.c
+++ b/src/video_player.c
@@ -1074,6 +1074,7 @@ VideoPlayer* video_player_new(gint work_factor, gboolean force_text, gboolean fo
     player->present_fps = 0.0;
     player->present_fps_valid = FALSE;
     player->show_stats = FALSE;
+    player->color_enhance = COLOR_ENHANCE_OFF;
 
     if (work_factor < 1) {
         work_factor = 1;
@@ -1277,7 +1278,7 @@ static RendererConfig video_player_render_worker_config(VideoPlayer *player) {
         .force_iterm2 = FALSE,
         .text_symbol_mode = TEXT_SYMBOL_MODE_AUTO,
         .gamma = 1.0,
-        .color_enhance = COLOR_ENHANCE_OFF,
+        .color_enhance = player ? player->color_enhance : COLOR_ENHANCE_OFF,
         .dither_mode = CHAFA_DITHER_MODE_NONE,
         .color_extractor = CHAFA_COLOR_EXTRACTOR_AVERAGE,
         .optimizations = CHAFA_OPTIMIZATION_REUSE_ATTRIBUTES
@@ -1291,6 +1292,10 @@ static RendererConfig video_player_render_worker_config(VideoPlayer *player) {
     config = player->renderer->config;
     g_mutex_unlock(&player->render_mutex);
     return config;
+}
+
+RendererConfig video_player_render_worker_config_for_test(VideoPlayer *player) {
+    return video_player_render_worker_config(player);
 }
 
 static void video_player_render_worker_refresh_layout(VideoPlayer *player,

--- a/src/video_player.c
+++ b/src/video_player.c
@@ -1095,6 +1095,7 @@ VideoPlayer* video_player_new(gint work_factor, gboolean force_text, gboolean fo
             .force_iterm2 = force_iterm2,
             .text_symbol_mode = text_symbol_mode,
             .gamma = gamma,
+            .color_enhance = COLOR_ENHANCE_OFF,
             .dither_mode = CHAFA_DITHER_MODE_NONE,
             .color_extractor = CHAFA_COLOR_EXTRACTOR_AVERAGE,
             .optimizations = CHAFA_OPTIMIZATION_REUSE_ATTRIBUTES
@@ -1276,6 +1277,7 @@ static RendererConfig video_player_render_worker_config(VideoPlayer *player) {
         .force_iterm2 = FALSE,
         .text_symbol_mode = TEXT_SYMBOL_MODE_AUTO,
         .gamma = 1.0,
+        .color_enhance = COLOR_ENHANCE_OFF,
         .dither_mode = CHAFA_DITHER_MODE_NONE,
         .color_extractor = CHAFA_COLOR_EXTRACTOR_AVERAGE,
         .optimizations = CHAFA_OPTIMIZATION_REUSE_ATTRIBUTES

--- a/tests/renderer_test_internal.h
+++ b/tests/renderer_test_internal.h
@@ -1,0 +1,16 @@
+#ifndef TESTS_RENDERER_TEST_INTERNAL_H
+#define TESTS_RENDERER_TEST_INTERNAL_H
+
+#include "renderer.h"
+
+/* Test-only declarations for renderer internals.
+ * These are not part of the supported production API surface.
+ */
+guint8 *renderer_color_enhance_copy_for_test(const guint8 *pixel_data,
+                                             gint width,
+                                             gint height,
+                                             gint rowstride,
+                                             gint n_channels,
+                                             ColorEnhanceMode mode);
+
+#endif

--- a/tests/test_app_cli.c
+++ b/tests/test_app_cli.c
@@ -41,6 +41,11 @@ typedef struct {
 } TextSymbolCase;
 
 typedef struct {
+    const gchar *value;
+    ColorEnhanceMode expected_mode;
+} ColorEnhanceCase;
+
+typedef struct {
     char **argv;
     gchar **path_out;
     AppConfig *config;
@@ -721,6 +726,7 @@ static void test_cli_apply_runtime_copies_app_owned_config_fields(AppCliFixture 
     config.clear_workaround_enabled = TRUE;
     config.work_factor = 4;
     config.gamma = 1.75;
+    config.color_enhance = COLOR_ENHANCE_VIVID;
     config.force_text = TRUE;
     config.force_sixel = FALSE;
     config.force_kitty = TRUE;
@@ -737,6 +743,7 @@ static void test_cli_apply_runtime_copies_app_owned_config_fields(AppCliFixture 
     g_assert_true(app.clear_workaround_enabled);
     g_assert_cmpint(app.render_work_factor, ==, 4);
     g_assert_cmpfloat_with_epsilon(app.gamma, 1.75, 0.0001);
+    g_assert_cmpint(app.color_enhance, ==, COLOR_ENHANCE_VIVID);
     g_assert_true(app.force_text);
     g_assert_false(app.force_sixel);
     g_assert_true(app.force_kitty);
@@ -759,13 +766,15 @@ static void test_cli_default_config_applies_terminal_specific_precedence(AppCliF
         "work_factor=3\n"
         "protocol=text\n"
         "text_symbols=quarter\n"
+        "color_enhance=off\n"
         "gamma=1.25\n"
         "\n"
         "[WarpTerminal]\n"
         "alt_screen=false\n"
         "clear_workaround=true\n"
         "protocol=kitty\n"
-        "text_symbols=half\n");
+        "text_symbols=half\n"
+        "color_enhance=vivid\n");
 
     pixelterm_env_set_for_test("TERM_PROGRAM", "WarpTerminal");
 
@@ -783,6 +792,7 @@ static void test_cli_default_config_applies_terminal_specific_precedence(AppCliF
     g_assert_cmpint(config.work_factor, ==, 3);
     g_assert_cmpint(config.protocol_mode, ==, APP_PROTOCOL_KITTY);
     g_assert_cmpint(config.text_symbol_mode, ==, TEXT_SYMBOL_MODE_HALF);
+    g_assert_cmpint(config.color_enhance, ==, COLOR_ENHANCE_VIVID);
     g_assert_true(config.gamma_set);
     g_assert_cmpfloat_with_epsilon(config.gamma, 1.25, 0.0001);
     g_free(path);
@@ -803,13 +813,15 @@ static void test_cli_default_config_respects_runtime_xdg_after_glib_cache_prime(
         "work_factor=3\n"
         "protocol=text\n"
         "text_symbols=quarter\n"
+        "color_enhance=off\n"
         "gamma=1.25\n"
         "\n"
         "[WarpTerminal]\n"
         "alt_screen=false\n"
         "clear_workaround=true\n"
         "protocol=kitty\n"
-        "text_symbols=half\n");
+        "text_symbols=half\n"
+        "color_enhance=vivid\n");
 
     pixelterm_env_set_for_test("XDG_CONFIG_HOME", config_root);
     pixelterm_env_set_for_test("TERM_PROGRAM", "WarpTerminal");
@@ -828,6 +840,7 @@ static void test_cli_default_config_respects_runtime_xdg_after_glib_cache_prime(
     g_assert_cmpint(config.work_factor, ==, 3);
     g_assert_cmpint(config.protocol_mode, ==, APP_PROTOCOL_KITTY);
     g_assert_cmpint(config.text_symbol_mode, ==, TEXT_SYMBOL_MODE_HALF);
+    g_assert_cmpint(config.color_enhance, ==, COLOR_ENHANCE_VIVID);
     g_assert_true(config.gamma_set);
     g_assert_cmpfloat_with_epsilon(config.gamma, 1.25, 0.0001);
 
@@ -850,6 +863,7 @@ static void test_cli_flags_override_loaded_config_values(AppCliFixture *fixture,
         "work_factor=2\n"
         "protocol=text\n"
         "text_symbols=half\n"
+        "color_enhance=off\n"
         "gamma=1.5\n");
 
     AppConfig config;
@@ -872,6 +886,8 @@ static void test_cli_flags_override_loaded_config_values(AppCliFixture *fixture,
         "sixel",
         "--text-symbols",
         "quarter",
+        "--color-enhance",
+        "vivid",
         "--gamma",
         "2.5",
         "sample.png",
@@ -887,9 +903,50 @@ static void test_cli_flags_override_loaded_config_values(AppCliFixture *fixture,
     g_assert_cmpint(config.work_factor, ==, 8);
     g_assert_cmpint(config.protocol_mode, ==, APP_PROTOCOL_SIXEL);
     g_assert_cmpint(config.text_symbol_mode, ==, TEXT_SYMBOL_MODE_QUARTER);
+    g_assert_cmpint(config.color_enhance, ==, COLOR_ENHANCE_VIVID);
     g_assert_true(config.gamma_set);
     g_assert_cmpfloat_with_epsilon(config.gamma, 2.5, 0.0001);
     g_free(path);
+}
+
+static void test_cli_color_enhance_argument_parses_supported_modes(AppCliFixture *fixture,
+                                                                   gconstpointer user_data) {
+    (void)fixture;
+    (void)user_data;
+
+    const ColorEnhanceCase cases[] = {
+        {"off", COLOR_ENHANCE_OFF},
+        {"vivid", COLOR_ENHANCE_VIVID},
+        {"VIVID", COLOR_ENHANCE_VIVID},
+    };
+
+    for (gsize i = 0; i < G_N_ELEMENTS(cases); i++) {
+        AppConfig config;
+        gchar *path = NULL;
+        app_config_init(&config);
+
+        char *argv[] = {"pixelterm", "--color-enhance", (char *)cases[i].value, "sample.png", NULL};
+
+        g_assert_cmpint(parse_cli_args(argv, &path, &config), ==, ERROR_NONE);
+        g_assert_cmpint(config.color_enhance, ==, cases[i].expected_mode);
+        g_assert_cmpstr(path, ==, "sample.png");
+        g_free(path);
+    }
+}
+
+static void test_cli_color_enhance_argument_rejects_unknown_mode(AppCliFixture *fixture,
+                                                                 gconstpointer user_data) {
+    (void)fixture;
+    (void)user_data;
+
+    AppConfig config;
+    gchar *path = NULL;
+    app_config_init(&config);
+
+    char *argv[] = {"pixelterm", "--color-enhance", "neon", NULL};
+
+    g_assert_cmpint(parse_cli_args(argv, &path, &config), ==, ERROR_INVALID_ARGS);
+    g_assert_null(path);
 }
 
 static void test_cli_double_dash_preserves_positional_config_like_path(AppCliFixture *fixture,
@@ -1223,6 +1280,10 @@ void register_app_cli_tests(void) {
     add_app_cli_test("/app_cli/parse/protocol", test_cli_protocol_argument_parses_supported_modes);
     add_app_cli_test("/app_cli/parse/text_symbols",
                      test_cli_text_symbols_argument_parses_supported_modes);
+    add_app_cli_test("/app_cli/parse/color_enhance",
+                     test_cli_color_enhance_argument_parses_supported_modes);
+    add_app_cli_test("/app_cli/parse/color_enhance_invalid",
+                     test_cli_color_enhance_argument_rejects_unknown_mode);
     add_app_cli_test("/app_cli/protocol_resolution/auto_prefers_affirmative_signal_before_generic_probe_order",
                      test_cli_protocol_resolution_auto_prefers_affirmative_signal_before_generic_probe_order);
     add_app_cli_test("/app_cli/protocol_resolution/auto_accepts_libghostty_xtversion_as_kitty_signal",

--- a/tests/test_renderer.c
+++ b/tests/test_renderer.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include "renderer.h"
+#include "renderer_test_internal.h"
 
 GdkPixbuf *gdk_pixbuf_new_from_stream(GInputStream *stream, GCancellable *cancellable, GError **error) {
     (void)cancellable;
@@ -358,6 +359,19 @@ static void test_renderer_color_enhance_vivid_boosts_color_separation(void) {
     g_free(adjusted);
 }
 
+static void test_renderer_color_enhance_skips_short_pixel_formats(void) {
+    const guint8 pixels[] = {120, 80};
+
+    guint8 *adjusted = renderer_color_enhance_copy_for_test(pixels,
+                                                            1,
+                                                            1,
+                                                            2,
+                                                            2,
+                                                            COLOR_ENHANCE_VIVID);
+
+    g_assert_null(adjusted);
+}
+
 void register_renderer_tests(void) {
     g_test_add_func("/renderer/cache_roundtrip", test_renderer_cache_roundtrip);
     g_test_add_func("/renderer/get_rendered_dimensions", test_renderer_get_rendered_dimensions_defaults);
@@ -378,4 +392,6 @@ void register_renderer_tests(void) {
                     test_renderer_color_enhance_off_keeps_pixels_unchanged);
     g_test_add_func("/renderer/color_enhance/vivid_boosts_color_separation",
                     test_renderer_color_enhance_vivid_boosts_color_separation);
+    g_test_add_func("/renderer/color_enhance/skips_short_pixel_formats",
+                    test_renderer_color_enhance_skips_short_pixel_formats);
 }

--- a/tests/test_renderer.c
+++ b/tests/test_renderer.c
@@ -320,6 +320,44 @@ static void test_renderer_is_image_supported(void) {
     g_assert_true(renderer_is_image_supported(path));
 }
 
+static void test_renderer_color_enhance_off_keeps_pixels_unchanged(void) {
+    const guint8 pixels[] = {120, 80, 70, 255};
+
+    guint8 *adjusted = renderer_color_enhance_copy_for_test(pixels,
+                                                            1,
+                                                            1,
+                                                            4,
+                                                            4,
+                                                            COLOR_ENHANCE_OFF);
+
+    g_assert_null(adjusted);
+    g_assert_cmpuint(pixels[0], ==, 120);
+    g_assert_cmpuint(pixels[1], ==, 80);
+    g_assert_cmpuint(pixels[2], ==, 70);
+    g_assert_cmpuint(pixels[3], ==, 255);
+}
+
+static void test_renderer_color_enhance_vivid_boosts_color_separation(void) {
+    const guint8 pixels[] = {120, 80, 70, 255};
+
+    guint8 *adjusted = renderer_color_enhance_copy_for_test(pixels,
+                                                            1,
+                                                            1,
+                                                            4,
+                                                            4,
+                                                            COLOR_ENHANCE_VIVID);
+
+    g_assert_nonnull(adjusted);
+    g_assert_cmpuint(adjusted[0], >, pixels[0]);
+    g_assert_cmpuint(adjusted[1], <, pixels[1]);
+    g_assert_cmpuint(adjusted[2], <, pixels[2]);
+    g_assert_cmpuint(adjusted[3], ==, pixels[3]);
+    g_assert_cmpuint(adjusted[0], <=, 255);
+    g_assert_cmpuint(adjusted[1], <=, 255);
+    g_assert_cmpuint(adjusted[2], <=, 255);
+    g_free(adjusted);
+}
+
 void register_renderer_tests(void) {
     g_test_add_func("/renderer/cache_roundtrip", test_renderer_cache_roundtrip);
     g_test_add_func("/renderer/get_rendered_dimensions", test_renderer_get_rendered_dimensions_defaults);
@@ -336,4 +374,8 @@ void register_renderer_tests(void) {
     g_test_add_func("/renderer/get_image_dimensions/valid", test_renderer_get_image_dimensions_valid);
     g_test_add_func("/renderer/get_image_dimensions/invalid", test_renderer_get_image_dimensions_invalid);
     g_test_add_func("/renderer/is_image_supported", test_renderer_is_image_supported);
+    g_test_add_func("/renderer/color_enhance/off_keeps_pixels_unchanged",
+                    test_renderer_color_enhance_off_keeps_pixels_unchanged);
+    g_test_add_func("/renderer/color_enhance/vivid_boosts_color_separation",
+                    test_renderer_color_enhance_vivid_boosts_color_separation);
 }

--- a/tests/test_video_player.c
+++ b/tests/test_video_player.c
@@ -2241,6 +2241,26 @@ static void test_seek_frame_with_test_hook_uses_registered_callback(void) {
     video_player_destroy(player);
 }
 
+static void test_render_worker_config_uses_player_color_enhance_without_renderer(void) {
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    if (!player) {
+        g_test_skip("video player unavailable");
+        return;
+    }
+
+    if (player->renderer && player->owns_renderer) {
+        renderer_destroy(player->renderer);
+    }
+    player->renderer = NULL;
+    player->owns_renderer = FALSE;
+    player->color_enhance = COLOR_ENHANCE_VIVID;
+
+    RendererConfig config = video_player_render_worker_config_for_test(player);
+
+    g_assert_cmpint(config.color_enhance, ==, COLOR_ENHANCE_VIVID);
+    video_player_destroy(player);
+}
+
 void register_video_player_tests(void) {
     g_test_add_func("/video_player/reset_timing_state/clears_loop_sensitive_fields",
                     test_reset_timing_state_clears_loop_sensitive_fields);
@@ -2300,6 +2320,8 @@ void register_video_player_tests(void) {
                     test_render_layout_generation_starts_initialized);
     g_test_add_func("/video_player/render_layout_generation/increments_only_on_layout_change",
                     test_render_layout_generation_increments_only_on_layout_change);
+    g_test_add_func("/video_player/render_worker_config/uses_player_color_enhance_without_renderer",
+                    test_render_worker_config_uses_player_color_enhance_without_renderer);
     g_test_add_func("/video_player/drop_late_frame/does_not_drop_when_backlog_is_shallow",
                     test_should_not_drop_late_frame_when_backlog_is_shallow);
     g_test_add_func("/video_player/drop_late_frame/does_not_drop_when_backlog_is_medium",

--- a/tests/video_player_test_internal.h
+++ b/tests/video_player_test_internal.h
@@ -39,5 +39,6 @@ gint video_player_calc_delay_ms(VideoPlayer *player);
 void video_player_update_queue_depth(VideoPlayer *player, gint rendered_w, gint rendered_h);
 gint64 video_player_current_position_ms_for_test(VideoPlayer *player);
 gint64 video_player_seek_target_ms_for_test(VideoPlayer *player, gint64 delta_ms, gint64 duration_ms);
+RendererConfig video_player_render_worker_config_for_test(VideoPlayer *player);
 
 #endif


### PR DESCRIPTION
## Summary
- add a default-off vivid color enhancement mode before Chafa rendering
- expose it through --color-enhance and color_enhance config
- document the option and cover renderer/CLI behavior with tests

## Tests
- make bin/pixelterm-tests && G_TEST_FILTER=/renderer/color_enhance* bin/pixelterm-tests
- make bin/pixelterm-tests && G_TEST_FILTER=/app_cli/*color* bin/pixelterm-tests
- make test

## 由 Sourcery 提供的摘要

引入一个可配置的鲜艳色彩增强模式，可在渲染前应用，并贯穿于渲染器、应用程序、预加载器、视频/GIF 播放器、CLI 和配置系统。

新功能：
- 添加一个鲜艳色彩增强模式，在 Chafa 渲染前提升颜色分离度，默认关闭。
- 通过 `--color-enhance` CLI 标志以及配置文件中的 `color_enhance` 选项暴露颜色增强配置。

改进：
- 将颜色增强设置在渲染器、预加载器、应用状态、网格/书籍渲染器和媒体播放器之间进行传递，从而在所有渲染路径中保持一致生效。

文档：
- 在 README、使用指南和示例配置中记录新的 `--color-enhance` 选项及其行为。

测试：
- 为颜色增强行为添加渲染器单元测试，并为 `color_enhance` 选项的解析、优先级和校验添加 CLI 测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个可配置的鲜艳色彩增强模式，可在渲染前应用，并贯穿渲染器、应用状态、预加载器和媒体播放器，同时在 CLI 和配置中集成，并补充相关文档与测试。

New Features:
- 添加颜色增强模式（`off` 或 `vivid`），在 Chafa 渲染前对支持的像素格式进行轻量的色彩分离增强。
- 通过新的 `--color-enhance` CLI 标志以及 `color_enhance` 配置项，在默认和终端特定配置组中暴露颜色增强控制。

Enhancements:
- 将颜色增强设置传递到渲染器配置、应用运行时状态、预加载器、网格/书籍渲染器、GIF 播放器和视频播放器，使所有渲染路径共享相同的行为。

Documentation:
- 在 README、使用指南和示例配置中记录颜色增强选项，包括其设计意图和取舍。

Tests:
- 添加渲染器单元测试，验证颜色增强行为以及在短像素格式上的安全性。
- 扩展 CLI 测试，以覆盖 `color_enhance` 的解析、相对于配置的优先级，以及对无效模式的错误处理。
- 添加视频播放器测试，以确保在没有渲染器存在时，渲染工作线程配置会使用播放器级别的颜色增强设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable vivid color enhancement mode that can be applied before rendering and is threaded through the renderer, app state, preloader, and media players, with CLI and config integration plus documentation and tests.

New Features:
- Add a color enhancement mode (off or vivid) that lightly boosts color separation before Chafa rendering for supported pixel formats.
- Expose color enhancement control via the new --color-enhance CLI flag and color_enhance configuration option across default and terminal-specific config groups.

Enhancements:
- Propagate color enhancement settings through renderer configuration, app runtime state, preloader, grid/book renderers, GIF player, and video player so all rendering paths can share the same behavior.

Documentation:
- Document the color enhancement option in the README, usage guide, and example config, including its intent and tradeoffs.

Tests:
- Add renderer unit tests validating color enhancement behavior and safety on short pixel formats.
- Extend CLI tests to cover color_enhance parsing, precedence over config, and error handling for invalid modes.
- Add a video player test to ensure the render worker configuration uses the player-level color enhancement when no renderer is present.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a default-off vivid color enhancement mode that lightly boosts color separation before Chafa rendering to improve clarity for muted images. Exposes control via `--color-enhance` and `color_enhance`.

- **New Features**
  - Rendering: optional pre-render vivid enhancement with small CPU cost; no change when off; skips non-RGB pixel formats safely.
  - CLI/config: `--color-enhance off|vivid`; `color_enhance` in config; CLI overrides config.
  - Wiring: plumbed through app state, renderer, preloader, grid/book renderers, and GIF/video players; video worker uses the player’s setting even without a renderer.
  - Docs/tests: README/USAGE updated; `config.example.ini` extended; tests cover renderer behavior, CLI parsing/validation, and video worker config propagation.

<sup>Written for commit 5f860f02cfcf49cc6a42988a0d475ff85b86d8dd. Summary will update on new commits. <a href="https://cubic.dev/pr/zouyonghe/PixelTerm-C/pull/19?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

