### PR TITLE
Harden installer and CI follow-ups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
         
         # Build PixelTerm-C
         make clean && make
+        make EXTRA_CFLAGS=-Werror test
         if command -v strip >/dev/null; then
           strip bin/pixelterm || true
         fi
@@ -109,6 +110,7 @@ jobs:
         
         # Build PixelTerm-C
         make clean && make
+        make EXTRA_CFLAGS=-Werror test
         if command -v strip >/dev/null; then
           strip bin/pixelterm || true
         fi
@@ -149,6 +151,10 @@ jobs:
       with:
         pattern: pixelterm*
         merge-multiple: true
+
+    - name: Generate release checksums
+      run: |
+        sha256sum pixelterm-* > SHA256SUMS
 
     - name: Prepare release notes inputs
       id: release_notes_inputs
@@ -204,6 +210,7 @@ jobs:
       with:
         body_path: ${{ steps.release_notes_inputs.outputs.output_file }}
         files: |
+          SHA256SUMS
           pixelterm-amd64-linux.tar.gz
           pixelterm-amd64-linux
           pixelterm-arm64-linux.tar.gz

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -65,9 +65,9 @@ jobs:
         run: |
           make EXTRA_CFLAGS=-Werror test
 
-      - name: Validate debug AddressSanitizer build
+      - name: Run debug AddressSanitizer tests
         run: |
-          make EXTRA_CFLAGS=-Werror debug
+          make EXTRA_CFLAGS=-Werror debug-test
 
   build-and-test-macos:
     if: github.event_name == 'pull_request'
@@ -96,6 +96,6 @@ jobs:
         run: |
           make EXTRA_CFLAGS=-Werror test
 
-      - name: Validate debug AddressSanitizer build
+      - name: Run debug AddressSanitizer tests
         run: |
-          make EXTRA_CFLAGS=-Werror debug
+          make EXTRA_CFLAGS=-Werror debug-test

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ INSTALL ?= install
 VERSION = $(shell git describe --tags --exact-match 2>/dev/null || git describe --tags --always --dirty 2>/dev/null | cut -d'-' -f1 | cut -c2- || echo "unknown")
 CFLAGS = -Wall -Wextra -std=c11 -O2 -Wno-sign-compare -Wno-unused-variable -Wno-unused-but-set-variable -Wno-switch -DAPP_VERSION=\"$(VERSION)\"
 DEBUG_CFLAGS = -g -DDEBUG -fsanitize=address
+DEBUG ?= 0
 EXTRA_CFLAGS ?=
 DEPFLAGS = -MMD -MP
 # Prefer the locally installed Chafa when both system and /usr/local versions exist
@@ -28,6 +29,9 @@ ifeq ($(UNAME_S),Linux)
   LDFLAGS += -Wl,--gc-sections
 else ifeq ($(UNAME_S),Darwin)
   LDFLAGS += -Wl,-dead_strip
+endif
+ifeq ($(DEBUG),1)
+  CFLAGS += $(DEBUG_CFLAGS)
 endif
 EXTRA_LIBS =
 ifneq ($(shell $(PKG_CONFIG_CMD) --exists zlib >/dev/null 2>&1 && echo yes),)
@@ -93,6 +97,8 @@ endif
 SRCDIR = src
 OBJDIR = obj
 BINDIR = bin
+DEBUG_OBJDIR ?= obj-debug
+DEBUG_BINDIR ?= bin-debug
 BUILD_FLAGS_FILE = $(OBJDIR)/.build-flags
 
 # Source files
@@ -138,15 +144,16 @@ $(BINDIR):
 
 $(BUILD_FLAGS_FILE): FORCE | $(OBJDIR)
 	@{ \
+		tmp_file="$@.$$$$.tmp"; \
 		printf '%s\n' \
 			'CC=$(CC)' \
 			'CFLAGS=$(CFLAGS)' \
 			'EXTRA_CFLAGS=$(EXTRA_CFLAGS)' \
 			'INCLUDES=$(INCLUDES)' \
 			'LDFLAGS=$(LDFLAGS)' \
-			'LIBS=$(LIBS)'; \
-	} > $@.tmp
-	@if [ ! -f $@ ] || ! cmp -s $@.tmp $@; then mv $@.tmp $@; else rm -f $@.tmp; fi
+			'LIBS=$(LIBS)' > "$${tmp_file}"; \
+		if [ ! -f $@ ] || ! cmp -s "$${tmp_file}" $@; then mv "$${tmp_file}" $@; else rm -f "$${tmp_file}"; fi; \
+	}
 
 # Build the main executable
 $(TARGET): $(OBJECTS) $(BUILD_FLAGS_FILE) | $(BINDIR)
@@ -174,15 +181,15 @@ $(BOOK_PREVIEW_TEST_TARGET): $(BOOK_PREVIEW_TEST_OBJECT) $(BOOK_PREVIEW_TEST_LIN
 	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDES) $(LDFLAGS) -o $@ $(BOOK_PREVIEW_TEST_OBJECT) $(BOOK_PREVIEW_TEST_LINK_OBJECTS) $(LIBS)
 
 # Debug build
-debug: CFLAGS += $(DEBUG_CFLAGS)
-debug: clean all
+debug:
+	$(MAKE) OBJDIR="$(DEBUG_OBJDIR)" BINDIR="$(DEBUG_BINDIR)" DEBUG=1 EXTRA_CFLAGS="$(EXTRA_CFLAGS)" all
 
-debug-test: CFLAGS += $(DEBUG_CFLAGS)
-debug-test: clean test
+debug-test:
+	$(MAKE) OBJDIR="$(DEBUG_OBJDIR)" BINDIR="$(DEBUG_BINDIR)" DEBUG=1 EXTRA_CFLAGS="$(EXTRA_CFLAGS)" test
 
 # Clean build artifacts
 clean:
-	rm -rf $(OBJDIR) $(BINDIR)
+	rm -rf $(OBJDIR) $(BINDIR) $(DEBUG_OBJDIR) $(DEBUG_BINDIR)
 
 # Install
 install: $(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,9 @@ $(BOOK_PREVIEW_TEST_TARGET): $(BOOK_PREVIEW_TEST_OBJECT) $(BOOK_PREVIEW_TEST_LIN
 debug: CFLAGS += $(DEBUG_CFLAGS)
 debug: clean all
 
+debug-test: CFLAGS += $(DEBUG_CFLAGS)
+debug-test: clean test
+
 # Clean build artifacts
 clean:
 	rm -rf $(OBJDIR) $(BINDIR)
@@ -215,6 +218,7 @@ help:
 	@echo "Available targets:"
 	@echo "  all       - Build the application (default)"
 	@echo "  debug     - Build with debug flags"
+	@echo "  debug-test - Run tests with debug AddressSanitizer flags"
 	@echo "  clean     - Remove build artifacts"
 	@echo "  install   - Install to system"
 	@echo "  test      - Run tests"
@@ -232,7 +236,7 @@ help:
 	@echo "  make CC=aarch64-linux-gnu-gcc ARCH=aarch64  # Full cross-compilation"
 	@echo "  make run ARGS=\"/path/to/image.jpg\"  # Run with args"
 
-.PHONY: FORCE all debug clean install test run check-deps help
+.PHONY: FORCE all debug debug-test clean install test run check-deps help
 
 FORCE:
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Need a custom install directory instead of `/usr/local/bin`?
 curl -fsSL https://raw.githubusercontent.com/zouyonghe/PixelTerm-C/main/scripts/install.sh | bash -s -- --bin-dir "$HOME/.local/bin"
 ```
 
+Need a reproducible install? Pin a release tag:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/zouyonghe/PixelTerm-C/main/scripts/install.sh | bash -s -- --version v1.7.26
+```
+
 If you prefer a package manager or manual install, use one of these paths:
 
 ```bash

--- a/docs/i18n/README_ja.md
+++ b/docs/i18n/README_ja.md
@@ -39,6 +39,12 @@ curl -fsSL https://raw.githubusercontent.com/zouyonghe/PixelTerm-C/main/scripts/
 curl -fsSL https://raw.githubusercontent.com/zouyonghe/PixelTerm-C/main/scripts/install.sh | bash -s -- --bin-dir "$HOME/.local/bin"
 ```
 
+再現性のあるインストールが必要な場合は、release tag を固定できます。
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/zouyonghe/PixelTerm-C/main/scripts/install.sh | bash -s -- --version v1.7.26
+```
+
 パッケージマネージャや手動インストールを使いたい場合は、以下の方法も利用できます。
 
 ### パッケージマネージャ

--- a/docs/i18n/README_zh.md
+++ b/docs/i18n/README_zh.md
@@ -39,6 +39,12 @@ curl -fsSL https://raw.githubusercontent.com/zouyonghe/PixelTerm-C/main/scripts/
 curl -fsSL https://raw.githubusercontent.com/zouyonghe/PixelTerm-C/main/scripts/install.sh | bash -s -- --bin-dir "$HOME/.local/bin"
 ```
 
+如果需要可复现安装，可以固定 release tag：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/zouyonghe/PixelTerm-C/main/scripts/install.sh | bash -s -- --version v1.7.26
+```
+
 如果你更偏向包管理器或手动安装，也可以继续用下面这些方式：
 
 ```bash

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,7 @@ DRY_RUN=0
 PRINT_ASSET_NAME=0
 PRINT_INSTALL_PATH=0
 TMP_DIR=""
+CHECKSUMS_URL="https://github.com/%s/releases/latest/download/SHA256SUMS"
 
 usage() {
   cat <<'EOF'
@@ -117,6 +118,10 @@ download_url() {
   printf 'https://github.com/%s/releases/latest/download/%s\n' "${REPO_SLUG}" "${asset_name}"
 }
 
+checksums_url() {
+  printf "${CHECKSUMS_URL}\n" "${REPO_SLUG}"
+}
+
 install_path() {
   printf '%s/pixelterm\n' "${INSTALL_DIR%/}"
 }
@@ -156,6 +161,51 @@ download_binary() {
   fi
 
   die "curl or wget is required to download PixelTerm-C"
+}
+
+download_checksums() {
+  local url
+  local destination
+
+  url="$(checksums_url)"
+  destination="$1"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "${url}" -o "${destination}"
+    return 0
+  fi
+
+  if command -v wget >/dev/null 2>&1; then
+    wget -qO "${destination}" "${url}"
+    return 0
+  fi
+
+  die "curl or wget is required to download release checksums"
+}
+
+verify_checksum() {
+  local checksums_file
+  local downloaded_file
+  local asset_name
+  local expected
+  local actual
+
+  checksums_file="$1"
+  downloaded_file="$2"
+  asset_name="$3"
+
+  expected="$(grep " ${asset_name}$" "${checksums_file}" | awk '{print $1}')"
+  [ -n "${expected}" ] || die "Missing checksum for ${asset_name}"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "${downloaded_file}" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "${downloaded_file}" | awk '{print $1}')"
+  else
+    die "sha256sum or shasum is required to verify PixelTerm-C"
+  fi
+
+  [ "${actual}" = "${expected}" ] || die "Checksum verification failed for ${asset_name}"
 }
 
 prepare_install_dir() {
@@ -220,6 +270,7 @@ main() {
   local url
   local destination
   local tmp_file
+  local checksum_file
   local os_name
   local arch_name
 
@@ -251,9 +302,16 @@ main() {
 
   TMP_DIR="$(mktemp -d)"
   tmp_file="${TMP_DIR}/${asset_name}"
+  checksum_file="${TMP_DIR}/SHA256SUMS"
 
   log "Downloading ${asset_name}..."
   download_binary "${tmp_file}"
+
+  log "Downloading SHA256SUMS..."
+  download_checksums "${checksum_file}"
+
+  log "Verifying checksum..."
+  verify_checksum "${checksum_file}" "${tmp_file}" "${asset_name}"
 
   log "Installing to ${destination}..."
   install_binary "${tmp_file}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,17 +7,18 @@ DRY_RUN=0
 PRINT_ASSET_NAME=0
 PRINT_INSTALL_PATH=0
 TMP_DIR=""
-CHECKSUMS_URL="https://github.com/%s/releases/latest/download/SHA256SUMS"
+RELEASE_VERSION=""
 
 usage() {
   cat <<'EOF'
-Install PixelTerm-C from the latest GitHub Release.
+Install PixelTerm-C from a GitHub Release.
 
 Usage:
   bash install.sh [options]
 
 Options:
   --bin-dir <dir>       Install pixelterm into the given directory
+  --version <tag>       Install a specific release tag instead of latest
   --dry-run             Print the resolved download URL and destination
   --print-asset-name    Print the detected release asset name and exit
   --print-install-path  Print the final install path and exit
@@ -26,6 +27,7 @@ Options:
 Examples:
   curl -fsSL https://raw.githubusercontent.com/zouyonghe/PixelTerm-C/main/scripts/install.sh | bash
   curl -fsSL https://raw.githubusercontent.com/zouyonghe/PixelTerm-C/main/scripts/install.sh | bash -s -- --bin-dir "$HOME/.local/bin"
+  curl -fsSL https://raw.githubusercontent.com/zouyonghe/PixelTerm-C/main/scripts/install.sh | bash -s -- --version v1.7.26
 EOF
 }
 
@@ -112,14 +114,23 @@ release_asset_name() {
   printf 'pixelterm-%s-%s\n' "${arch_name}" "${os_name}"
 }
 
+release_selector() {
+  if [ -n "${RELEASE_VERSION}" ]; then
+    printf 'download/%s' "${RELEASE_VERSION}"
+    return
+  fi
+
+  printf 'latest/download'
+}
+
 download_url() {
   local asset_name
   asset_name="$(release_asset_name)"
-  printf 'https://github.com/%s/releases/latest/download/%s\n' "${REPO_SLUG}" "${asset_name}"
+  printf 'https://github.com/%s/releases/%s/%s\n' "${REPO_SLUG}" "$(release_selector)" "${asset_name}"
 }
 
 checksums_url() {
-  printf "${CHECKSUMS_URL}\n" "${REPO_SLUG}"
+  printf 'https://github.com/%s/releases/%s/SHA256SUMS\n' "${REPO_SLUG}" "$(release_selector)"
 }
 
 install_path() {
@@ -242,6 +253,11 @@ parse_args() {
         INSTALL_DIR="$2"
         shift 2
         ;;
+      --version)
+        [ "$#" -ge 2 ] || die "Missing value for --version"
+        RELEASE_VERSION="$2"
+        shift 2
+        ;;
       --dry-run)
         DRY_RUN=1
         shift
@@ -294,6 +310,11 @@ main() {
 
   if [ "${DRY_RUN}" -eq 1 ]; then
     log "Resolved platform: ${os_name}/${arch_name}"
+    if [ -n "${RELEASE_VERSION}" ]; then
+      log "Release version: ${RELEASE_VERSION}"
+    else
+      log "Release version: latest"
+    fi
     log "Release asset: ${asset_name}"
     log "Download URL: ${url}"
     log "Install destination: ${destination}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -115,7 +115,7 @@ release_asset_name() {
 }
 
 release_selector() {
-  if [ -n "${RELEASE_VERSION}" ]; then
+  if [ -n "${RELEASE_VERSION}" ] && [ "${RELEASE_VERSION}" != "latest" ]; then
     printf 'download/%s' "${RELEASE_VERSION}"
     return
   fi
@@ -154,12 +154,12 @@ run_privileged() {
   die "Install target is not writable and sudo is not available"
 }
 
-download_binary() {
+download_file() {
   local url
   local destination
 
-  url="$(download_url)"
-  destination="$1"
+  url="$1"
+  destination="$2"
 
   if command -v curl >/dev/null 2>&1; then
     curl -fsSL "${url}" -o "${destination}"
@@ -174,24 +174,12 @@ download_binary() {
   die "curl or wget is required to download PixelTerm-C"
 }
 
+download_binary() {
+  download_file "$(download_url)" "$1"
+}
+
 download_checksums() {
-  local url
-  local destination
-
-  url="$(checksums_url)"
-  destination="$1"
-
-  if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "${url}" -o "${destination}"
-    return 0
-  fi
-
-  if command -v wget >/dev/null 2>&1; then
-    wget -qO "${destination}" "${url}"
-    return 0
-  fi
-
-  die "curl or wget is required to download release checksums"
+  download_file "$(checksums_url)" "$1"
 }
 
 verify_checksum() {

--- a/scripts/test_install_script.py
+++ b/scripts/test_install_script.py
@@ -35,6 +35,62 @@ def run_script(
     )
 
 
+def create_fake_curl(fake_bin_dir: Path) -> None:
+    fake_binary = b"#!/usr/bin/env bash\nexit 0\n"
+    fake_binary_sha256 = hashlib.sha256(fake_binary).hexdigest()
+    fake_curl = fake_bin_dir / "curl"
+    fake_curl.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -eu\n"
+        "out=''\n"
+        "url=''\n"
+        'while [ "$#" -gt 0 ]; do\n'
+        '  case "$1" in\n'
+        '    -o) out="$2"; shift 2 ;;\n'
+        '    -*) shift ;;\n'
+        '    *) url="$1"; shift ;;\n'
+        "  esac\n"
+        "done\n"
+        "if printf '%s' \"$url\" | grep -q 'SHA256SUMS$'; then\n"
+        "  if [ \"${CURL_FAIL_FOR_CHECKSUMS:-0}\" = \"1\" ]; then\n"
+        "    printf 'simulated curl failure for checksums\\n' >&2\n"
+        "    exit 22\n"
+        "  fi\n"
+        "  if [ \"${CURL_EMPTY_SHA256SUMS:-0}\" = \"1\" ]; then\n"
+        "    : > \"$out\"\n"
+        "    exit 0\n"
+        "  fi\n"
+        "  if [ \"${CURL_BAD_SHA256SUMS:-0}\" = \"1\" ]; then\n"
+        "    printf '%s  %s\\n' "
+        "'0000000000000000000000000000000000000000000000000000000000000000' "
+        "pixelterm-amd64-linux > \"$out\"\n"
+        "    exit 0\n"
+        "  fi\n"
+        f"  printf '%s  %s\\n' '{fake_binary_sha256}' pixelterm-amd64-linux > \"$out\"\n"
+        "else\n"
+        "  if [ \"${CURL_FAIL_FOR_BINARY:-0}\" = \"1\" ]; then\n"
+        "    printf 'simulated curl failure for binary\\n' >&2\n"
+        "    exit 22\n"
+        "  fi\n"
+        "  printf '#!/usr/bin/env bash\\nexit 0\\n' > \"$out\"\n"
+        "  chmod 0755 \"$out\"\n"
+        "fi\n",
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
+
+
+def fake_install_env(fake_bin_dir: Path, extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = {
+        "PATH": f"{fake_bin_dir}:{os.environ['PATH']}",
+        "PIXELTERM_INSTALL_UNAME_S": "Linux",
+        "PIXELTERM_INSTALL_UNAME_M": "x86_64",
+    }
+    if extra:
+        env.update(extra)
+    return env
+
+
 class InstallScriptCLITest(unittest.TestCase):
     def test_selects_linux_amd64_release_asset(self) -> None:
         result = run_script(
@@ -164,46 +220,98 @@ class InstallScriptCLITest(unittest.TestCase):
             fake_bin_dir = temp_path / "fake-bin"
             install_dir = temp_path / "install-bin"
             fake_bin_dir.mkdir()
-            fake_binary = b"#!/usr/bin/env bash\nexit 0\n"
-            fake_binary_sha256 = hashlib.sha256(fake_binary).hexdigest()
-
-            fake_curl = fake_bin_dir / "curl"
-            fake_curl.write_text(
-                "#!/usr/bin/env bash\n"
-                "set -eu\n"
-                "out=''\n"
-                "url=''\n"
-                'while [ "$#" -gt 0 ]; do\n'
-                '  case "$1" in\n'
-                '    -o) out="$2"; shift 2 ;;\n'
-                '    -*) shift ;;\n'
-                '    *) url="$1"; shift ;;\n'
-                "  esac\n"
-                "done\n"
-                "if printf '%s' \"$url\" | grep -q 'SHA256SUMS$'; then\n"
-                f"  printf '%s  %s\\n' '{fake_binary_sha256}' pixelterm-amd64-linux > \"$out\"\n"
-                "else\n"
-                "  printf '#!/usr/bin/env bash\\nexit 0\\n' > \"$out\"\n"
-                "  chmod 0755 \"$out\"\n"
-                "fi\n",
-                encoding="utf-8",
-            )
-            fake_curl.chmod(0o755)
+            create_fake_curl(fake_bin_dir)
 
             result = run_script(
                 "--bin-dir",
                 str(install_dir),
                 "--version",
                 "v1.7.26",
-                env={
-                    "PATH": f"{fake_bin_dir}:{os.environ['PATH']}",
-                    "PIXELTERM_INSTALL_UNAME_S": "Linux",
-                    "PIXELTERM_INSTALL_UNAME_M": "x86_64",
-                },
+                env=fake_install_env(fake_bin_dir),
             )
 
             self.assertEqual(result.returncode, 0, msg=result.stderr)
             self.assertTrue((install_dir / "pixelterm").exists())
+
+    def test_install_aborts_on_mismatched_sha256(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            fake_bin_dir = temp_path / "fake-bin"
+            install_dir = temp_path / "install-bin"
+            fake_bin_dir.mkdir()
+            create_fake_curl(fake_bin_dir)
+
+            result = run_script(
+                "--bin-dir",
+                str(install_dir),
+                "--version",
+                "v1.7.26",
+                env=fake_install_env(fake_bin_dir, {"CURL_BAD_SHA256SUMS": "1"}),
+            )
+
+            self.assertNotEqual(result.returncode, 0, msg=result.stdout)
+            self.assertIn("Checksum verification failed", result.stderr)
+            self.assertFalse((install_dir / "pixelterm").exists())
+
+    def test_install_aborts_on_empty_sha256sums(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            fake_bin_dir = temp_path / "fake-bin"
+            install_dir = temp_path / "install-bin"
+            fake_bin_dir.mkdir()
+            create_fake_curl(fake_bin_dir)
+
+            result = run_script(
+                "--bin-dir",
+                str(install_dir),
+                "--version",
+                "v1.7.26",
+                env=fake_install_env(fake_bin_dir, {"CURL_EMPTY_SHA256SUMS": "1"}),
+            )
+
+            self.assertNotEqual(result.returncode, 0, msg=result.stdout)
+            self.assertIn("Missing checksum", result.stderr)
+            self.assertFalse((install_dir / "pixelterm").exists())
+
+    def test_install_aborts_when_binary_download_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            fake_bin_dir = temp_path / "fake-bin"
+            install_dir = temp_path / "install-bin"
+            fake_bin_dir.mkdir()
+            create_fake_curl(fake_bin_dir)
+
+            result = run_script(
+                "--bin-dir",
+                str(install_dir),
+                "--version",
+                "v1.7.26",
+                env=fake_install_env(fake_bin_dir, {"CURL_FAIL_FOR_BINARY": "1"}),
+            )
+
+            self.assertNotEqual(result.returncode, 0, msg=result.stdout)
+            self.assertIn("simulated curl failure for binary", result.stderr)
+            self.assertFalse((install_dir / "pixelterm").exists())
+
+    def test_install_aborts_when_checksum_download_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            fake_bin_dir = temp_path / "fake-bin"
+            install_dir = temp_path / "install-bin"
+            fake_bin_dir.mkdir()
+            create_fake_curl(fake_bin_dir)
+
+            result = run_script(
+                "--bin-dir",
+                str(install_dir),
+                "--version",
+                "v1.7.26",
+                env=fake_install_env(fake_bin_dir, {"CURL_FAIL_FOR_CHECKSUMS": "1"}),
+            )
+
+            self.assertNotEqual(result.returncode, 0, msg=result.stdout)
+            self.assertIn("simulated curl failure for checksums", result.stderr)
+            self.assertFalse((install_dir / "pixelterm").exists())
 
 
 class InstallReadmeTest(unittest.TestCase):

--- a/scripts/test_install_script.py
+++ b/scripts/test_install_script.py
@@ -130,14 +130,20 @@ class InstallScriptCLITest(unittest.TestCase):
                 "#!/usr/bin/env bash\n"
                 "set -eu\n"
                 "out=''\n"
+                "url=''\n"
                 'while [ "$#" -gt 0 ]; do\n'
                 '  case "$1" in\n'
                 '    -o) out="$2"; shift 2 ;;\n'
-                "    *) shift ;;\n"
+                '    -*) shift ;;\n'
+                '    *) url="$1"; shift ;;\n'
                 "  esac\n"
                 "done\n"
-                "printf '#!/usr/bin/env bash\\nexit 0\\n' > \"$out\"\n"
-                'chmod 0755 "$out"\n',
+                "if printf '%s' \"$url\" | grep -q 'SHA256SUMS$'; then\n"
+                "  printf '%s  %s\\n' \"$(printf '#!/usr/bin/env bash\\nexit 0\\n' | sha256sum | awk '{print $1}')\" pixelterm-amd64-linux > \"$out\"\n"
+                "else\n"
+                "  printf '#!/usr/bin/env bash\\nexit 0\\n' > \"$out\"\n"
+                "  chmod 0755 \"$out\"\n"
+                "fi\n",
                 encoding="utf-8",
             )
             fake_curl.chmod(0o755)

--- a/scripts/test_install_script.py
+++ b/scripts/test_install_script.py
@@ -118,6 +118,25 @@ class InstallScriptCLITest(unittest.TestCase):
         )
         self.assertIn("/usr/local/bin/pixelterm", result.stdout)
 
+    def test_dry_run_supports_pinned_release_version(self) -> None:
+        result = run_script(
+            "--dry-run",
+            "--version",
+            "v1.7.26",
+            env={
+                "PIXELTERM_INSTALL_UNAME_S": "Linux",
+                "PIXELTERM_INSTALL_UNAME_M": "x86_64",
+            },
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Release version: v1.7.26", result.stdout)
+        self.assertIn(
+            "https://github.com/zouyonghe/PixelTerm-C/releases/download/"
+            "v1.7.26/pixelterm-amd64-linux",
+            result.stdout,
+        )
+
     def test_install_completes_without_unbound_tmp_dir_error(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
@@ -151,6 +170,8 @@ class InstallScriptCLITest(unittest.TestCase):
             result = run_script(
                 "--bin-dir",
                 str(install_dir),
+                "--version",
+                "v1.7.26",
                 env={
                     "PATH": f"{fake_bin_dir}:{os.environ['PATH']}",
                     "PIXELTERM_INSTALL_UNAME_S": "Linux",

--- a/scripts/test_install_script.py
+++ b/scripts/test_install_script.py
@@ -138,6 +138,26 @@ class InstallScriptCLITest(unittest.TestCase):
             result.stdout,
         )
 
+    def test_dry_run_treats_latest_version_as_latest_selector(self) -> None:
+        result = run_script(
+            "--dry-run",
+            "--version",
+            "latest",
+            env={
+                "PIXELTERM_INSTALL_UNAME_S": "Linux",
+                "PIXELTERM_INSTALL_UNAME_M": "x86_64",
+            },
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Release version: latest", result.stdout)
+        self.assertIn(
+            "https://github.com/zouyonghe/PixelTerm-C/releases/latest/download/"
+            "pixelterm-amd64-linux",
+            result.stdout,
+        )
+        self.assertNotIn("/releases/download/latest/", result.stdout)
+
     def test_install_completes_without_unbound_tmp_dir_error(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)

--- a/src/app_file_manager_render.c
+++ b/src/app_file_manager_render.c
@@ -43,16 +43,20 @@ static DirectoryMediaSummary directory_media_summary_scan(const gchar *dir_path)
     return summary;
 }
 
-static const DirectoryMediaSummary *directory_media_summary_get(GHashTable *cache, const gchar *dir_path) {
+static const DirectoryMediaSummary *directory_media_summary_get(GHashTable **cache, const gchar *dir_path) {
     if (!cache || !dir_path) {
         return NULL;
     }
 
-    DirectoryMediaSummary *summary = g_hash_table_lookup(cache, dir_path);
+    if (!*cache) {
+        *cache = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+    }
+
+    DirectoryMediaSummary *summary = g_hash_table_lookup(*cache, dir_path);
     if (!summary) {
         summary = g_new0(DirectoryMediaSummary, 1);
         *summary = directory_media_summary_scan(dir_path);
-        g_hash_table_insert(cache, g_strdup(dir_path), summary);
+        g_hash_table_insert(*cache, g_strdup(dir_path), summary);
     }
     return summary;
 }
@@ -414,8 +418,7 @@ ErrorCode app_render_file_manager(PixelTermApp *app) {
     }
 
     FileManagerViewport viewport = app_file_manager_compute_viewport(app);
-    GHashTable *directory_media_cache = g_hash_table_new_full(g_str_hash, g_str_equal,
-                                                             g_free, g_free);
+    GHashTable *directory_media_cache = NULL;
     app->file_manager.scroll_offset = viewport.start_row;
     gint total_entries = viewport.total_entries;
     const char *help_text = "↑/↓ Move   ← Parent   →/Enter Open   TAB Toggle   ? Help   ESC Exit";
@@ -482,7 +485,7 @@ ErrorCode app_render_file_manager(PixelTermApp *app) {
         gboolean is_video = (!is_dir && is_video_file(entry));
         gboolean is_book = (!is_dir && is_book_file(entry));
         const DirectoryMediaSummary *dir_summary = is_dir
-            ? directory_media_summary_get(directory_media_cache, entry)
+            ? directory_media_summary_get(&directory_media_cache, entry)
             : NULL;
         gboolean is_dir_with_images = dir_summary ? dir_summary->has_images : FALSE;
         gboolean is_dir_with_media = dir_summary ? dir_summary->has_media : FALSE;
@@ -579,6 +582,8 @@ ErrorCode app_render_file_manager(PixelTermApp *app) {
     if (free_dir) {
         g_free((gchar*)current_dir);
     }
-    g_hash_table_destroy(directory_media_cache);
+    if (directory_media_cache) {
+        g_hash_table_destroy(directory_media_cache);
+    }
     return ERROR_NONE;
 }

--- a/src/app_file_manager_render.c
+++ b/src/app_file_manager_render.c
@@ -2,79 +2,59 @@
 #include "text_utils.h"
 #include "app_file_manager_internal.h"
 
-static gboolean directory_contains_media(const gchar *dir_path) {
+typedef struct {
+    gboolean has_images;
+    gboolean has_media;
+    gboolean has_books;
+} DirectoryMediaSummary;
+
+static DirectoryMediaSummary directory_media_summary_scan(const gchar *dir_path) {
+    DirectoryMediaSummary summary = {0};
     if (!dir_path || !g_file_test(dir_path, G_FILE_TEST_IS_DIR)) {
-        return FALSE;
+        return summary;
     }
 
     GDir *dir = g_dir_open(dir_path, 0, NULL);
     if (!dir) {
-        return FALSE;
+        return summary;
     }
 
     const gchar *filename;
     while ((filename = g_dir_read_name(dir))) {
         gchar *full_path = g_build_filename(dir_path, filename, NULL);
-        if (g_file_test(full_path, G_FILE_TEST_IS_REGULAR) && is_media_file(full_path)) {
-            g_free(full_path);
-            g_dir_close(dir);
-            return TRUE;
+        if (g_file_test(full_path, G_FILE_TEST_IS_REGULAR)) {
+            if (is_image_file(full_path)) {
+                summary.has_images = TRUE;
+                summary.has_media = TRUE;
+            } else if (is_video_file(full_path)) {
+                summary.has_media = TRUE;
+            } else if (is_book_file(full_path)) {
+                summary.has_books = TRUE;
+            }
         }
         g_free(full_path);
+
+        if (summary.has_images && summary.has_media && summary.has_books) {
+            break;
+        }
     }
 
     g_dir_close(dir);
-    return FALSE;
+    return summary;
 }
 
-static gboolean directory_contains_images(const gchar *dir_path) {
-    if (!dir_path || !g_file_test(dir_path, G_FILE_TEST_IS_DIR)) {
-        return FALSE;
+static const DirectoryMediaSummary *directory_media_summary_get(GHashTable *cache, const gchar *dir_path) {
+    if (!cache || !dir_path) {
+        return NULL;
     }
 
-    GDir *dir = g_dir_open(dir_path, 0, NULL);
-    if (!dir) {
-        return FALSE;
+    DirectoryMediaSummary *summary = g_hash_table_lookup(cache, dir_path);
+    if (!summary) {
+        summary = g_new0(DirectoryMediaSummary, 1);
+        *summary = directory_media_summary_scan(dir_path);
+        g_hash_table_insert(cache, g_strdup(dir_path), summary);
     }
-
-    const gchar *filename;
-    while ((filename = g_dir_read_name(dir))) {
-        gchar *full_path = g_build_filename(dir_path, filename, NULL);
-        if (g_file_test(full_path, G_FILE_TEST_IS_REGULAR) && is_image_file(full_path)) {
-            g_free(full_path);
-            g_dir_close(dir);
-            return TRUE;
-        }
-        g_free(full_path);
-    }
-
-    g_dir_close(dir);
-    return FALSE;
-}
-
-static gboolean directory_contains_books(const gchar *dir_path) {
-    if (!dir_path || !g_file_test(dir_path, G_FILE_TEST_IS_DIR)) {
-        return FALSE;
-    }
-
-    GDir *dir = g_dir_open(dir_path, 0, NULL);
-    if (!dir) {
-        return FALSE;
-    }
-
-    const gchar *filename;
-    while ((filename = g_dir_read_name(dir))) {
-        gchar *full_path = g_build_filename(dir_path, filename, NULL);
-        if (g_file_test(full_path, G_FILE_TEST_IS_REGULAR) && is_book_file(full_path)) {
-            g_free(full_path);
-            g_dir_close(dir);
-            return TRUE;
-        }
-        g_free(full_path);
-    }
-
-    g_dir_close(dir);
-    return FALSE;
+    return summary;
 }
 
 static gchar *app_file_manager_format_size(gint64 size) {
@@ -433,6 +413,8 @@ ErrorCode app_render_file_manager(PixelTermApp *app) {
     }
 
     FileManagerViewport viewport = app_file_manager_compute_viewport(app);
+    GHashTable *directory_media_cache = g_hash_table_new_full(g_str_hash, g_str_equal,
+                                                             g_free, g_free);
     app->file_manager.scroll_offset = viewport.start_row;
     gint total_entries = viewport.total_entries;
     const char *help_text = "↑/↓ Move   ← Parent   →/Enter Open   TAB Toggle   ? Help   ESC Exit";
@@ -498,9 +480,12 @@ ErrorCode app_render_file_manager(PixelTermApp *app) {
         gboolean is_image = (!is_dir && is_image_file(entry));
         gboolean is_video = (!is_dir && is_video_file(entry));
         gboolean is_book = (!is_dir && is_book_file(entry));
-        gboolean is_dir_with_images = is_dir && directory_contains_images(entry);
-        gboolean is_dir_with_media = is_dir && directory_contains_media(entry);
-        gboolean is_dir_with_books = is_dir && directory_contains_books(entry);
+        const DirectoryMediaSummary *dir_summary = is_dir
+            ? directory_media_summary_get(directory_media_cache, entry)
+            : NULL;
+        gboolean is_dir_with_images = dir_summary ? dir_summary->has_images : FALSE;
+        gboolean is_dir_with_media = dir_summary ? dir_summary->has_media : FALSE;
+        gboolean is_dir_with_books = dir_summary ? dir_summary->has_books : FALSE;
 
         gboolean is_valid_media = (!is_dir && is_valid_media_file(entry));
         gboolean is_valid_book = (!is_dir && is_valid_book_file(entry));
@@ -593,5 +578,6 @@ ErrorCode app_render_file_manager(PixelTermApp *app) {
     if (free_dir) {
         g_free((gchar*)current_dir);
     }
+    g_hash_table_destroy(directory_media_cache);
     return ERROR_NONE;
 }

--- a/src/text_utils.c
+++ b/src/text_utils.c
@@ -8,11 +8,22 @@ gchar* sanitize_for_terminal(const gchar *text) {
     }
 
     gchar *safe = g_strdup(text);
-    for (gchar *p = safe; *p; ++p) {
-        unsigned char c = (unsigned char)*p;
-        if (c < 0x20 || c == 0x7f || c == '\033') {
+    for (gchar *p = safe; *p;) {
+        gunichar ch = g_utf8_get_char_validated(p, -1);
+        if (ch == (gunichar)-1 || ch == (gunichar)-2) {
             *p = '?';
+            p++;
+            continue;
         }
+
+        if ((ch < 0x20) || (ch >= 0x80 && ch <= 0x9f) || ch == 0x7f || ch == 0x1b) {
+            gint char_len = (gint)(g_utf8_next_char(p) - p);
+            memset(p, '?', (gsize)char_len);
+            p += char_len;
+            continue;
+        }
+
+        p = g_utf8_next_char(p);
     }
     return safe;
 }

--- a/tests/test_app_cli.c
+++ b/tests/test_app_cli.c
@@ -758,7 +758,7 @@ static void test_cli_default_config_applies_terminal_specific_precedence(AppCliF
     (void)fixture;
     (void)user_data;
 
-    write_default_config_file(
+    gchar *default_config_path = write_default_config_file(
         "[default]\n"
         "preload=false\n"
         "alt_screen=true\n"
@@ -796,6 +796,7 @@ static void test_cli_default_config_applies_terminal_specific_precedence(AppCliF
     g_assert_true(config.gamma_set);
     g_assert_cmpfloat_with_epsilon(config.gamma, 1.25, 0.0001);
     g_free(path);
+    g_free(default_config_path);
 }
 
 static void test_cli_default_config_respects_runtime_xdg_after_glib_cache_prime(void) {
@@ -804,7 +805,7 @@ static void test_cli_default_config_respects_runtime_xdg_after_glib_cache_prime(
     (void)g_get_user_config_dir();
 
     gchar *config_root = make_temp_config_root();
-    write_default_config_file_at_root(
+    gchar *default_config_path = write_default_config_file_at_root(
         config_root,
         "[default]\n"
         "preload=false\n"
@@ -845,6 +846,7 @@ static void test_cli_default_config_respects_runtime_xdg_after_glib_cache_prime(
     g_assert_cmpfloat_with_epsilon(config.gamma, 1.25, 0.0001);
 
     g_free(path);
+    g_free(default_config_path);
     g_free(config_root);
     pixelterm_env_reset_for_test();
 }
@@ -907,6 +909,7 @@ static void test_cli_flags_override_loaded_config_values(AppCliFixture *fixture,
     g_assert_true(config.gamma_set);
     g_assert_cmpfloat_with_epsilon(config.gamma, 2.5, 0.0001);
     g_free(path);
+    g_free(config_path);
 }
 
 static void test_cli_color_enhance_argument_parses_supported_modes(AppCliFixture *fixture,

--- a/tests/test_app_file_manager.c
+++ b/tests/test_app_file_manager.c
@@ -517,6 +517,31 @@ static void test_render_selected_row_uses_full_width_highlight_with_size(void) {
     g_free(dir);
 }
 
+static void test_render_marks_directory_containing_media(void) {
+    gchar *dir = create_temp_dir();
+    gchar *child_dir = create_dir_in_dir(dir, "child");
+    gchar *child_png = write_file_in_dir(child_dir, "inside.png", k_png_data, sizeof(k_png_data));
+    gchar *a_png = write_file_in_dir(dir, "a.png", k_png_data, sizeof(k_png_data));
+    PixelTermApp app = {0};
+
+    init_file_manager_app(&app, dir, 24);
+    app.term_width = 80;
+
+    g_assert_cmpint(app_file_manager_refresh(&app), ==, ERROR_NONE);
+    g_assert_cmpint(app_file_manager_select_path(&app, a_png), ==, ERROR_NONE);
+
+    gchar *output = capture_render_output(render_file_manager_capture, &app);
+
+    g_assert_nonnull(g_strstr_len(output, -1, "\033[33m[DIR]  child/"));
+
+    g_free(output);
+    cleanup_file_manager_app(&app);
+    g_free(child_dir);
+    g_free(child_png);
+    g_free(a_png);
+    g_free(dir);
+}
+
 int main(int argc, char **argv) {
     g_test_init(&argc, &argv, NULL);
 
@@ -542,6 +567,8 @@ int main(int argc, char **argv) {
                     test_enter_parent_entry_selects_directory_just_left);
     g_test_add_func("/app_file_manager/render/selected_row_uses_full_width_highlight_with_size",
                     test_render_selected_row_uses_full_width_highlight_with_size);
+    g_test_add_func("/app_file_manager/render/marks_directory_containing_media",
+                    test_render_marks_directory_containing_media);
 
     return g_test_run();
 }

--- a/tests/test_app_startup.c
+++ b/tests/test_app_startup.c
@@ -141,6 +141,7 @@ static void test_classify_path_book_returns_book_target(void) {
     g_assert_cmpstr(decision.path, ==, book_path);
 
     g_free(decision.path);
+    g_free(book_path);
 }
 
 static void test_classify_path_media_returns_media_target(void) {
@@ -158,6 +159,7 @@ static void test_classify_path_media_returns_media_target(void) {
     g_assert_cmpstr(decision.path, ==, media_path);
 
     g_free(decision.path);
+    g_free(media_path);
 }
 
 static void test_classify_path_non_media_file_falls_back_to_parent_directory(void) {
@@ -173,6 +175,7 @@ static void test_classify_path_non_media_file_falls_back_to_parent_directory(voi
     g_assert_cmpstr(decision.path, ==, temp_dir);
 
     g_free(decision.path);
+    g_free(text_path);
 }
 
 static void test_classify_relative_non_media_file_returns_canonical_parent_directory(void) {
@@ -207,6 +210,7 @@ static void test_classify_relative_non_media_file_returns_canonical_parent_direc
     g_free(nested_dir);
     g_free(original_dir);
     g_free(decision.path);
+    g_free(text_path);
 }
 
 void register_app_startup_tests(void) {

--- a/tests/test_app_startup.c
+++ b/tests/test_app_startup.c
@@ -99,6 +99,7 @@ static void test_classify_path_without_argument_uses_current_directory(void) {
     g_free(expected_dir);
     g_free(original_dir);
     g_free(decision.path);
+    g_free(temp_dir);
 }
 
 static void test_classify_path_rejects_missing_path(void) {
@@ -126,6 +127,7 @@ static void test_classify_path_directory_returns_directory_target(void) {
     g_assert_cmpstr(decision.path, ==, temp_dir);
 
     g_free(decision.path);
+    g_free(temp_dir);
 }
 
 static void test_classify_path_book_returns_book_target(void) {
@@ -142,6 +144,7 @@ static void test_classify_path_book_returns_book_target(void) {
 
     g_free(decision.path);
     g_free(book_path);
+    g_free(temp_dir);
 }
 
 static void test_classify_path_media_returns_media_target(void) {
@@ -160,6 +163,7 @@ static void test_classify_path_media_returns_media_target(void) {
 
     g_free(decision.path);
     g_free(media_path);
+    g_free(temp_dir);
 }
 
 static void test_classify_path_non_media_file_falls_back_to_parent_directory(void) {
@@ -176,6 +180,7 @@ static void test_classify_path_non_media_file_falls_back_to_parent_directory(voi
 
     g_free(decision.path);
     g_free(text_path);
+    g_free(temp_dir);
 }
 
 static void test_classify_relative_non_media_file_returns_canonical_parent_directory(void) {
@@ -211,6 +216,7 @@ static void test_classify_relative_non_media_file_returns_canonical_parent_direc
     g_free(original_dir);
     g_free(decision.path);
     g_free(text_path);
+    g_free(temp_dir);
 }
 
 void register_app_startup_tests(void) {

--- a/tests/test_book.c
+++ b/tests/test_book.c
@@ -215,6 +215,7 @@ static void test_book_open_rejects_directory_path(void) {
 
     g_assert_null(doc);
     g_assert_cmpint(error, ==, ERROR_FILE_NOT_FOUND);
+    g_free(dir_path);
 }
 
 static void test_book_open_rejects_invalid_book_bytes(void) {

--- a/tests/test_browser.c
+++ b/tests/test_browser.c
@@ -57,8 +57,8 @@ static void test_browser_scan_directory_filters_and_sorts(void) {
     gchar *a_jpg = write_file_in_dir(dir, "a.jpg", k_jpeg, sizeof(k_jpeg));
     gchar *b_png = write_file_in_dir(dir, "b.png", k_png, sizeof(k_png));
     gchar *noext = write_file_in_dir(dir, "noext", k_png, sizeof(k_png));
-    write_file_in_dir(dir, "c.png", k_invalid, sizeof(k_invalid));
-    write_file_in_dir(dir, "note.txt", (const guint8 *)"text", 4);
+    gchar *c_png = write_file_in_dir(dir, "c.png", k_invalid, sizeof(k_invalid));
+    gchar *note_txt = write_file_in_dir(dir, "note.txt", (const guint8 *)"text", 4);
 
     FileBrowser *browser = browser_create();
     g_assert_nonnull(browser);
@@ -88,6 +88,8 @@ static void test_browser_scan_directory_filters_and_sorts(void) {
     g_free(a_jpg);
     g_free(b_png);
     g_free(noext);
+    g_free(c_png);
+    g_free(note_txt);
 }
 
 static void test_browser_navigation_and_delete(void) {
@@ -133,8 +135,8 @@ static void test_browser_reset(void) {
     static const guint8 k_png[] = {0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
 
     gchar *dir = create_temp_dir();
-    write_file_in_dir(dir, "a.png", k_png, sizeof(k_png));
-    write_file_in_dir(dir, "b.png", k_png, sizeof(k_png));
+    gchar *a_png = write_file_in_dir(dir, "a.png", k_png, sizeof(k_png));
+    gchar *b_png = write_file_in_dir(dir, "b.png", k_png, sizeof(k_png));
 
     FileBrowser *browser = browser_create();
     g_assert_nonnull(browser);
@@ -147,6 +149,8 @@ static void test_browser_reset(void) {
     g_assert_cmpint(browser_get_current_index(browser), ==, 0);
 
     browser_destroy(browser);
+    g_free(a_png);
+    g_free(b_png);
 }
 
 void register_browser_tests(void) {

--- a/tests/test_renderer.c
+++ b/tests/test_renderer.c
@@ -194,6 +194,7 @@ static void test_renderer_cache_roundtrip(void) {
     renderer_cache_clear(renderer);
     g_assert_null(renderer_cache_get(renderer, "path"));
 
+    g_string_free(rendered, TRUE);
     renderer_destroy(renderer);
 }
 

--- a/tests/test_text_utils.c
+++ b/tests/test_text_utils.c
@@ -26,6 +26,22 @@ static void test_sanitize_for_terminal_empty(void) {
     g_free(result);
 }
 
+static void test_sanitize_for_terminal_replaces_c1_controls(void) {
+    const gchar *input = "名\x9btitle\x9d终";
+    gchar *result = sanitize_for_terminal(input);
+    g_assert_nonnull(result);
+    g_assert_cmpstr(result, ==, "名?title?终");
+    g_free(result);
+}
+
+static void test_sanitize_for_terminal_replaces_escape_and_preserves_utf8(void) {
+    const gchar *input = "文\033字";
+    gchar *result = sanitize_for_terminal(input);
+    g_assert_nonnull(result);
+    g_assert_cmpstr(result, ==, "文?字");
+    g_free(result);
+}
+
 // Test utf8_display_width
 static void test_utf8_display_width_ascii(void) {
     gint width = utf8_display_width("Hello");
@@ -142,6 +158,8 @@ void register_text_utils_tests(void) {
     g_test_add_func("/text_utils/sanitize/null", test_sanitize_for_terminal_null);
     g_test_add_func("/text_utils/sanitize/simple", test_sanitize_for_terminal_simple);
     g_test_add_func("/text_utils/sanitize/empty", test_sanitize_for_terminal_empty);
+    g_test_add_func("/text_utils/sanitize/c1_controls", test_sanitize_for_terminal_replaces_c1_controls);
+    g_test_add_func("/text_utils/sanitize/escape_and_utf8", test_sanitize_for_terminal_replaces_escape_and_preserves_utf8);
 
     // utf8_display_width tests
     g_test_add_func("/text_utils/display_width/ascii", test_utf8_display_width_ascii);


### PR DESCRIPTION
## Summary
- harden terminal sanitization for C1 controls and invalid UTF-8
- verify release downloads with SHA256SUMS and support pinned installer versions
- run release/ASan tests in CI and isolate debug build artifacts
- cache file manager directory media summaries during render

## Verification
- python3 scripts/test_install_script.py
- bash -n scripts/install.sh
- bin/pixelterm-file-manager-tests
- rtk make clean && rtk make EXTRA_CFLAGS=-Werror test >/dev/null && rtk make EXTRA_CFLAGS=-Werror debug-test >/dev/null

## Summary by Sourcery

添加支持固定版本且经校验和验证的安装程序、提升文件管理器媒体渲染效率，并强化调试/测试工作流。

New Features:
- 允许安装脚本通过 `--version` 选项将安装固定到特定的 GitHub 发布标签。

Bug Fixes:
- 确保测试创建的临时文件、目录和配置路径被正确释放，避免泄漏和内存/地址检测器（sanitizer）警告。

Enhancements:
- 在文件管理器中缓存按目录的媒体摘要，避免在渲染媒体指示器时重复扫描目录。
- 扩展终端清理（sanitization）测试，涵盖转义序列处理，同时保持有效 UTF-8 输出。

Build:
- 引入 `DEBUG` 标志和单独的调试对象/二进制目录，并新增 `debug-test` 目标以使用 AddressSanitizer 运行测试。
- 通过先写入临时文件，再以原子方式更新被跟踪文件，使构建标志快照生成更健壮。

CI:
- 更新静态分析工作流，改为运行带 AddressSanitizer 的 `debug-test` 测试目标，而不是仅验证调试构建是否通过。
- 在发布构建工作流中，在创建与发布发布产物之前运行测试。

Deployment:
- 在发布二进制文件的同时生成并发布 `SHA256SUMS`，以支持客户端进行校验和验证。

Documentation:
- 在英文、日文和中文的 README 中记录如何使用安装程序的 `--version` 选项进行可复现、基于标签固定的安装。

Tests:
- 扩展安装程序测试，涵盖固定版本、校验和验证以及失败场景。
- 增加文件管理器测试，用于验证媒体目录渲染标记。
- 加强 CLI、启动流程、浏览器、书本、渲染器以及文本清理器测试，以覆盖配置优先级、资源清理，以及确保 UTF-8 安全的清理路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add pinned, checksum-verified installer support, improve file manager media rendering efficiency, and strengthen debug/testing workflows.

New Features:
- Allow the install script to pin installations to a specific GitHub release tag via a --version option.

Bug Fixes:
- Ensure test-created temporary files, directories, and config paths are freed to avoid leaks and sanitizer warnings.

Enhancements:
- Cache per-directory media summaries in the file manager to avoid repeated directory scans when rendering media indicators.
- Extend terminal sanitization tests to cover escape handling while preserving valid UTF-8 output.

Build:
- Introduce a DEBUG flag and separate debug object/binary directories, along with a debug-test target that runs tests with AddressSanitizer.
- Make build flag snapshot generation more robust by writing to a temporary file before atomically updating the tracked file.

CI:
- Update static analysis workflows to run the debug-test AddressSanitizer test target instead of only validating a debug build.
- Run tests as part of the release build workflows before creating and publishing release artifacts.

Deployment:
- Generate and publish SHA256SUMS alongside release binaries to support client-side checksum verification.

Documentation:
- Document reproducible, tag-pinned installs with the installer --version option in the English, Japanese, and Chinese READMEs.

Tests:
- Expand installer tests to cover pinned versions, checksum verification, and failure scenarios.
- Add file manager tests that verify media-directory rendering markers.
- Strengthen CLI, startup, browser, book, renderer, and text sanitizer tests to cover config precedence, resource cleanup, and UTF-8-safe sanitization paths.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加支持固定版本且经校验和验证的安装程序、提升文件管理器媒体渲染效率，并强化调试/测试工作流。

New Features:
- 允许安装脚本通过 `--version` 选项将安装固定到特定的 GitHub 发布标签。

Bug Fixes:
- 确保测试创建的临时文件、目录和配置路径被正确释放，避免泄漏和内存/地址检测器（sanitizer）警告。

Enhancements:
- 在文件管理器中缓存按目录的媒体摘要，避免在渲染媒体指示器时重复扫描目录。
- 扩展终端清理（sanitization）测试，涵盖转义序列处理，同时保持有效 UTF-8 输出。

Build:
- 引入 `DEBUG` 标志和单独的调试对象/二进制目录，并新增 `debug-test` 目标以使用 AddressSanitizer 运行测试。
- 通过先写入临时文件，再以原子方式更新被跟踪文件，使构建标志快照生成更健壮。

CI:
- 更新静态分析工作流，改为运行带 AddressSanitizer 的 `debug-test` 测试目标，而不是仅验证调试构建是否通过。
- 在发布构建工作流中，在创建与发布发布产物之前运行测试。

Deployment:
- 在发布二进制文件的同时生成并发布 `SHA256SUMS`，以支持客户端进行校验和验证。

Documentation:
- 在英文、日文和中文的 README 中记录如何使用安装程序的 `--version` 选项进行可复现、基于标签固定的安装。

Tests:
- 扩展安装程序测试，涵盖固定版本、校验和验证以及失败场景。
- 增加文件管理器测试，用于验证媒体目录渲染标记。
- 加强 CLI、启动流程、浏览器、书本、渲染器以及文本清理器测试，以覆盖配置优先级、资源清理，以及确保 UTF-8 安全的清理路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add pinned, checksum-verified installer support, improve file manager media rendering efficiency, and strengthen debug/testing workflows.

New Features:
- Allow the install script to pin installations to a specific GitHub release tag via a --version option.

Bug Fixes:
- Ensure test-created temporary files, directories, and config paths are freed to avoid leaks and sanitizer warnings.

Enhancements:
- Cache per-directory media summaries in the file manager to avoid repeated directory scans when rendering media indicators.
- Extend terminal sanitization tests to cover escape handling while preserving valid UTF-8 output.

Build:
- Introduce a DEBUG flag and separate debug object/binary directories, along with a debug-test target that runs tests with AddressSanitizer.
- Make build flag snapshot generation more robust by writing to a temporary file before atomically updating the tracked file.

CI:
- Update static analysis workflows to run the debug-test AddressSanitizer test target instead of only validating a debug build.
- Run tests as part of the release build workflows before creating and publishing release artifacts.

Deployment:
- Generate and publish SHA256SUMS alongside release binaries to support client-side checksum verification.

Documentation:
- Document reproducible, tag-pinned installs with the installer --version option in the English, Japanese, and Chinese READMEs.

Tests:
- Expand installer tests to cover pinned versions, checksum verification, and failure scenarios.
- Add file manager tests that verify media-directory rendering markers.
- Strengthen CLI, startup, browser, book, renderer, and text sanitizer tests to cover config precedence, resource cleanup, and UTF-8-safe sanitization paths.

</details>

</details>

新功能：
- 在安装脚本中通过新增的 `--version` 参数支持安装指定的 GitHub Release 版本。

缺陷修复：
- 确保测试中创建的临时文件和路径被正确释放，避免泄漏和 ASan 警告。

增强改进：
- 在文件管理器中为每个目录缓存媒体摘要，避免在渲染时重复扫描目录。
- 优化终端输出的清理行为，在处理转义字符的同时保留有效的 UTF-8 文本。
- 将调试构建产物隔离到单独的目标文件和二进制目录中，并使构建标志的追踪在增量构建中更加安全。

构建：
- 添加 `DEBUG` 标志以及单独的调试目标文件/二进制目录，并新增使用 AddressSanitizer 运行测试的 `debug-test` 目标。
- 通过先写入临时文件再进行原子替换，使构建标志快照文件的创建更加健壮。

CI：
- 在静态分析工作流中运行调试构建的 AddressSanitizer 测试，而不再仅仅验证调试构建是否通过编译。
- 在发布构建工作流中执行测试，并将生成的 `SHA256SUMS` 附加到 Release 中。

部署：
- 在发布二进制文件的同时发布 `SHA256SUMS` 工件，以便客户端进行校验和验证。

文档：
- 在英文、日文和中文的 README 中记录使用安装程序 `--version` 参数进行可重现、基于标签固定版本的安装方式。

测试：
- 扩展安装程序测试，覆盖固定版本和校验和验证路径。
- 为文件管理器媒体目录渲染、改进后的终端清理行为添加测试，并在浏览器、启动流程、CLI、书籍和渲染器测试中增加更多内存安全相关的清理测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加支持固定版本且经校验和验证的安装程序、提升文件管理器媒体渲染效率，并强化调试/测试工作流。

New Features:
- 允许安装脚本通过 `--version` 选项将安装固定到特定的 GitHub 发布标签。

Bug Fixes:
- 确保测试创建的临时文件、目录和配置路径被正确释放，避免泄漏和内存/地址检测器（sanitizer）警告。

Enhancements:
- 在文件管理器中缓存按目录的媒体摘要，避免在渲染媒体指示器时重复扫描目录。
- 扩展终端清理（sanitization）测试，涵盖转义序列处理，同时保持有效 UTF-8 输出。

Build:
- 引入 `DEBUG` 标志和单独的调试对象/二进制目录，并新增 `debug-test` 目标以使用 AddressSanitizer 运行测试。
- 通过先写入临时文件，再以原子方式更新被跟踪文件，使构建标志快照生成更健壮。

CI:
- 更新静态分析工作流，改为运行带 AddressSanitizer 的 `debug-test` 测试目标，而不是仅验证调试构建是否通过。
- 在发布构建工作流中，在创建与发布发布产物之前运行测试。

Deployment:
- 在发布二进制文件的同时生成并发布 `SHA256SUMS`，以支持客户端进行校验和验证。

Documentation:
- 在英文、日文和中文的 README 中记录如何使用安装程序的 `--version` 选项进行可复现、基于标签固定的安装。

Tests:
- 扩展安装程序测试，涵盖固定版本、校验和验证以及失败场景。
- 增加文件管理器测试，用于验证媒体目录渲染标记。
- 加强 CLI、启动流程、浏览器、书本、渲染器以及文本清理器测试，以覆盖配置优先级、资源清理，以及确保 UTF-8 安全的清理路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add pinned, checksum-verified installer support, improve file manager media rendering efficiency, and strengthen debug/testing workflows.

New Features:
- Allow the install script to pin installations to a specific GitHub release tag via a --version option.

Bug Fixes:
- Ensure test-created temporary files, directories, and config paths are freed to avoid leaks and sanitizer warnings.

Enhancements:
- Cache per-directory media summaries in the file manager to avoid repeated directory scans when rendering media indicators.
- Extend terminal sanitization tests to cover escape handling while preserving valid UTF-8 output.

Build:
- Introduce a DEBUG flag and separate debug object/binary directories, along with a debug-test target that runs tests with AddressSanitizer.
- Make build flag snapshot generation more robust by writing to a temporary file before atomically updating the tracked file.

CI:
- Update static analysis workflows to run the debug-test AddressSanitizer test target instead of only validating a debug build.
- Run tests as part of the release build workflows before creating and publishing release artifacts.

Deployment:
- Generate and publish SHA256SUMS alongside release binaries to support client-side checksum verification.

Documentation:
- Document reproducible, tag-pinned installs with the installer --version option in the English, Japanese, and Chinese READMEs.

Tests:
- Expand installer tests to cover pinned versions, checksum verification, and failure scenarios.
- Add file manager tests that verify media-directory rendering markers.
- Strengthen CLI, startup, browser, book, renderer, and text sanitizer tests to cover config precedence, resource cleanup, and UTF-8-safe sanitization paths.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加支持固定版本且经校验和验证的安装程序、提升文件管理器媒体渲染效率，并强化调试/测试工作流。

New Features:
- 允许安装脚本通过 `--version` 选项将安装固定到特定的 GitHub 发布标签。

Bug Fixes:
- 确保测试创建的临时文件、目录和配置路径被正确释放，避免泄漏和内存/地址检测器（sanitizer）警告。

Enhancements:
- 在文件管理器中缓存按目录的媒体摘要，避免在渲染媒体指示器时重复扫描目录。
- 扩展终端清理（sanitization）测试，涵盖转义序列处理，同时保持有效 UTF-8 输出。

Build:
- 引入 `DEBUG` 标志和单独的调试对象/二进制目录，并新增 `debug-test` 目标以使用 AddressSanitizer 运行测试。
- 通过先写入临时文件，再以原子方式更新被跟踪文件，使构建标志快照生成更健壮。

CI:
- 更新静态分析工作流，改为运行带 AddressSanitizer 的 `debug-test` 测试目标，而不是仅验证调试构建是否通过。
- 在发布构建工作流中，在创建与发布发布产物之前运行测试。

Deployment:
- 在发布二进制文件的同时生成并发布 `SHA256SUMS`，以支持客户端进行校验和验证。

Documentation:
- 在英文、日文和中文的 README 中记录如何使用安装程序的 `--version` 选项进行可复现、基于标签固定的安装。

Tests:
- 扩展安装程序测试，涵盖固定版本、校验和验证以及失败场景。
- 增加文件管理器测试，用于验证媒体目录渲染标记。
- 加强 CLI、启动流程、浏览器、书本、渲染器以及文本清理器测试，以覆盖配置优先级、资源清理，以及确保 UTF-8 安全的清理路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add pinned, checksum-verified installer support, improve file manager media rendering efficiency, and strengthen debug/testing workflows.

New Features:
- Allow the install script to pin installations to a specific GitHub release tag via a --version option.

Bug Fixes:
- Ensure test-created temporary files, directories, and config paths are freed to avoid leaks and sanitizer warnings.

Enhancements:
- Cache per-directory media summaries in the file manager to avoid repeated directory scans when rendering media indicators.
- Extend terminal sanitization tests to cover escape handling while preserving valid UTF-8 output.

Build:
- Introduce a DEBUG flag and separate debug object/binary directories, along with a debug-test target that runs tests with AddressSanitizer.
- Make build flag snapshot generation more robust by writing to a temporary file before atomically updating the tracked file.

CI:
- Update static analysis workflows to run the debug-test AddressSanitizer test target instead of only validating a debug build.
- Run tests as part of the release build workflows before creating and publishing release artifacts.

Deployment:
- Generate and publish SHA256SUMS alongside release binaries to support client-side checksum verification.

Documentation:
- Document reproducible, tag-pinned installs with the installer --version option in the English, Japanese, and Chinese READMEs.

Tests:
- Expand installer tests to cover pinned versions, checksum verification, and failure scenarios.
- Add file manager tests that verify media-directory rendering markers.
- Strengthen CLI, startup, browser, book, renderer, and text sanitizer tests to cover config precedence, resource cleanup, and UTF-8-safe sanitization paths.

</details>

</details>

</details>

新功能：
- 允许安装器通过 `--version` 参数固定到指定的 GitHub 发布版本。
- 在安装过程中，将下载的发布二进制文件与已发布的 SHA256 校验和进行验证。
- 在文件管理器中为每个目录缓存媒体摘要，以避免在渲染时重复扫描。

缺陷修复：
- 改进终端输入清理逻辑，在不破坏有效多字节字符的前提下，更安全地处理 C1 控制字符、转义序列以及无效的 UTF-8。

增强改进：
- 重构文件管理器目录媒体检测逻辑，使用一次汇总扫描结果复用到各个条目。
- 将调试构建隔离到单独的目标文件和二进制目录中，并调整 Makefile 的编译标志跟踪，以提高增量构建的安全性。

CI：
- 在静态分析工作流中运行带 AddressSanitizer 的调试测试目标，而不是仅仅验证调试构建是否成功。
- 在发布工作流的构建中执行测试，以在发布构件之前捕获回归问题。

文档：
- 在英文、日文和中文的 README 中记录可复现安装流程以及新的 `--version` 参数。

测试：
- 扩展安装器测试，以覆盖固定版本处理和校验和验证流程。
- 添加针对包含媒体的目录在文件管理器中的渲染测试，以及更严格的终端输入清理行为测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加支持固定版本且经校验和验证的安装程序、提升文件管理器媒体渲染效率，并强化调试/测试工作流。

New Features:
- 允许安装脚本通过 `--version` 选项将安装固定到特定的 GitHub 发布标签。

Bug Fixes:
- 确保测试创建的临时文件、目录和配置路径被正确释放，避免泄漏和内存/地址检测器（sanitizer）警告。

Enhancements:
- 在文件管理器中缓存按目录的媒体摘要，避免在渲染媒体指示器时重复扫描目录。
- 扩展终端清理（sanitization）测试，涵盖转义序列处理，同时保持有效 UTF-8 输出。

Build:
- 引入 `DEBUG` 标志和单独的调试对象/二进制目录，并新增 `debug-test` 目标以使用 AddressSanitizer 运行测试。
- 通过先写入临时文件，再以原子方式更新被跟踪文件，使构建标志快照生成更健壮。

CI:
- 更新静态分析工作流，改为运行带 AddressSanitizer 的 `debug-test` 测试目标，而不是仅验证调试构建是否通过。
- 在发布构建工作流中，在创建与发布发布产物之前运行测试。

Deployment:
- 在发布二进制文件的同时生成并发布 `SHA256SUMS`，以支持客户端进行校验和验证。

Documentation:
- 在英文、日文和中文的 README 中记录如何使用安装程序的 `--version` 选项进行可复现、基于标签固定的安装。

Tests:
- 扩展安装程序测试，涵盖固定版本、校验和验证以及失败场景。
- 增加文件管理器测试，用于验证媒体目录渲染标记。
- 加强 CLI、启动流程、浏览器、书本、渲染器以及文本清理器测试，以覆盖配置优先级、资源清理，以及确保 UTF-8 安全的清理路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add pinned, checksum-verified installer support, improve file manager media rendering efficiency, and strengthen debug/testing workflows.

New Features:
- Allow the install script to pin installations to a specific GitHub release tag via a --version option.

Bug Fixes:
- Ensure test-created temporary files, directories, and config paths are freed to avoid leaks and sanitizer warnings.

Enhancements:
- Cache per-directory media summaries in the file manager to avoid repeated directory scans when rendering media indicators.
- Extend terminal sanitization tests to cover escape handling while preserving valid UTF-8 output.

Build:
- Introduce a DEBUG flag and separate debug object/binary directories, along with a debug-test target that runs tests with AddressSanitizer.
- Make build flag snapshot generation more robust by writing to a temporary file before atomically updating the tracked file.

CI:
- Update static analysis workflows to run the debug-test AddressSanitizer test target instead of only validating a debug build.
- Run tests as part of the release build workflows before creating and publishing release artifacts.

Deployment:
- Generate and publish SHA256SUMS alongside release binaries to support client-side checksum verification.

Documentation:
- Document reproducible, tag-pinned installs with the installer --version option in the English, Japanese, and Chinese READMEs.

Tests:
- Expand installer tests to cover pinned versions, checksum verification, and failure scenarios.
- Add file manager tests that verify media-directory rendering markers.
- Strengthen CLI, startup, browser, book, renderer, and text sanitizer tests to cover config precedence, resource cleanup, and UTF-8-safe sanitization paths.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加支持固定版本且经校验和验证的安装程序、提升文件管理器媒体渲染效率，并强化调试/测试工作流。

New Features:
- 允许安装脚本通过 `--version` 选项将安装固定到特定的 GitHub 发布标签。

Bug Fixes:
- 确保测试创建的临时文件、目录和配置路径被正确释放，避免泄漏和内存/地址检测器（sanitizer）警告。

Enhancements:
- 在文件管理器中缓存按目录的媒体摘要，避免在渲染媒体指示器时重复扫描目录。
- 扩展终端清理（sanitization）测试，涵盖转义序列处理，同时保持有效 UTF-8 输出。

Build:
- 引入 `DEBUG` 标志和单独的调试对象/二进制目录，并新增 `debug-test` 目标以使用 AddressSanitizer 运行测试。
- 通过先写入临时文件，再以原子方式更新被跟踪文件，使构建标志快照生成更健壮。

CI:
- 更新静态分析工作流，改为运行带 AddressSanitizer 的 `debug-test` 测试目标，而不是仅验证调试构建是否通过。
- 在发布构建工作流中，在创建与发布发布产物之前运行测试。

Deployment:
- 在发布二进制文件的同时生成并发布 `SHA256SUMS`，以支持客户端进行校验和验证。

Documentation:
- 在英文、日文和中文的 README 中记录如何使用安装程序的 `--version` 选项进行可复现、基于标签固定的安装。

Tests:
- 扩展安装程序测试，涵盖固定版本、校验和验证以及失败场景。
- 增加文件管理器测试，用于验证媒体目录渲染标记。
- 加强 CLI、启动流程、浏览器、书本、渲染器以及文本清理器测试，以覆盖配置优先级、资源清理，以及确保 UTF-8 安全的清理路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add pinned, checksum-verified installer support, improve file manager media rendering efficiency, and strengthen debug/testing workflows.

New Features:
- Allow the install script to pin installations to a specific GitHub release tag via a --version option.

Bug Fixes:
- Ensure test-created temporary files, directories, and config paths are freed to avoid leaks and sanitizer warnings.

Enhancements:
- Cache per-directory media summaries in the file manager to avoid repeated directory scans when rendering media indicators.
- Extend terminal sanitization tests to cover escape handling while preserving valid UTF-8 output.

Build:
- Introduce a DEBUG flag and separate debug object/binary directories, along with a debug-test target that runs tests with AddressSanitizer.
- Make build flag snapshot generation more robust by writing to a temporary file before atomically updating the tracked file.

CI:
- Update static analysis workflows to run the debug-test AddressSanitizer test target instead of only validating a debug build.
- Run tests as part of the release build workflows before creating and publishing release artifacts.

Deployment:
- Generate and publish SHA256SUMS alongside release binaries to support client-side checksum verification.

Documentation:
- Document reproducible, tag-pinned installs with the installer --version option in the English, Japanese, and Chinese READMEs.

Tests:
- Expand installer tests to cover pinned versions, checksum verification, and failure scenarios.
- Add file manager tests that verify media-directory rendering markers.
- Strengthen CLI, startup, browser, book, renderer, and text sanitizer tests to cover config precedence, resource cleanup, and UTF-8-safe sanitization paths.

</details>

</details>

新功能：
- 在安装脚本中通过新增的 `--version` 参数支持安装指定的 GitHub Release 版本。

缺陷修复：
- 确保测试中创建的临时文件和路径被正确释放，避免泄漏和 ASan 警告。

增强改进：
- 在文件管理器中为每个目录缓存媒体摘要，避免在渲染时重复扫描目录。
- 优化终端输出的清理行为，在处理转义字符的同时保留有效的 UTF-8 文本。
- 将调试构建产物隔离到单独的目标文件和二进制目录中，并使构建标志的追踪在增量构建中更加安全。

构建：
- 添加 `DEBUG` 标志以及单独的调试目标文件/二进制目录，并新增使用 AddressSanitizer 运行测试的 `debug-test` 目标。
- 通过先写入临时文件再进行原子替换，使构建标志快照文件的创建更加健壮。

CI：
- 在静态分析工作流中运行调试构建的 AddressSanitizer 测试，而不再仅仅验证调试构建是否通过编译。
- 在发布构建工作流中执行测试，并将生成的 `SHA256SUMS` 附加到 Release 中。

部署：
- 在发布二进制文件的同时发布 `SHA256SUMS` 工件，以便客户端进行校验和验证。

文档：
- 在英文、日文和中文的 README 中记录使用安装程序 `--version` 参数进行可重现、基于标签固定版本的安装方式。

测试：
- 扩展安装程序测试，覆盖固定版本和校验和验证路径。
- 为文件管理器媒体目录渲染、改进后的终端清理行为添加测试，并在浏览器、启动流程、CLI、书籍和渲染器测试中增加更多内存安全相关的清理测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加支持固定版本且经校验和验证的安装程序、提升文件管理器媒体渲染效率，并强化调试/测试工作流。

New Features:
- 允许安装脚本通过 `--version` 选项将安装固定到特定的 GitHub 发布标签。

Bug Fixes:
- 确保测试创建的临时文件、目录和配置路径被正确释放，避免泄漏和内存/地址检测器（sanitizer）警告。

Enhancements:
- 在文件管理器中缓存按目录的媒体摘要，避免在渲染媒体指示器时重复扫描目录。
- 扩展终端清理（sanitization）测试，涵盖转义序列处理，同时保持有效 UTF-8 输出。

Build:
- 引入 `DEBUG` 标志和单独的调试对象/二进制目录，并新增 `debug-test` 目标以使用 AddressSanitizer 运行测试。
- 通过先写入临时文件，再以原子方式更新被跟踪文件，使构建标志快照生成更健壮。

CI:
- 更新静态分析工作流，改为运行带 AddressSanitizer 的 `debug-test` 测试目标，而不是仅验证调试构建是否通过。
- 在发布构建工作流中，在创建与发布发布产物之前运行测试。

Deployment:
- 在发布二进制文件的同时生成并发布 `SHA256SUMS`，以支持客户端进行校验和验证。

Documentation:
- 在英文、日文和中文的 README 中记录如何使用安装程序的 `--version` 选项进行可复现、基于标签固定的安装。

Tests:
- 扩展安装程序测试，涵盖固定版本、校验和验证以及失败场景。
- 增加文件管理器测试，用于验证媒体目录渲染标记。
- 加强 CLI、启动流程、浏览器、书本、渲染器以及文本清理器测试，以覆盖配置优先级、资源清理，以及确保 UTF-8 安全的清理路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add pinned, checksum-verified installer support, improve file manager media rendering efficiency, and strengthen debug/testing workflows.

New Features:
- Allow the install script to pin installations to a specific GitHub release tag via a --version option.

Bug Fixes:
- Ensure test-created temporary files, directories, and config paths are freed to avoid leaks and sanitizer warnings.

Enhancements:
- Cache per-directory media summaries in the file manager to avoid repeated directory scans when rendering media indicators.
- Extend terminal sanitization tests to cover escape handling while preserving valid UTF-8 output.

Build:
- Introduce a DEBUG flag and separate debug object/binary directories, along with a debug-test target that runs tests with AddressSanitizer.
- Make build flag snapshot generation more robust by writing to a temporary file before atomically updating the tracked file.

CI:
- Update static analysis workflows to run the debug-test AddressSanitizer test target instead of only validating a debug build.
- Run tests as part of the release build workflows before creating and publishing release artifacts.

Deployment:
- Generate and publish SHA256SUMS alongside release binaries to support client-side checksum verification.

Documentation:
- Document reproducible, tag-pinned installs with the installer --version option in the English, Japanese, and Chinese READMEs.

Tests:
- Expand installer tests to cover pinned versions, checksum verification, and failure scenarios.
- Add file manager tests that verify media-directory rendering markers.
- Strengthen CLI, startup, browser, book, renderer, and text sanitizer tests to cover config precedence, resource cleanup, and UTF-8-safe sanitization paths.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加支持固定版本且经校验和验证的安装程序、提升文件管理器媒体渲染效率，并强化调试/测试工作流。

New Features:
- 允许安装脚本通过 `--version` 选项将安装固定到特定的 GitHub 发布标签。

Bug Fixes:
- 确保测试创建的临时文件、目录和配置路径被正确释放，避免泄漏和内存/地址检测器（sanitizer）警告。

Enhancements:
- 在文件管理器中缓存按目录的媒体摘要，避免在渲染媒体指示器时重复扫描目录。
- 扩展终端清理（sanitization）测试，涵盖转义序列处理，同时保持有效 UTF-8 输出。

Build:
- 引入 `DEBUG` 标志和单独的调试对象/二进制目录，并新增 `debug-test` 目标以使用 AddressSanitizer 运行测试。
- 通过先写入临时文件，再以原子方式更新被跟踪文件，使构建标志快照生成更健壮。

CI:
- 更新静态分析工作流，改为运行带 AddressSanitizer 的 `debug-test` 测试目标，而不是仅验证调试构建是否通过。
- 在发布构建工作流中，在创建与发布发布产物之前运行测试。

Deployment:
- 在发布二进制文件的同时生成并发布 `SHA256SUMS`，以支持客户端进行校验和验证。

Documentation:
- 在英文、日文和中文的 README 中记录如何使用安装程序的 `--version` 选项进行可复现、基于标签固定的安装。

Tests:
- 扩展安装程序测试，涵盖固定版本、校验和验证以及失败场景。
- 增加文件管理器测试，用于验证媒体目录渲染标记。
- 加强 CLI、启动流程、浏览器、书本、渲染器以及文本清理器测试，以覆盖配置优先级、资源清理，以及确保 UTF-8 安全的清理路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add pinned, checksum-verified installer support, improve file manager media rendering efficiency, and strengthen debug/testing workflows.

New Features:
- Allow the install script to pin installations to a specific GitHub release tag via a --version option.

Bug Fixes:
- Ensure test-created temporary files, directories, and config paths are freed to avoid leaks and sanitizer warnings.

Enhancements:
- Cache per-directory media summaries in the file manager to avoid repeated directory scans when rendering media indicators.
- Extend terminal sanitization tests to cover escape handling while preserving valid UTF-8 output.

Build:
- Introduce a DEBUG flag and separate debug object/binary directories, along with a debug-test target that runs tests with AddressSanitizer.
- Make build flag snapshot generation more robust by writing to a temporary file before atomically updating the tracked file.

CI:
- Update static analysis workflows to run the debug-test AddressSanitizer test target instead of only validating a debug build.
- Run tests as part of the release build workflows before creating and publishing release artifacts.

Deployment:
- Generate and publish SHA256SUMS alongside release binaries to support client-side checksum verification.

Documentation:
- Document reproducible, tag-pinned installs with the installer --version option in the English, Japanese, and Chinese READMEs.

Tests:
- Expand installer tests to cover pinned versions, checksum verification, and failure scenarios.
- Add file manager tests that verify media-directory rendering markers.
- Strengthen CLI, startup, browser, book, renderer, and text sanitizer tests to cover config precedence, resource cleanup, and UTF-8-safe sanitization paths.

</details>

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the installer and terminal handling, adds checksum‑verified, pin‑able releases, and speeds up the file manager. CI runs tests on release builds, publishes `SHA256SUMS`, and keeps ASan clean.

- **Security & Reliability**
  - Sanitizes C1 controls, ESC, and invalid UTF‑8 in terminal output.
  - Verifies release downloads against `SHA256SUMS`; installer supports `--version` (including `latest`) and shows the chosen version in dry‑run.
  - Tests cover pinned installs, checksum verification and failure paths; media‑directory rendering and sanitization; clean up remaining temp allocations.

- **CI & Performance**
  - Release workflow runs tests and uploads `SHA256SUMS`; static analysis runs `debug-test` (ASan). Debug artifacts are isolated in `obj-debug`/`bin-debug`.
  - Caches per‑directory media summaries from a single scan to avoid repeated I/O and improve directory media markers.
  - README and localized docs document reproducible, pinned installs.

<sup>Written for commit 7459238555ae7a3cda6e61dd67ec264d0e91bb5c. Summary will update on new commits. <a href="https://cubic.dev/pr/zouyonghe/PixelTerm-C/pull/21?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

