### PR TITLE
fix: harden review race findings

### DIFF
--- a/docs/project/CODE_REVIEW_REPORT.md
+++ b/docs/project/CODE_REVIEW_REPORT.md
@@ -1,7 +1,7 @@
 # PixelTerm-C Code Review Report
 
 Date: 2026-05-25
-Scope: current code in `/Users/buding/Code/PixelTerm-C`
+Scope: current code in this repository
 
 ## Summary
 

--- a/docs/project/CODE_REVIEW_REPORT.md
+++ b/docs/project/CODE_REVIEW_REPORT.md
@@ -1,0 +1,145 @@
+# PixelTerm-C Code Review Report
+
+Date: 2026-05-25
+Scope: current code in `/Users/buding/Code/PixelTerm-C`
+
+## Summary
+
+Reviewed the current C codebase with emphasis on hidden races, media decode/render paths, preloading, document rendering, and file deletion behavior. The highest-risk area is video playback: the player mixes GLib timeout callbacks, decode/render worker threads, and public controls while many shared fields are read or written without a single synchronization rule.
+
+Existing unit coverage is broad, but most concurrency-sensitive cases are deterministic hook tests rather than sanitizer-backed race tests. The findings below are based on static source inspection.
+
+## Findings
+
+### High: VideoPlayer shared state has unsynchronized cross-thread access
+
+Files:
+- `include/video_player.h`
+- `src/video_player.c`
+
+Evidence:
+- `VideoPlayer` stores playback state, EOF state, timer id, FFmpeg pointers, layout fields, and worker flags in one struct: `include/video_player.h:33`.
+- Some helpers use `state_mutex`, for example `video_player_is_eof_pending()` and `video_player_is_eof_ended()` in `src/video_player.c:128` and `src/video_player.c:139`.
+- Other paths read or write the same state without the mutex:
+  - `video_player_schedule_tick()` reads `player->is_playing` and mutates `player->timer_id` at `src/video_player.c:287`.
+  - `video_player_tick()` reads/writes `player->is_playing` and `player->timer_id` before taking `state_mutex` at `src/video_player.c:1450`.
+  - `video_player_play()`, `video_player_pause()`, and `video_player_stop()` update `is_playing`, `timer_id`, frame layout state, and timing state directly at `src/video_player.c:2105`, `src/video_player.c:2146`, and `src/video_player.c:2162`.
+  - The decode worker reads and writes `player->draining` without a lock at `src/video_player.c:1509` and `src/video_player.c:1512`; EOF handlers also write it directly at `src/video_player.c:383` and `src/video_player.c:395`.
+  - `video_player_render_frame()` reads and writes render layout fields directly at `src/video_player.c:1783` through `src/video_player.c:1904`, while `video_player_set_render_area()` writes those fields under `state_mutex` at `src/video_player.c:1162`.
+
+Impact:
+The code has real C data races if playback controls, GLib timeout callbacks, terminal resize handling, EOF handling, or worker activity overlap. Symptoms can include duplicate or lost timers, playback stopping unexpectedly, stuck EOF handling, stale frames after seek/resize, or undefined behavior under ThreadSanitizer.
+
+Recommendation:
+Define one ownership rule for every `VideoPlayer` field. A practical first step is to keep FFmpeg decode state worker-owned after startup, keep timer operations main-context-only, and move all shared playback/layout/EOF fields behind `state_mutex` or atomics. Add a ThreadSanitizer job or targeted TSAN test binary for play/pause/seek/resize/EOF overlap.
+
+### High: Renderer pointer replacement is unsafe while video workers can run
+
+Files:
+- `src/video_player.c`
+
+Evidence:
+- `video_player_set_renderer()` can destroy the owned renderer and replace `player->renderer` under `render_mutex` at `src/video_player.c:1137`.
+- The decode worker checks `player->renderer` without `render_mutex` at `src/video_player.c:1501`.
+- `video_player_start_worker()` uses `!player->renderer` without `render_mutex` at `src/video_player.c:1271`.
+- Render worker config reads the renderer under `render_mutex` at `src/video_player.c:1287`, but that does not protect the unchecked reads elsewhere.
+
+Impact:
+If a renderer is swapped while playback is active or workers are starting/stopping, workers may observe stale or inconsistent renderer state. The common setup path may not hit this, but the public API does not enforce "only before playback".
+
+Recommendation:
+Either make renderer replacement illegal while workers are running, or stop/join workers before replacing the renderer. Document the API contract and assert it in debug builds.
+
+### Medium: Preloader configuration fields are not consistently protected
+
+Files:
+- `include/preloader.h`
+- `src/preloader.c`
+
+Evidence:
+- `ImagePreloader` stores config fields such as terminal size, dither, protocol flags, work factor, gamma, and color enhancement in `include/preloader.h:31`.
+- `preloader_initialize()` writes these config fields without `preloader->mutex` at `src/preloader.c:217`.
+- `preloader_update_terminal_size()` writes terminal dimensions under the mutex at `src/preloader.c:695`.
+- The worker snapshots terminal size under the mutex at `src/preloader.c:719`, but then reads dither/protocol/gamma/color config without the mutex while building `RendererConfig` at `src/preloader.c:725`.
+- While processing a task, the worker calls `preloader_normalize_dims()` at `src/preloader.c:793`; that helper can read `term_width` and `term_height` without taking the mutex at `src/preloader.c:45`.
+
+Impact:
+Most current call sites appear to initialize after stopping the worker, but the API itself allows concurrent configuration and worker access. This is another TSAN-visible race and can render cached entries at inconsistent dimensions or with mixed config if future code calls initialization/update while running.
+
+Recommendation:
+Make `preloader_initialize()` require an idle preloader or take the mutex and signal/restart safely. Avoid reading any `ImagePreloader` mutable fields outside the mutex; pass normalized dimensions/config snapshots into worker-local variables.
+
+### Medium: Public preloader cache cleanup mutates shared structures without locking
+
+Files:
+- `include/preloader.h`
+- `src/preloader.c`
+
+Evidence:
+- `preloader_cache_cleanup()` is declared as a public function in `include/preloader.h:262`.
+- It reads and mutates `preload_cache` and `lru_queue` without locking `preloader->mutex` at `src/preloader.c:631`.
+- It is currently called internally by `preloader_cache_add()` while the mutex is already held at `src/preloader.c:563`, which is safe only because the helper assumes its caller owns the lock.
+
+Impact:
+Any external caller can corrupt the hash table/LRU queue if cleanup overlaps with worker cache insertions, cache reads, or cache clears. The public declaration makes that misuse easy.
+
+Recommendation:
+Split this into a private `_locked` helper for `preloader_cache_add()` and a public wrapper that takes `preloader->mutex`, or remove the public declaration if no external caller should use it.
+
+### Medium: MuPDF page target pixel dimensions can overflow before clamping
+
+Files:
+- `src/book.c`
+
+Evidence:
+- `book_render_page()` calculates pixel dimensions with `gint target_px_w = target_cols * cell_w;` and `gint target_px_h = target_rows * cell_h;` at `src/book.c:262`.
+- The later `max_dim = 4096.0` clamp only runs after these signed integer multiplications.
+
+Impact:
+Very large or corrupted terminal geometry values can overflow `gint` before the renderer clamps scale. That can produce negative or very small dimensions, incorrect scaling, or unexpected MuPDF allocation behavior.
+
+Recommendation:
+Use checked multiplication (`g_size_checked_mul` or explicit `gint64`) before converting to a render scale. Clamp target pixel dimensions before calling MuPDF.
+
+### Low: `preloader_stop()` does not match its documented queue-clearing contract
+
+Files:
+- `include/preloader.h`
+- `src/preloader.c`
+
+Evidence:
+- The header says `preloader_stop()` "clears any remaining tasks in the queue" at `include/preloader.h:108`.
+- The implementation signals stop, joins the thread, and sets status idle, but does not clear `task_queue` at `src/preloader.c:265`.
+
+Impact:
+Pending tasks can survive a stop/start cycle. In current flows this may be harmless or even intentional, but it is surprising when toggling render settings or reusing the preloader after a stop.
+
+Recommendation:
+Either clear `task_queue` in `preloader_stop()` or update the comment and ensure callers explicitly call `preloader_clear_queue()` when they need old work discarded.
+
+### Low: Media buffer rejection log limit is off by one
+
+Files:
+- `src/media_buffer.c`
+
+Evidence:
+- `MEDIA_BUFFER_REJECTION_LOG_LIMIT` is `32` at `src/media_buffer.c:5`.
+- `media_buffer_debug_reject()` suppresses only when `previous_count > MEDIA_BUFFER_REJECTION_LOG_LIMIT` at `src/media_buffer.c:11` and prints the suppression notice when `previous_count == MEDIA_BUFFER_REJECTION_LOG_LIMIT` at `src/media_buffer.c:14`.
+
+Impact:
+The function allows 32 detailed logs plus one suppression notice. If the intended limit is exactly 32 total log emissions, this is off by one. If the intended behavior is 32 detailed messages plus one notice, the constant/comment should say so.
+
+Recommendation:
+Clarify the limit semantics or change the comparison to match the intended count.
+
+## Suggested Follow-Up Tests
+
+- Add a ThreadSanitizer build target that exercises video play/pause/stop/seek while a worker is decoding and while terminal layout changes.
+- Add a preloader concurrency test that starts the worker, repeatedly updates terminal size/config, and queues tasks under TSAN.
+- Add a MuPDF render unit test or internal helper test for oversized target column/row values to prove checked clamping occurs before multiplication.
+- Add a regression test for `preloader_stop()` semantics once the intended queue behavior is chosen.
+
+## Notes
+
+- This report does not claim all findings are user-triggerable through the current UI. The concurrency items are still worth fixing because the public APIs and worker topology currently rely on implicit call ordering that is not encoded in the code.
+- No code fixes are included in this report; it is intended as the requested bug/defect/race assessment.

--- a/include/video_player.h
+++ b/include/video_player.h
@@ -126,6 +126,9 @@ ErrorCode video_player_play(VideoPlayer *player);
 ErrorCode video_player_pause(VideoPlayer *player);
 ErrorCode video_player_stop(VideoPlayer *player);
 ErrorCode video_player_seek_relative_ms(VideoPlayer *player, gint64 delta_ms);
+
+/* Thread-safe state accessors. These acquire the player's internal state mutex
+ * and may block; do not call them while already holding that mutex. */
 gboolean video_player_is_playing(const VideoPlayer *player);
 gboolean video_player_has_video(const VideoPlayer *player);
 ErrorCode video_player_update_terminal_size(VideoPlayer *player);

--- a/src/book.c
+++ b/src/book.c
@@ -237,6 +237,18 @@ static gdouble book_compute_scale(gdouble page_w, gdouble page_h, gint target_px
     return scale;
 }
 
+static gint book_clamped_target_pixels(gint cells, gint cell_px) {
+    const gint max_dim = 4096;
+    gint64 pixels = (gint64)cells * (gint64)cell_px;
+    if (pixels < 1) {
+        return 1;
+    }
+    if (pixels > max_dim) {
+        return max_dim;
+    }
+    return (gint)pixels;
+}
+
 ErrorCode book_render_page(BookDocument *doc,
                            gint page_index,
                            gint target_cols,
@@ -259,10 +271,8 @@ ErrorCode book_render_page(BookDocument *doc,
     if (target_cols < 1) target_cols = 1;
     if (target_rows < 1) target_rows = 1;
 
-    gint target_px_w = target_cols * cell_w;
-    gint target_px_h = target_rows * cell_h;
-    if (target_px_w < 1) target_px_w = 1;
-    if (target_px_h < 1) target_px_h = 1;
+    gint target_px_w = book_clamped_target_pixels(target_cols, cell_w);
+    gint target_px_h = book_clamped_target_pixels(target_rows, cell_h);
 
     fz_context *ctx = doc->ctx;
     fz_page *page = NULL;

--- a/src/media_buffer.c
+++ b/src/media_buffer.c
@@ -8,10 +8,10 @@ static gint media_buffer_rejection_log_count = 0;
 
 static void media_buffer_debug_reject(const gchar *format, ...) {
     gint previous_count = g_atomic_int_add(&media_buffer_rejection_log_count, 1);
-    if (previous_count > MEDIA_BUFFER_REJECTION_LOG_LIMIT) {
+    if (previous_count >= MEDIA_BUFFER_REJECTION_LOG_LIMIT) {
         return;
     }
-    if (previous_count == MEDIA_BUFFER_REJECTION_LOG_LIMIT) {
+    if (previous_count == MEDIA_BUFFER_REJECTION_LOG_LIMIT - 1) {
         g_debug("Further media buffer rejection logs suppressed");
         return;
     }

--- a/src/preloader.c
+++ b/src/preloader.c
@@ -585,11 +585,6 @@ void preloader_cache_add(ImagePreloader *preloader,
         return;
     }
 
-    // Check cache size and cleanup if necessary before inserting new
-    if (g_hash_table_size(preloader->preload_cache) >= preloader->max_cache_size) {
-        preloader_cache_cleanup_locked(preloader);
-    }
-
     // Add to cache with dimensions
     PreloadCacheKey *key = preload_cache_key_new(filepath, key_width, key_height);
     CachedImageData *value = g_new0(CachedImageData, 1);
@@ -615,6 +610,7 @@ void preloader_cache_add(ImagePreloader *preloader,
     g_hash_table_insert(preloader->preload_cache, key, value);
     g_queue_remove(preloader->lru_queue, key);
     g_queue_push_head(preloader->lru_queue, key);
+    preloader_cache_cleanup_locked(preloader);
 
     g_mutex_unlock(&preloader->mutex);
 }

--- a/src/preloader.c
+++ b/src/preloader.c
@@ -42,6 +42,29 @@ static PreloadCacheKey* preload_cache_key_new(const char *filepath, gint width, 
     return key;
 }
 
+static void preloader_clear_queue_locked(ImagePreloader *preloader) {
+    while (!g_queue_is_empty(preloader->task_queue)) {
+        PreloadTask *task = (PreloadTask*)g_queue_pop_head(preloader->task_queue);
+        g_free(task->filepath);
+        g_free(task);
+    }
+}
+
+static void preloader_cache_cleanup_locked(ImagePreloader *preloader) {
+    guint size = g_hash_table_size(preloader->preload_cache);
+    if (size <= preloader->max_cache_size) {
+        return;
+    }
+
+    while (g_hash_table_size(preloader->preload_cache) > preloader->max_cache_size) {
+        gpointer key = g_queue_pop_tail(preloader->lru_queue);
+        if (!key) {
+            break;
+        }
+        g_hash_table_remove(preloader->preload_cache, key);
+    }
+}
+
 static void preloader_normalize_dims(ImagePreloader *preloader, gint *width, gint *height) {
     if (!preloader || !width || !height) {
         return;
@@ -221,12 +244,14 @@ ErrorCode preloader_initialize(ImagePreloader *preloader, gboolean dither_enable
     if (!preloader) {
         return ERROR_MEMORY_ALLOC;
     }
-    preloader->dither_enabled = dither_enabled;
     if (work_factor < 1) {
         work_factor = 1;
     } else if (work_factor > 9) {
         work_factor = 9;
     }
+
+    g_mutex_lock(&preloader->mutex);
+    preloader->dither_enabled = dither_enabled;
     preloader->work_factor = work_factor;
     preloader->force_text = force_text;
     preloader->force_sixel = force_sixel;
@@ -235,6 +260,7 @@ ErrorCode preloader_initialize(ImagePreloader *preloader, gboolean dither_enable
     preloader->text_symbol_mode = text_symbol_mode;
     preloader->gamma = gamma;
     preloader->color_enhance = color_enhance;
+    g_mutex_unlock(&preloader->mutex);
 
     return ERROR_NONE;
 }
@@ -285,6 +311,7 @@ ErrorCode preloader_stop(ImagePreloader *preloader) {
 
     g_mutex_lock(&preloader->mutex);
     preloader->status = PRELOADER_IDLE;
+    preloader_clear_queue_locked(preloader);
     g_mutex_unlock(&preloader->mutex);
 
     return ERROR_NONE;
@@ -378,7 +405,9 @@ ErrorCode preloader_add_tasks_for_directory(ImagePreloader *preloader, GList *fi
 
     gint task_width = target_width;
     gint task_height = target_height;
+    g_mutex_lock(&preloader->mutex);
     preloader_normalize_dims(preloader, &task_width, &task_height);
+    g_mutex_unlock(&preloader->mutex);
 
     if (current_index < 0) {
         return ERROR_NONE;
@@ -421,11 +450,7 @@ ErrorCode preloader_clear_queue(ImagePreloader *preloader) {
 
     g_mutex_lock(&preloader->mutex);
 
-    while (!g_queue_is_empty(preloader->task_queue)) {
-        PreloadTask *task = (PreloadTask*)g_queue_pop_head(preloader->task_queue);
-        g_free(task->filepath);
-        g_free(task);
-    }
+    preloader_clear_queue_locked(preloader);
 
     g_mutex_unlock(&preloader->mutex);
 
@@ -562,7 +587,7 @@ void preloader_cache_add(ImagePreloader *preloader,
 
     // Check cache size and cleanup if necessary before inserting new
     if (g_hash_table_size(preloader->preload_cache) >= preloader->max_cache_size) {
-        preloader_cache_cleanup(preloader);
+        preloader_cache_cleanup_locked(preloader);
     }
 
     // Add to cache with dimensions
@@ -633,19 +658,9 @@ void preloader_cache_cleanup(ImagePreloader *preloader) {
         return;
     }
 
-    guint size = g_hash_table_size(preloader->preload_cache);
-    if (size <= preloader->max_cache_size) {
-        return;
-    }
-
-    // Remove oldest entries from LRU tail
-    while (g_hash_table_size(preloader->preload_cache) > preloader->max_cache_size) {
-        gpointer key = g_queue_pop_tail(preloader->lru_queue);
-        if (!key) {
-            break;
-        }
-        g_hash_table_remove(preloader->preload_cache, key);
-    }
+    g_mutex_lock(&preloader->mutex);
+    preloader_cache_cleanup_locked(preloader);
+    g_mutex_unlock(&preloader->mutex);
 }
 
 // Enable preloader
@@ -715,28 +730,46 @@ gpointer preloader_worker_thread(gpointer data) {
         return NULL;
     }
 
-    // Get current terminal dimensions
+    // Snapshot mutable configuration before creating the worker-local renderer.
     gint term_width, term_height;
+    gboolean dither_enabled;
+    gint work_factor;
+    gboolean force_text;
+    gboolean force_sixel;
+    gboolean force_kitty;
+    gboolean force_iterm2;
+    TextSymbolMode text_symbol_mode;
+    gdouble gamma;
+    ColorEnhanceMode color_enhance;
     g_mutex_lock(&preloader->mutex);
     term_width = preloader->term_width;
     term_height = preloader->term_height;
+    dither_enabled = preloader->dither_enabled;
+    work_factor = preloader->work_factor;
+    force_text = preloader->force_text;
+    force_sixel = preloader->force_sixel;
+    force_kitty = preloader->force_kitty;
+    force_iterm2 = preloader->force_iterm2;
+    text_symbol_mode = preloader->text_symbol_mode;
+    gamma = preloader->gamma;
+    color_enhance = preloader->color_enhance;
     g_mutex_unlock(&preloader->mutex);
 
     RendererConfig config = {
         .max_width = term_width,
         .max_height = term_height,
         .preserve_aspect_ratio = TRUE,
-        .dither = preloader->dither_enabled,
+        .dither = dither_enabled,
         .color_space = CHAFA_COLOR_SPACE_RGB,
-        .work_factor = preloader->work_factor,
-        .force_text = preloader->force_text,
-        .force_sixel = preloader->force_sixel,
-        .force_kitty = preloader->force_kitty,
-        .force_iterm2 = preloader->force_iterm2,
-        .text_symbol_mode = preloader->text_symbol_mode,
-        .gamma = preloader->gamma,
-        .color_enhance = preloader->color_enhance,
-        .dither_mode = preloader->dither_enabled ? CHAFA_DITHER_MODE_ORDERED : CHAFA_DITHER_MODE_NONE,
+        .work_factor = work_factor,
+        .force_text = force_text,
+        .force_sixel = force_sixel,
+        .force_kitty = force_kitty,
+        .force_iterm2 = force_iterm2,
+        .text_symbol_mode = text_symbol_mode,
+        .gamma = gamma,
+        .color_enhance = color_enhance,
+        .dither_mode = dither_enabled ? CHAFA_DITHER_MODE_ORDERED : CHAFA_DITHER_MODE_NONE,
         .color_extractor = CHAFA_COLOR_EXTRACTOR_AVERAGE,
         .optimizations = CHAFA_OPTIMIZATION_REUSE_ATTRIBUTES
     };
@@ -790,7 +823,6 @@ gpointer preloader_worker_thread(gpointer data) {
         if (task) {
             gint task_width = task->target_width;
             gint task_height = task->target_height;
-            preloader_normalize_dims(preloader, &task_width, &task_height);
 
             // Reconfigure target size when tasks demand different geometry
             if (task_width != current_max_width || task_height != current_max_height) {

--- a/src/video_player.c
+++ b/src/video_player.c
@@ -305,7 +305,7 @@ static void video_player_set_draining(VideoPlayer *player, gboolean draining) {
     g_mutex_unlock(&player->state_mutex);
 }
 
-static gboolean video_player_has_renderer_locked(VideoPlayer *player) {
+static gboolean video_player_has_renderer(VideoPlayer *player) {
     if (!player) {
         return FALSE;
     }
@@ -1319,7 +1319,7 @@ static void video_player_debug_log_snapshot(VideoPlayer *player,
 }
 
 static void video_player_start_worker(VideoPlayer *player) {
-    if (!player || player->worker_thread || !video_player_has_renderer_locked(player)) {
+    if (!player || player->worker_thread || !video_player_has_renderer(player)) {
         return;
     }
     g_mutex_lock(&player->queue_mutex);
@@ -1557,7 +1557,7 @@ static gpointer video_player_worker_thread(gpointer user_data) {
             continue;
         }
 
-        if (!player->format_context || !player->codec_context || !video_player_has_renderer_locked(player)) {
+        if (!player->format_context || !player->codec_context || !video_player_has_renderer(player)) {
             g_usleep(10000);
             continue;
         }
@@ -1782,7 +1782,7 @@ static gpointer video_player_render_worker_thread(gpointer user_data) {
 }
 
 static gboolean video_player_render_frame(VideoPlayer *player) {
-    if (!player || !video_player_has_renderer_locked(player) || !player->format_context || !player->codec_context) {
+    if (!player || !video_player_has_renderer(player) || !player->format_context || !player->codec_context) {
         return FALSE;
     }
 
@@ -2321,6 +2321,7 @@ gboolean video_player_is_playing(const VideoPlayer *player) {
         return FALSE;
     }
 
+    /* Cast away const only to acquire the internal mutex for a stable read. */
     VideoPlayer *mutable_player = (VideoPlayer*)player;
     g_mutex_lock(&mutable_player->state_mutex);
     gboolean is_playing = mutable_player->is_playing;
@@ -2333,6 +2334,7 @@ gboolean video_player_has_video(const VideoPlayer *player) {
         return FALSE;
     }
 
+    /* Cast away const only to acquire the internal mutex for a stable read. */
     VideoPlayer *mutable_player = (VideoPlayer*)player;
     g_mutex_lock(&mutable_player->state_mutex);
     gboolean has_video = mutable_player->has_video;

--- a/src/video_player.c
+++ b/src/video_player.c
@@ -49,6 +49,7 @@ static void video_player_render_work_finished(VideoPlayer *player);
 static void video_player_handle_terminal_eof(VideoPlayer *player);
 static void video_player_handle_worker_eof(VideoPlayer *player);
 static void video_player_stop_worker(VideoPlayer *player);
+static void video_player_resume_playback_loop(VideoPlayer *player);
 gint video_player_calc_delay_ms(VideoPlayer *player);
 static gboolean video_player_tick(gpointer user_data);
 static gboolean video_player_render_frame(VideoPlayer *player);
@@ -1183,6 +1184,7 @@ void video_player_set_renderer(VideoPlayer *player, ImageRenderer *renderer) {
     g_mutex_lock(&player->render_mutex);
     gboolean replacing_renderer = player->renderer && player->renderer != renderer;
     g_mutex_unlock(&player->render_mutex);
+    gboolean was_playing = replacing_renderer && renderer && video_player_is_playing(player);
     if (replacing_renderer) {
         video_player_stop_worker(player);
     }
@@ -1194,6 +1196,10 @@ void video_player_set_renderer(VideoPlayer *player, ImageRenderer *renderer) {
     player->renderer = renderer;
     player->owns_renderer = FALSE;
     g_mutex_unlock(&player->render_mutex);
+
+    if (was_playing) {
+        video_player_resume_playback_loop(player);
+    }
 }
 
 void video_player_set_render_area(VideoPlayer *player,

--- a/src/video_player.c
+++ b/src/video_player.c
@@ -48,6 +48,7 @@ static gboolean video_player_finalize_pending_eof_if_drained(VideoPlayer *player
 static void video_player_render_work_finished(VideoPlayer *player);
 static void video_player_handle_terminal_eof(VideoPlayer *player);
 static void video_player_handle_worker_eof(VideoPlayer *player);
+static void video_player_stop_worker(VideoPlayer *player);
 gint video_player_calc_delay_ms(VideoPlayer *player);
 static gboolean video_player_tick(gpointer user_data);
 static gboolean video_player_render_frame(VideoPlayer *player);
@@ -120,9 +121,8 @@ void video_player_reset_timing_state(VideoPlayer *player) {
     player->present_fps = 0.0;
     player->present_fps_valid = FALSE;
     player->fallback_pts_ms = 0;
-    g_mutex_unlock(&player->state_mutex);
-
     player->draining = FALSE;
+    g_mutex_unlock(&player->state_mutex);
 }
 
 static gboolean video_player_is_eof_pending(VideoPlayer *player) {
@@ -284,8 +284,47 @@ static guint video_player_generation_bump(VideoPlayer *player) {
     return (guint)(g_atomic_int_add(&player->playback_generation, 1) + 1);
 }
 
+static gboolean video_player_get_draining(VideoPlayer *player) {
+    if (!player) {
+        return FALSE;
+    }
+
+    g_mutex_lock(&player->state_mutex);
+    gboolean draining = player->draining;
+    g_mutex_unlock(&player->state_mutex);
+    return draining;
+}
+
+static void video_player_set_draining(VideoPlayer *player, gboolean draining) {
+    if (!player) {
+        return;
+    }
+
+    g_mutex_lock(&player->state_mutex);
+    player->draining = draining;
+    g_mutex_unlock(&player->state_mutex);
+}
+
+static gboolean video_player_has_renderer_locked(VideoPlayer *player) {
+    if (!player) {
+        return FALSE;
+    }
+
+    g_mutex_lock(&player->render_mutex);
+    gboolean has_renderer = player->renderer != NULL;
+    g_mutex_unlock(&player->render_mutex);
+    return has_renderer;
+}
+
 static void video_player_schedule_tick(VideoPlayer *player) {
-    if (!player || !player->is_playing) {
+    if (!player) {
+        return;
+    }
+
+    g_mutex_lock(&player->state_mutex);
+    gboolean is_playing = player->is_playing;
+    g_mutex_unlock(&player->state_mutex);
+    if (!is_playing) {
         return;
     }
 
@@ -295,10 +334,13 @@ static void video_player_schedule_tick(VideoPlayer *player) {
         delay = 1;
     }
 
-    if (player->timer_id != 0) {
-        g_source_remove(player->timer_id);
-    }
+    g_mutex_lock(&player->state_mutex);
+    guint old_timer_id = player->timer_id;
     player->timer_id = g_timeout_add(delay, video_player_tick, player);
+    g_mutex_unlock(&player->state_mutex);
+    if (old_timer_id != 0) {
+        g_source_remove(old_timer_id);
+    }
 }
 
 void decoded_frame_destroy(DecodedFrame *frame) {
@@ -374,13 +416,12 @@ static void video_player_handle_terminal_eof(VideoPlayer *player) {
     player->rewind_needs_resync = FALSE;
     player->eof_pending = FALSE;
     player->eof_ended = TRUE;
+    player->draining = FALSE;
     g_mutex_unlock(&player->state_mutex);
 
     if (timer_id != 0) {
         g_source_remove(timer_id);
     }
-
-    player->draining = FALSE;
     video_player_debug_log(player, "worker-eof-stop", 0, 0, 0, 0);
 }
 
@@ -391,8 +432,8 @@ static void video_player_handle_worker_eof(VideoPlayer *player) {
 
     g_mutex_lock(&player->state_mutex);
     player->eof_pending = TRUE;
-    g_mutex_unlock(&player->state_mutex);
     player->draining = FALSE;
+    g_mutex_unlock(&player->state_mutex);
     (void)video_player_finalize_pending_eof_if_drained(player);
 }
 
@@ -1140,6 +1181,13 @@ void video_player_set_renderer(VideoPlayer *player, ImageRenderer *renderer) {
     }
 
     g_mutex_lock(&player->render_mutex);
+    gboolean replacing_renderer = player->renderer && player->renderer != renderer;
+    g_mutex_unlock(&player->render_mutex);
+    if (replacing_renderer) {
+        video_player_stop_worker(player);
+    }
+
+    g_mutex_lock(&player->render_mutex);
     if (player->renderer && player->renderer != renderer && player->owns_renderer) {
         renderer_destroy(player->renderer);
     }
@@ -1230,7 +1278,9 @@ void video_player_clear_render_area(VideoPlayer *player) {
         printf("\033[%d;1H\033[2K", row);
     }
     fflush(stdout);
+    g_mutex_lock(&player->state_mutex);
     video_player_clear_line_cache(player);
+    g_mutex_unlock(&player->state_mutex);
 }
 
 static gboolean video_player_render_frame(VideoPlayer *player);
@@ -1269,13 +1319,13 @@ static void video_player_debug_log_snapshot(VideoPlayer *player,
 }
 
 static void video_player_start_worker(VideoPlayer *player) {
-    if (!player || player->worker_thread || !player->renderer) {
+    if (!player || player->worker_thread || !video_player_has_renderer_locked(player)) {
         return;
     }
     g_mutex_lock(&player->queue_mutex);
     player->worker_stop = FALSE;
     g_mutex_unlock(&player->queue_mutex);
-    player->draining = FALSE;
+    video_player_set_draining(player, FALSE);
     player->worker_thread = g_thread_new("video-decode", video_player_worker_thread, player);
     if (!player->render_workers_started) {
         player->render_workers[0] = g_thread_new("video-render-0", video_player_render_worker_thread, player);
@@ -1304,12 +1354,14 @@ static RendererConfig video_player_render_worker_config(VideoPlayer *player) {
         .optimizations = CHAFA_OPTIMIZATION_REUSE_ATTRIBUTES
     };
 
-    if (!player || !player->renderer) {
+    if (!player) {
         return config;
     }
 
     g_mutex_lock(&player->render_mutex);
-    config = player->renderer->config;
+    if (player->renderer) {
+        config = player->renderer->config;
+    }
     g_mutex_unlock(&player->render_mutex);
     return config;
 }
@@ -1409,7 +1461,7 @@ static void video_player_stop_worker(VideoPlayer *player) {
 }
 
 static void video_player_resume_playback_loop(VideoPlayer *player) {
-    if (!player || !player->is_playing) {
+    if (!video_player_is_playing(player)) {
         return;
     }
 
@@ -1453,15 +1505,22 @@ static gboolean video_player_tick(gpointer user_data) {
         return G_SOURCE_REMOVE;
     }
 
-    if (!player->is_playing) {
+    g_mutex_lock(&player->state_mutex);
+    gboolean is_playing = player->is_playing;
+    g_mutex_unlock(&player->state_mutex);
+    if (!is_playing) {
+        g_mutex_lock(&player->state_mutex);
         player->timer_id = 0;
+        g_mutex_unlock(&player->state_mutex);
         return G_SOURCE_REMOVE;
     }
 
     if (!video_player_render_frame(player)) {
         video_player_debug_log(player, "tick-stop", 0, 0, 0, 0);
+        g_mutex_lock(&player->state_mutex);
         player->timer_id = 0;
         player->is_playing = FALSE;
+        g_mutex_unlock(&player->state_mutex);
         return G_SOURCE_REMOVE;
     }
 
@@ -1498,7 +1557,7 @@ static gpointer video_player_worker_thread(gpointer user_data) {
             continue;
         }
 
-        if (!player->format_context || !player->codec_context || !player->renderer) {
+        if (!player->format_context || !player->codec_context || !video_player_has_renderer_locked(player)) {
             g_usleep(10000);
             continue;
         }
@@ -1506,10 +1565,12 @@ static gpointer video_player_worker_thread(gpointer user_data) {
         gboolean frame_ready = FALSE;
         gint64 decode_start_us = g_get_monotonic_time();
         while (!frame_ready && !video_player_should_stop(player)) {
-            if (!player->draining) {
+            gboolean draining = video_player_get_draining(player);
+            if (!draining) {
                 int read_result = av_read_frame(player->format_context, player->packet);
                 if (read_result < 0) {
-                    player->draining = TRUE;
+                    video_player_set_draining(player, TRUE);
+                    draining = TRUE;
                     avcodec_send_packet(player->codec_context, NULL);
                 } else if (player->packet->stream_index == player->video_stream_index) {
                     avcodec_send_packet(player->codec_context, player->packet);
@@ -1538,13 +1599,13 @@ static gpointer video_player_worker_thread(gpointer user_data) {
             }
 
             if (receive_result == AVERROR(EAGAIN)) {
-                if (player->draining) {
+                if (video_player_get_draining(player)) {
                     break;
                 }
                 continue;
             }
 
-            if (receive_result == AVERROR_INVALIDDATA && !player->draining) {
+            if (receive_result == AVERROR_INVALIDDATA && !video_player_get_draining(player)) {
                 continue;
             }
 
@@ -1721,7 +1782,7 @@ static gpointer video_player_render_worker_thread(gpointer user_data) {
 }
 
 static gboolean video_player_render_frame(VideoPlayer *player) {
-    if (!player || !player->renderer || !player->format_context || !player->codec_context) {
+    if (!player || !video_player_has_renderer_locked(player) || !player->format_context || !player->codec_context) {
         return FALSE;
     }
 
@@ -1780,6 +1841,7 @@ static gboolean video_player_render_frame(VideoPlayer *player) {
     video_player_debug_log(player, "render-frame", frame->pts_ms, rendered_w, rendered_h, graphics_mode ? 1 : 0);
 
     gint64 io_start_us = g_get_monotonic_time();
+    g_mutex_lock(&player->state_mutex);
     if (player->render_layout_valid && player->render_area_top_row > 0 && player->render_area_height > 0) {
         gint term_w = player->render_term_width > 0 ? player->render_term_width : player->render_max_width;
         gint term_h = player->render_term_height;
@@ -1945,6 +2007,7 @@ static gboolean video_player_render_frame(VideoPlayer *player) {
         player->last_frame_top_row = 0;
         player->last_frame_height = 0;
     }
+    g_mutex_unlock(&player->state_mutex);
 
     fflush(stdout);
     gint64 io_end_us = g_get_monotonic_time();
@@ -2096,25 +2159,30 @@ ErrorCode video_player_load(VideoPlayer *player, const gchar *filepath) {
     }
     video_player_set_fallback_pts_ms(player, 0);
     player->filepath = g_strdup(filepath);
+    g_mutex_lock(&player->state_mutex);
     player->has_video = TRUE;
     player->draining = FALSE;
+    g_mutex_unlock(&player->state_mutex);
 
     return ERROR_NONE;
 }
 
 ErrorCode video_player_play(VideoPlayer *player) {
-    if (!player || !player->has_video) {
+    if (!player || !video_player_has_video(player)) {
         return ERROR_INVALID_IMAGE;
     }
 
-    if (player->is_playing) {
+    if (video_player_is_playing(player)) {
         return ERROR_NONE;
     }
 
     if (video_player_is_eof_ended(player)) {
-        if (player->timer_id != 0) {
-            g_source_remove(player->timer_id);
-            player->timer_id = 0;
+        g_mutex_lock(&player->state_mutex);
+        guint timer_id = player->timer_id;
+        player->timer_id = 0;
+        g_mutex_unlock(&player->state_mutex);
+        if (timer_id != 0) {
+            g_source_remove(timer_id);
         }
         video_player_stop_worker_internal(player, FALSE);
         ErrorCode seek_result = video_player_seek_to_ms(player, 0, 0);
@@ -2123,12 +2191,14 @@ ErrorCode video_player_play(VideoPlayer *player) {
         }
     }
 
-    player->is_playing = TRUE;
     video_player_generation_bump(player);
+    g_mutex_lock(&player->state_mutex);
+    player->is_playing = TRUE;
     player->fixed_frame_valid = FALSE;
     player->last_frame_top_row = 0;
     player->last_frame_height = 0;
     video_player_clear_line_cache(player);
+    g_mutex_unlock(&player->state_mutex);
     video_player_reset_timing_state(player);
 
     video_player_queue_clear(player);
@@ -2148,11 +2218,14 @@ ErrorCode video_player_pause(VideoPlayer *player) {
         return ERROR_INVALID_IMAGE;
     }
 
-    player->is_playing = FALSE;
     video_player_generation_bump(player);
-    if (player->timer_id != 0) {
-        g_source_remove(player->timer_id);
-        player->timer_id = 0;
+    g_mutex_lock(&player->state_mutex);
+    player->is_playing = FALSE;
+    guint timer_id = player->timer_id;
+    player->timer_id = 0;
+    g_mutex_unlock(&player->state_mutex);
+    if (timer_id != 0) {
+        g_source_remove(timer_id);
     }
     video_player_stop_worker(player);
 
@@ -2164,11 +2237,14 @@ ErrorCode video_player_stop(VideoPlayer *player) {
         return ERROR_INVALID_IMAGE;
     }
 
-    player->is_playing = FALSE;
     video_player_generation_bump(player);
-    if (player->timer_id != 0) {
-        g_source_remove(player->timer_id);
-        player->timer_id = 0;
+    g_mutex_lock(&player->state_mutex);
+    player->is_playing = FALSE;
+    guint timer_id = player->timer_id;
+    player->timer_id = 0;
+    g_mutex_unlock(&player->state_mutex);
+    if (timer_id != 0) {
+        g_source_remove(timer_id);
     }
     video_player_stop_worker(player);
 
@@ -2176,7 +2252,7 @@ ErrorCode video_player_stop(VideoPlayer *player) {
 }
 
 ErrorCode video_player_seek_relative_ms(VideoPlayer *player, gint64 delta_ms) {
-    if (!player || !player->has_video || !player->format_context || !player->codec_context ||
+    if (!player || !video_player_has_video(player) || !player->format_context || !player->codec_context ||
         player->video_stream_index < 0 || !player->format_context->streams ||
         !player->format_context->streams[player->video_stream_index]) {
         return ERROR_INVALID_ARGS;
@@ -2200,9 +2276,12 @@ ErrorCode video_player_seek_relative_ms(VideoPlayer *player, gint64 delta_ms) {
     gboolean restart_from_eof = !was_playing && video_player_is_eof_ended(player);
 
     if (was_playing || restart_from_eof) {
-        if (player->timer_id != 0) {
-            g_source_remove(player->timer_id);
-            player->timer_id = 0;
+        g_mutex_lock(&player->state_mutex);
+        guint timer_id = player->timer_id;
+        player->timer_id = 0;
+        g_mutex_unlock(&player->state_mutex);
+        if (timer_id != 0) {
+            g_source_remove(timer_id);
         }
         video_player_stop_worker_internal(player, FALSE);
     }
@@ -2222,8 +2301,8 @@ ErrorCode video_player_seek_relative_ms(VideoPlayer *player, gint64 delta_ms) {
     player->fixed_frame_valid = FALSE;
     player->last_frame_top_row = 0;
     player->last_frame_height = 0;
-    g_mutex_unlock(&player->state_mutex);
     video_player_clear_line_cache(player);
+    g_mutex_unlock(&player->state_mutex);
 
     if (was_playing) {
         video_player_resume_playback_loop(player);
@@ -2238,19 +2317,39 @@ ErrorCode video_player_seek_relative_ms(VideoPlayer *player, gint64 delta_ms) {
 }
 
 gboolean video_player_is_playing(const VideoPlayer *player) {
-    return player && player->is_playing;
+    if (!player) {
+        return FALSE;
+    }
+
+    VideoPlayer *mutable_player = (VideoPlayer*)player;
+    g_mutex_lock(&mutable_player->state_mutex);
+    gboolean is_playing = mutable_player->is_playing;
+    g_mutex_unlock(&mutable_player->state_mutex);
+    return is_playing;
 }
 
 gboolean video_player_has_video(const VideoPlayer *player) {
-    return player && player->has_video;
+    if (!player) {
+        return FALSE;
+    }
+
+    VideoPlayer *mutable_player = (VideoPlayer*)player;
+    g_mutex_lock(&mutable_player->state_mutex);
+    gboolean has_video = mutable_player->has_video;
+    g_mutex_unlock(&mutable_player->state_mutex);
+    return has_video;
 }
 
 ErrorCode video_player_update_terminal_size(VideoPlayer *player) {
-    if (!player || !player->renderer) {
+    if (!player) {
         return ERROR_INVALID_IMAGE;
     }
 
     g_mutex_lock(&player->render_mutex);
+    if (!player->renderer) {
+        g_mutex_unlock(&player->render_mutex);
+        return ERROR_INVALID_IMAGE;
+    }
     ErrorCode result = renderer_update_terminal_size(player->renderer);
     g_mutex_unlock(&player->render_mutex);
     return result;

--- a/tests/test_preloader.c
+++ b/tests/test_preloader.c
@@ -195,6 +195,27 @@ static void test_preloader_stop_clears_pending_tasks(void) {
 static void test_preloader_cache_cleanup_public_wrapper_enforces_limit(void) {
     ImagePreloader *preloader = preloader_create();
     g_assert_nonnull(preloader);
+    preloader->max_cache_size = 2;
+
+    GString *first = g_string_new("first");
+    GString *second = g_string_new("second");
+    preloader_cache_add(preloader, "first.png", first, 7, 3, FALSE, 10, 5);
+    preloader_cache_add(preloader, "second.png", second, 7, 3, FALSE, 10, 5);
+    g_string_free(first, TRUE);
+    g_string_free(second, TRUE);
+
+    preloader->max_cache_size = 1;
+    g_assert_cmpuint(g_hash_table_size(preloader->preload_cache), ==, 2);
+
+    preloader_cache_cleanup(preloader);
+    g_assert_cmpuint(g_hash_table_size(preloader->preload_cache), ==, 1);
+
+    preloader_destroy(preloader);
+}
+
+static void test_preloader_cache_add_enforces_limit_after_insert(void) {
+    ImagePreloader *preloader = preloader_create();
+    g_assert_nonnull(preloader);
     preloader->max_cache_size = 1;
 
     GString *first = g_string_new("first");
@@ -204,8 +225,13 @@ static void test_preloader_cache_cleanup_public_wrapper_enforces_limit(void) {
     g_string_free(first, TRUE);
     g_string_free(second, TRUE);
 
-    preloader_cache_cleanup(preloader);
     g_assert_cmpuint(g_hash_table_size(preloader->preload_cache), ==, 1);
+    g_assert_null(preloader_get_cached_image(preloader, "first.png", 10, 5));
+
+    GString *cached = preloader_get_cached_image(preloader, "second.png", 10, 5);
+    g_assert_nonnull(cached);
+    g_assert_cmpstr(cached->str, ==, "second");
+    g_string_free(cached, TRUE);
 
     preloader_destroy(preloader);
 }
@@ -231,4 +257,6 @@ void register_preloader_tests(void) {
                     test_preloader_stop_clears_pending_tasks);
     g_test_add_func("/preloader/cache_cleanup/public_wrapper_enforces_limit",
                     test_preloader_cache_cleanup_public_wrapper_enforces_limit);
+    g_test_add_func("/preloader/cache_add/enforces_limit_after_insert",
+                    test_preloader_cache_add_enforces_limit_after_insert);
 }

--- a/tests/test_preloader.c
+++ b/tests/test_preloader.c
@@ -178,6 +178,38 @@ static void test_preloader_get_cached_render_info_miss_resets_dimensions(void) {
     preloader_destroy(preloader);
 }
 
+static void test_preloader_stop_clears_pending_tasks(void) {
+    ImagePreloader *preloader = preloader_create();
+    g_assert_nonnull(preloader);
+
+    g_assert_cmpint(preloader_add_task(preloader, "one.png", 1, 10, 5), ==, ERROR_NONE);
+    g_assert_cmpint(preloader_add_task(preloader, "two.png", 2, 10, 5), ==, ERROR_NONE);
+    g_assert_cmpuint(g_queue_get_length(preloader->task_queue), ==, 2);
+
+    g_assert_cmpint(preloader_stop(preloader), ==, ERROR_NONE);
+    g_assert_cmpuint(g_queue_get_length(preloader->task_queue), ==, 0);
+
+    preloader_destroy(preloader);
+}
+
+static void test_preloader_cache_cleanup_public_wrapper_enforces_limit(void) {
+    ImagePreloader *preloader = preloader_create();
+    g_assert_nonnull(preloader);
+    preloader->max_cache_size = 1;
+
+    GString *first = g_string_new("first");
+    GString *second = g_string_new("second");
+    preloader_cache_add(preloader, "first.png", first, 7, 3, FALSE, 10, 5);
+    preloader_cache_add(preloader, "second.png", second, 7, 3, FALSE, 10, 5);
+    g_string_free(first, TRUE);
+    g_string_free(second, TRUE);
+
+    preloader_cache_cleanup(preloader);
+    g_assert_cmpuint(g_hash_table_size(preloader->preload_cache), ==, 1);
+
+    preloader_destroy(preloader);
+}
+
 void register_preloader_tests(void) {
     g_test_add_func("/preloader/get_cached_image/caller_owned_copy",
                     test_preloader_get_cached_image_returns_caller_owned_copy);
@@ -195,4 +227,8 @@ void register_preloader_tests(void) {
                     test_preloader_get_cached_render_info_miss_resets_graphics_mode);
     g_test_add_func("/preloader/get_cached_render_info/miss_resets_dimensions",
                     test_preloader_get_cached_render_info_miss_resets_dimensions);
+    g_test_add_func("/preloader/stop/clears_pending_tasks",
+                    test_preloader_stop_clears_pending_tasks);
+    g_test_add_func("/preloader/cache_cleanup/public_wrapper_enforces_limit",
+                    test_preloader_cache_cleanup_public_wrapper_enforces_limit);
 }

--- a/tests/test_video_player.c
+++ b/tests/test_video_player.c
@@ -103,6 +103,7 @@ typedef struct {
     GMutex mutex;
     GCond cond;
     gboolean started;
+    gboolean finished;
 } ParkedWorkerCall;
 
 static VideoFrame *make_test_frame(gint64 pts_ms);
@@ -296,6 +297,11 @@ static gpointer parked_worker_thread_main(gpointer user_data) {
         g_cond_wait(&call->player->frame_queue_has_space, &call->player->queue_mutex);
     }
     g_mutex_unlock(&call->player->queue_mutex);
+
+    g_mutex_lock(&call->mutex);
+    call->finished = TRUE;
+    g_cond_broadcast(&call->cond);
+    g_mutex_unlock(&call->mutex);
     return NULL;
 }
 
@@ -306,6 +312,7 @@ static GThread *start_parked_worker_for_test(const gchar *name, ParkedWorkerCall
 
     call->player = player;
     call->started = FALSE;
+    call->finished = FALSE;
     g_mutex_init(&call->mutex);
     g_cond_init(&call->cond);
 
@@ -1292,6 +1299,18 @@ static void test_set_renderer_restarts_workers_when_replacing_during_playback(vo
 
     video_player_set_renderer(player, replacement);
 
+    wait_for_flag_or_fail(&decode_call.mutex,
+                          &decode_call.cond,
+                          &decode_call.finished,
+                          "Timed out waiting for replaced decode worker to stop");
+    wait_for_flag_or_fail(&render_a_call.mutex,
+                          &render_a_call.cond,
+                          &render_a_call.finished,
+                          "Timed out waiting for replaced render worker A to stop");
+    wait_for_flag_or_fail(&render_b_call.mutex,
+                          &render_b_call.cond,
+                          &render_b_call.finished,
+                          "Timed out waiting for replaced render worker B to stop");
     g_assert_nonnull(player->worker_thread);
     g_assert_true(player->render_workers_started);
     g_assert_nonnull(player->render_workers[0]);

--- a/tests/test_video_player.c
+++ b/tests/test_video_player.c
@@ -1264,6 +1264,47 @@ static void test_play_after_eof_rewinds_explicitly_to_start(void) {
     video_player_destroy(player);
 }
 
+static void test_set_renderer_restarts_workers_when_replacing_during_playback(void) {
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    if (!player) {
+        g_test_skip("video player unavailable");
+        return;
+    }
+
+    ImageRenderer *replacement = renderer_create();
+    if (!replacement) {
+        video_player_destroy(player);
+        g_test_skip("renderer unavailable");
+        return;
+    }
+
+    ParkedWorkerCall decode_call = {0};
+    ParkedWorkerCall render_a_call = {0};
+    ParkedWorkerCall render_b_call = {0};
+
+    g_mutex_lock(&player->state_mutex);
+    player->is_playing = TRUE;
+    g_mutex_unlock(&player->state_mutex);
+    player->worker_thread = start_parked_worker_for_test("parked-decode-renderer-test", &decode_call, player);
+    player->render_workers[0] = start_parked_worker_for_test("parked-render-a-renderer-test", &render_a_call, player);
+    player->render_workers[1] = start_parked_worker_for_test("parked-render-b-renderer-test", &render_b_call, player);
+    player->render_workers_started = TRUE;
+
+    video_player_set_renderer(player, replacement);
+
+    g_assert_nonnull(player->worker_thread);
+    g_assert_true(player->render_workers_started);
+    g_assert_nonnull(player->render_workers[0]);
+    g_assert_nonnull(player->render_workers[1]);
+
+    video_player_stop(player);
+    renderer_destroy(replacement);
+    clear_parked_worker_for_test(&render_b_call);
+    clear_parked_worker_for_test(&render_a_call);
+    clear_parked_worker_for_test(&decode_call);
+    video_player_destroy(player);
+}
+
 static void test_seek_relative_after_eof_stops_parked_workers_before_preview(void) {
     VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
     if (!player) {
@@ -2341,6 +2382,8 @@ void register_video_player_tests(void) {
                     test_seek_relative_resets_visual_state_under_state_mutex);
     g_test_add_func("/video_player/play/after_eof_rewinds_explicitly_to_start",
                     test_play_after_eof_rewinds_explicitly_to_start);
+    g_test_add_func("/video_player/set_renderer/restarts_workers_when_replacing_during_playback",
+                    test_set_renderer_restarts_workers_when_replacing_during_playback);
     g_test_add_func("/video_player/seek_relative/after_eof_stops_parked_workers_before_preview",
                     test_seek_relative_after_eof_stops_parked_workers_before_preview);
     g_test_add_func("/video_player/seek_relative/after_eof_real_preview_does_not_crash",


### PR DESCRIPTION
## Summary
- add the requested code review report under docs/project
- harden video playback shared state and renderer replacement synchronization
- lock preloader config/cache cleanup paths, clear stop queues, clamp MuPDF target pixels, and clarify media rejection log limit

## Tests
- make test

## Summary by Sourcery

在视频播放、图片预加载、文档渲染和媒体缓冲等多媒体模块中加强并发与资源管理，同时新增书面代码审查报告。

Bug 修复：
- 在工作线程、GLib 超时回调以及公共 API 之间同步 VideoPlayer 共享状态、计时器、draining 标志和渲染器的使用，防止在播放和更换渲染器过程中出现竞态条件和无效访问。
- 使用内部锁保护预加载器配置、队列操作和缓存清理，确保工作线程看到一致的设置，并避免共享结构被并发修改。
- 限制从终端几何信息推导出的 MuPDF 目标页面像素尺寸，使其处于安全范围内，以避免尺寸非法或溢出。
- 修正媒体缓冲拒绝日志的限流逻辑，使日志抑制行为与配置的最大日志条数保持一致。

增强：
- 为 VideoPlayer 增加线程安全的访问器和辅助方法，用于访问播放标志、渲染器存在与否、draining 状态以及渲染布局，从而封装并发访问模式。
- 将可变的预加载器配置快照到工作线程本地的渲染器设置中，使长时间运行的任务与实时配置变更解耦，并依赖一致的参数。

文档：
- 在 docs/project 下添加详细的代码审查报告，描述并发风险、共享状态的所有权，以及对媒体、预加载器和渲染路径的后续改进建议。

测试：
- 扩展预加载器测试，用于覆盖在 stop 时清理待处理任务，以及通过公共清理封装器和缓存插入行为两种途径来验证缓存大小限制的执行。
- 添加一个 VideoPlayer 回归测试，用于验证在播放过程中更换渲染器时，工作线程能够安全地停止并重新启动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden multimedia concurrency and resource management across video playback, image preloading, document rendering, and media buffering while adding a written code review report.

Bug Fixes:
- Synchronize VideoPlayer shared state, timers, draining flag, and renderer usage across worker threads, GLib timeouts, and public APIs to prevent races and invalid access during playback and renderer replacement.
- Guard preloader configuration, queue operations, and cache cleanup with internal locking so workers see consistent settings and shared structures are not modified concurrently.
- Clamp MuPDF target page pixel dimensions derived from terminal geometry to a safe range to avoid invalid or overflowing sizes.
- Correct media buffer rejection log limiting so suppression behavior matches the configured maximum number of log messages.

Enhancements:
- Introduce thread-safe VideoPlayer accessors and helpers around playback flags, renderer presence, draining state, and render layout to encapsulate concurrent access patterns.
- Snapshot mutable preloader configuration into worker-local renderer settings so long-running tasks are decoupled from live configuration changes and rely on consistent parameters.

Documentation:
- Add a detailed code review report under docs/project describing concurrency risks, shared state ownership, and follow-up recommendations for media, preloader, and rendering paths.

Tests:
- Extend preloader tests to cover clearing pending tasks on stop and enforcement of cache size limits via both the public cleanup wrapper and cache insertion behavior.
- Add a VideoPlayer regression test that verifies workers are safely stopped and restarted when replacing the renderer during playback.

</details>

**Bug 修复：**
- 在各个工作线程与 GLib 超时回调之间，对 `VideoPlayer` 的共享状态、定时器和 draining 标志进行同步，并将渲染器替换流程与工作线程生命周期进行协调，以避免竞争条件和非法访问。
- 使用内部锁机制保护预加载器配置、缓存清理以及任务队列操作，并对由终端几何尺寸推导出的 MuPDF 页面目标像素尺寸进行限制，使其保持在安全范围内。
- 修正媒体缓冲区拒绝日志的限制逻辑，使日志抑制行为与配置的最大值一致。

**增强：**
- 为 `VideoPlayer` 引入线程安全的访问器和辅助工具，用于围绕播放标志、渲染器存在性以及 draining 状态进行操作，并将预加载器配置快照进工作线程本地的渲染器设置，从而将长时间运行的任务与实时配置变更解耦。

**文档：**
- 在 `docs/project` 下新增一份详细的代码审查报告，描述并发风险、共享状态的所有权以及在媒体、预加载和渲染路径上的后续改进建议。

**测试：**
- 扩展预加载器测试，覆盖在停止时清理未决任务以及缓存大小限制的执行情况，并新增一个视频播放器回归测试，以确保在播放期间更换渲染器时，工作线程能够被安全地重启。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在视频播放、图片预加载、文档渲染和媒体缓冲等多媒体模块中加强并发与资源管理，同时新增书面代码审查报告。

Bug 修复：
- 在工作线程、GLib 超时回调以及公共 API 之间同步 VideoPlayer 共享状态、计时器、draining 标志和渲染器的使用，防止在播放和更换渲染器过程中出现竞态条件和无效访问。
- 使用内部锁保护预加载器配置、队列操作和缓存清理，确保工作线程看到一致的设置，并避免共享结构被并发修改。
- 限制从终端几何信息推导出的 MuPDF 目标页面像素尺寸，使其处于安全范围内，以避免尺寸非法或溢出。
- 修正媒体缓冲拒绝日志的限流逻辑，使日志抑制行为与配置的最大日志条数保持一致。

增强：
- 为 VideoPlayer 增加线程安全的访问器和辅助方法，用于访问播放标志、渲染器存在与否、draining 状态以及渲染布局，从而封装并发访问模式。
- 将可变的预加载器配置快照到工作线程本地的渲染器设置中，使长时间运行的任务与实时配置变更解耦，并依赖一致的参数。

文档：
- 在 docs/project 下添加详细的代码审查报告，描述并发风险、共享状态的所有权，以及对媒体、预加载器和渲染路径的后续改进建议。

测试：
- 扩展预加载器测试，用于覆盖在 stop 时清理待处理任务，以及通过公共清理封装器和缓存插入行为两种途径来验证缓存大小限制的执行。
- 添加一个 VideoPlayer 回归测试，用于验证在播放过程中更换渲染器时，工作线程能够安全地停止并重新启动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden multimedia concurrency and resource management across video playback, image preloading, document rendering, and media buffering while adding a written code review report.

Bug Fixes:
- Synchronize VideoPlayer shared state, timers, draining flag, and renderer usage across worker threads, GLib timeouts, and public APIs to prevent races and invalid access during playback and renderer replacement.
- Guard preloader configuration, queue operations, and cache cleanup with internal locking so workers see consistent settings and shared structures are not modified concurrently.
- Clamp MuPDF target page pixel dimensions derived from terminal geometry to a safe range to avoid invalid or overflowing sizes.
- Correct media buffer rejection log limiting so suppression behavior matches the configured maximum number of log messages.

Enhancements:
- Introduce thread-safe VideoPlayer accessors and helpers around playback flags, renderer presence, draining state, and render layout to encapsulate concurrent access patterns.
- Snapshot mutable preloader configuration into worker-local renderer settings so long-running tasks are decoupled from live configuration changes and rely on consistent parameters.

Documentation:
- Add a detailed code review report under docs/project describing concurrency risks, shared state ownership, and follow-up recommendations for media, preloader, and rendering paths.

Tests:
- Extend preloader tests to cover clearing pending tasks on stop and enforcement of cache size limits via both the public cleanup wrapper and cache insertion behavior.
- Add a VideoPlayer regression test that verifies workers are safely stopped and restarted when replacing the renderer during playback.

</details>

</details>

Bug 修复：
- 在 worker 线程、GLib 超时回调和公共 API 之间同步 `VideoPlayer` 的共享状态，包括播放标志、定时器、排空（draining）状态和布局字段，防止数据竞争和不一致的播放行为。
- 将视频渲染器的替换与 worker 的生命周期进行协调，避免 worker 在线程仍运行时访问已销毁或已被替换的渲染器。
- 使用内部锁保护预加载器配置、缓存清理和队列管理，确保 worker 线程看到一致的设置，并防止共享结构被并发修改。
- 将由终端单元格几何信息推导出的 MuPDF 页面目标像素尺寸限制在合理范围内，避免无效或溢出的尺寸。
- 修正媒体缓冲区拒绝日志的限制，使日志抑制行为与预期的最大日志条数保持一致。

增强：
- 为 `VideoPlayer` 引入线程安全的访问器和围绕共享标志及渲染器存在性的辅助函数，以封装并发访问模式。
- 在处理任务之前，将可变的预加载器配置快照到 worker 本地的渲染器配置中，使长时间运行的工作与实时配置变更解耦。

文档：
- 在 `docs/project` 下添加一份详细的代码审查报告，说明并发风险、共享状态所有权问题，以及针对媒体、预加载和渲染路径的后续建议。

测试：
- 扩展预加载器测试，用于验证在停止预加载器时会清除所有挂起任务，并且公共的缓存清理封装函数会强制执行已配置的缓存大小上限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在视频播放、图片预加载、文档渲染和媒体缓冲等多媒体模块中加强并发与资源管理，同时新增书面代码审查报告。

Bug 修复：
- 在工作线程、GLib 超时回调以及公共 API 之间同步 VideoPlayer 共享状态、计时器、draining 标志和渲染器的使用，防止在播放和更换渲染器过程中出现竞态条件和无效访问。
- 使用内部锁保护预加载器配置、队列操作和缓存清理，确保工作线程看到一致的设置，并避免共享结构被并发修改。
- 限制从终端几何信息推导出的 MuPDF 目标页面像素尺寸，使其处于安全范围内，以避免尺寸非法或溢出。
- 修正媒体缓冲拒绝日志的限流逻辑，使日志抑制行为与配置的最大日志条数保持一致。

增强：
- 为 VideoPlayer 增加线程安全的访问器和辅助方法，用于访问播放标志、渲染器存在与否、draining 状态以及渲染布局，从而封装并发访问模式。
- 将可变的预加载器配置快照到工作线程本地的渲染器设置中，使长时间运行的任务与实时配置变更解耦，并依赖一致的参数。

文档：
- 在 docs/project 下添加详细的代码审查报告，描述并发风险、共享状态的所有权，以及对媒体、预加载器和渲染路径的后续改进建议。

测试：
- 扩展预加载器测试，用于覆盖在 stop 时清理待处理任务，以及通过公共清理封装器和缓存插入行为两种途径来验证缓存大小限制的执行。
- 添加一个 VideoPlayer 回归测试，用于验证在播放过程中更换渲染器时，工作线程能够安全地停止并重新启动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden multimedia concurrency and resource management across video playback, image preloading, document rendering, and media buffering while adding a written code review report.

Bug Fixes:
- Synchronize VideoPlayer shared state, timers, draining flag, and renderer usage across worker threads, GLib timeouts, and public APIs to prevent races and invalid access during playback and renderer replacement.
- Guard preloader configuration, queue operations, and cache cleanup with internal locking so workers see consistent settings and shared structures are not modified concurrently.
- Clamp MuPDF target page pixel dimensions derived from terminal geometry to a safe range to avoid invalid or overflowing sizes.
- Correct media buffer rejection log limiting so suppression behavior matches the configured maximum number of log messages.

Enhancements:
- Introduce thread-safe VideoPlayer accessors and helpers around playback flags, renderer presence, draining state, and render layout to encapsulate concurrent access patterns.
- Snapshot mutable preloader configuration into worker-local renderer settings so long-running tasks are decoupled from live configuration changes and rely on consistent parameters.

Documentation:
- Add a detailed code review report under docs/project describing concurrency risks, shared state ownership, and follow-up recommendations for media, preloader, and rendering paths.

Tests:
- Extend preloader tests to cover clearing pending tasks on stop and enforcement of cache size limits via both the public cleanup wrapper and cache insertion behavior.
- Add a VideoPlayer regression test that verifies workers are safely stopped and restarted when replacing the renderer during playback.

</details>

**Bug 修复：**
- 在各个工作线程与 GLib 超时回调之间，对 `VideoPlayer` 的共享状态、定时器和 draining 标志进行同步，并将渲染器替换流程与工作线程生命周期进行协调，以避免竞争条件和非法访问。
- 使用内部锁机制保护预加载器配置、缓存清理以及任务队列操作，并对由终端几何尺寸推导出的 MuPDF 页面目标像素尺寸进行限制，使其保持在安全范围内。
- 修正媒体缓冲区拒绝日志的限制逻辑，使日志抑制行为与配置的最大值一致。

**增强：**
- 为 `VideoPlayer` 引入线程安全的访问器和辅助工具，用于围绕播放标志、渲染器存在性以及 draining 状态进行操作，并将预加载器配置快照进工作线程本地的渲染器设置，从而将长时间运行的任务与实时配置变更解耦。

**文档：**
- 在 `docs/project` 下新增一份详细的代码审查报告，描述并发风险、共享状态的所有权以及在媒体、预加载和渲染路径上的后续改进建议。

**测试：**
- 扩展预加载器测试，覆盖在停止时清理未决任务以及缓存大小限制的执行情况，并新增一个视频播放器回归测试，以确保在播放期间更换渲染器时，工作线程能够被安全地重启。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在视频播放、图片预加载、文档渲染和媒体缓冲等多媒体模块中加强并发与资源管理，同时新增书面代码审查报告。

Bug 修复：
- 在工作线程、GLib 超时回调以及公共 API 之间同步 VideoPlayer 共享状态、计时器、draining 标志和渲染器的使用，防止在播放和更换渲染器过程中出现竞态条件和无效访问。
- 使用内部锁保护预加载器配置、队列操作和缓存清理，确保工作线程看到一致的设置，并避免共享结构被并发修改。
- 限制从终端几何信息推导出的 MuPDF 目标页面像素尺寸，使其处于安全范围内，以避免尺寸非法或溢出。
- 修正媒体缓冲拒绝日志的限流逻辑，使日志抑制行为与配置的最大日志条数保持一致。

增强：
- 为 VideoPlayer 增加线程安全的访问器和辅助方法，用于访问播放标志、渲染器存在与否、draining 状态以及渲染布局，从而封装并发访问模式。
- 将可变的预加载器配置快照到工作线程本地的渲染器设置中，使长时间运行的任务与实时配置变更解耦，并依赖一致的参数。

文档：
- 在 docs/project 下添加详细的代码审查报告，描述并发风险、共享状态的所有权，以及对媒体、预加载器和渲染路径的后续改进建议。

测试：
- 扩展预加载器测试，用于覆盖在 stop 时清理待处理任务，以及通过公共清理封装器和缓存插入行为两种途径来验证缓存大小限制的执行。
- 添加一个 VideoPlayer 回归测试，用于验证在播放过程中更换渲染器时，工作线程能够安全地停止并重新启动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden multimedia concurrency and resource management across video playback, image preloading, document rendering, and media buffering while adding a written code review report.

Bug Fixes:
- Synchronize VideoPlayer shared state, timers, draining flag, and renderer usage across worker threads, GLib timeouts, and public APIs to prevent races and invalid access during playback and renderer replacement.
- Guard preloader configuration, queue operations, and cache cleanup with internal locking so workers see consistent settings and shared structures are not modified concurrently.
- Clamp MuPDF target page pixel dimensions derived from terminal geometry to a safe range to avoid invalid or overflowing sizes.
- Correct media buffer rejection log limiting so suppression behavior matches the configured maximum number of log messages.

Enhancements:
- Introduce thread-safe VideoPlayer accessors and helpers around playback flags, renderer presence, draining state, and render layout to encapsulate concurrent access patterns.
- Snapshot mutable preloader configuration into worker-local renderer settings so long-running tasks are decoupled from live configuration changes and rely on consistent parameters.

Documentation:
- Add a detailed code review report under docs/project describing concurrency risks, shared state ownership, and follow-up recommendations for media, preloader, and rendering paths.

Tests:
- Extend preloader tests to cover clearing pending tasks on stop and enforcement of cache size limits via both the public cleanup wrapper and cache insertion behavior.
- Add a VideoPlayer regression test that verifies workers are safely stopped and restarted when replacing the renderer during playback.

</details>

</details>

</details>

Bug 修复：
- 在工作线程、GLib 超时回调以及公共 API 调用之间同步 VideoPlayer 共享状态的访问（播放标志、定时器、排空过程、渲染器存在性以及布局相关字段），以避免数据竞争和不一致的播放行为。
- 确保视频播放器的渲染器替换与工作线程生命周期协同进行，防止在渲染器已销毁或被替换后仍被并发使用。
- 使用内部互斥锁保护预加载器配置、缓存清理以及队列管理，确保工作线程看到一致的配置设置，并避免对共享数据结构的并发修改。
- 对由终端单元格计算出的 MuPDF 目标像素尺寸进行限制，使其保持在合理范围内，避免产生无效或溢出的尺寸。
- 明确并修正媒体缓冲区拒绝日志的输出上限，使日志抑制行为与预期的最大日志条数相匹配。

增强：
- 将可变的预加载器配置快照到工作线程本地的渲染器配置中，将长时间运行的工作与实时配置更改解耦，并减少竞争。
- 优化视频播放控制流程，使用辅助访问器来操作状态标志，从而在并发敏感字段周围提供更好的封装。

文档：
- 新增一份详细的代码审查报告，记录视频播放、预加载、文档渲染以及媒体缓冲行为中的竞态风险、共享状态所有权问题以及后续改进建议。

测试：
- 新增回归测试，确保预加载器的停止操作会清理挂起任务，并验证公共缓存清理操作会强制执行配置的缓存大小上限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在视频播放、图片预加载、文档渲染和媒体缓冲等多媒体模块中加强并发与资源管理，同时新增书面代码审查报告。

Bug 修复：
- 在工作线程、GLib 超时回调以及公共 API 之间同步 VideoPlayer 共享状态、计时器、draining 标志和渲染器的使用，防止在播放和更换渲染器过程中出现竞态条件和无效访问。
- 使用内部锁保护预加载器配置、队列操作和缓存清理，确保工作线程看到一致的设置，并避免共享结构被并发修改。
- 限制从终端几何信息推导出的 MuPDF 目标页面像素尺寸，使其处于安全范围内，以避免尺寸非法或溢出。
- 修正媒体缓冲拒绝日志的限流逻辑，使日志抑制行为与配置的最大日志条数保持一致。

增强：
- 为 VideoPlayer 增加线程安全的访问器和辅助方法，用于访问播放标志、渲染器存在与否、draining 状态以及渲染布局，从而封装并发访问模式。
- 将可变的预加载器配置快照到工作线程本地的渲染器设置中，使长时间运行的任务与实时配置变更解耦，并依赖一致的参数。

文档：
- 在 docs/project 下添加详细的代码审查报告，描述并发风险、共享状态的所有权，以及对媒体、预加载器和渲染路径的后续改进建议。

测试：
- 扩展预加载器测试，用于覆盖在 stop 时清理待处理任务，以及通过公共清理封装器和缓存插入行为两种途径来验证缓存大小限制的执行。
- 添加一个 VideoPlayer 回归测试，用于验证在播放过程中更换渲染器时，工作线程能够安全地停止并重新启动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden multimedia concurrency and resource management across video playback, image preloading, document rendering, and media buffering while adding a written code review report.

Bug Fixes:
- Synchronize VideoPlayer shared state, timers, draining flag, and renderer usage across worker threads, GLib timeouts, and public APIs to prevent races and invalid access during playback and renderer replacement.
- Guard preloader configuration, queue operations, and cache cleanup with internal locking so workers see consistent settings and shared structures are not modified concurrently.
- Clamp MuPDF target page pixel dimensions derived from terminal geometry to a safe range to avoid invalid or overflowing sizes.
- Correct media buffer rejection log limiting so suppression behavior matches the configured maximum number of log messages.

Enhancements:
- Introduce thread-safe VideoPlayer accessors and helpers around playback flags, renderer presence, draining state, and render layout to encapsulate concurrent access patterns.
- Snapshot mutable preloader configuration into worker-local renderer settings so long-running tasks are decoupled from live configuration changes and rely on consistent parameters.

Documentation:
- Add a detailed code review report under docs/project describing concurrency risks, shared state ownership, and follow-up recommendations for media, preloader, and rendering paths.

Tests:
- Extend preloader tests to cover clearing pending tasks on stop and enforcement of cache size limits via both the public cleanup wrapper and cache insertion behavior.
- Add a VideoPlayer regression test that verifies workers are safely stopped and restarted when replacing the renderer during playback.

</details>

**Bug 修复：**
- 在各个工作线程与 GLib 超时回调之间，对 `VideoPlayer` 的共享状态、定时器和 draining 标志进行同步，并将渲染器替换流程与工作线程生命周期进行协调，以避免竞争条件和非法访问。
- 使用内部锁机制保护预加载器配置、缓存清理以及任务队列操作，并对由终端几何尺寸推导出的 MuPDF 页面目标像素尺寸进行限制，使其保持在安全范围内。
- 修正媒体缓冲区拒绝日志的限制逻辑，使日志抑制行为与配置的最大值一致。

**增强：**
- 为 `VideoPlayer` 引入线程安全的访问器和辅助工具，用于围绕播放标志、渲染器存在性以及 draining 状态进行操作，并将预加载器配置快照进工作线程本地的渲染器设置，从而将长时间运行的任务与实时配置变更解耦。

**文档：**
- 在 `docs/project` 下新增一份详细的代码审查报告，描述并发风险、共享状态的所有权以及在媒体、预加载和渲染路径上的后续改进建议。

**测试：**
- 扩展预加载器测试，覆盖在停止时清理未决任务以及缓存大小限制的执行情况，并新增一个视频播放器回归测试，以确保在播放期间更换渲染器时，工作线程能够被安全地重启。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在视频播放、图片预加载、文档渲染和媒体缓冲等多媒体模块中加强并发与资源管理，同时新增书面代码审查报告。

Bug 修复：
- 在工作线程、GLib 超时回调以及公共 API 之间同步 VideoPlayer 共享状态、计时器、draining 标志和渲染器的使用，防止在播放和更换渲染器过程中出现竞态条件和无效访问。
- 使用内部锁保护预加载器配置、队列操作和缓存清理，确保工作线程看到一致的设置，并避免共享结构被并发修改。
- 限制从终端几何信息推导出的 MuPDF 目标页面像素尺寸，使其处于安全范围内，以避免尺寸非法或溢出。
- 修正媒体缓冲拒绝日志的限流逻辑，使日志抑制行为与配置的最大日志条数保持一致。

增强：
- 为 VideoPlayer 增加线程安全的访问器和辅助方法，用于访问播放标志、渲染器存在与否、draining 状态以及渲染布局，从而封装并发访问模式。
- 将可变的预加载器配置快照到工作线程本地的渲染器设置中，使长时间运行的任务与实时配置变更解耦，并依赖一致的参数。

文档：
- 在 docs/project 下添加详细的代码审查报告，描述并发风险、共享状态的所有权，以及对媒体、预加载器和渲染路径的后续改进建议。

测试：
- 扩展预加载器测试，用于覆盖在 stop 时清理待处理任务，以及通过公共清理封装器和缓存插入行为两种途径来验证缓存大小限制的执行。
- 添加一个 VideoPlayer 回归测试，用于验证在播放过程中更换渲染器时，工作线程能够安全地停止并重新启动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden multimedia concurrency and resource management across video playback, image preloading, document rendering, and media buffering while adding a written code review report.

Bug Fixes:
- Synchronize VideoPlayer shared state, timers, draining flag, and renderer usage across worker threads, GLib timeouts, and public APIs to prevent races and invalid access during playback and renderer replacement.
- Guard preloader configuration, queue operations, and cache cleanup with internal locking so workers see consistent settings and shared structures are not modified concurrently.
- Clamp MuPDF target page pixel dimensions derived from terminal geometry to a safe range to avoid invalid or overflowing sizes.
- Correct media buffer rejection log limiting so suppression behavior matches the configured maximum number of log messages.

Enhancements:
- Introduce thread-safe VideoPlayer accessors and helpers around playback flags, renderer presence, draining state, and render layout to encapsulate concurrent access patterns.
- Snapshot mutable preloader configuration into worker-local renderer settings so long-running tasks are decoupled from live configuration changes and rely on consistent parameters.

Documentation:
- Add a detailed code review report under docs/project describing concurrency risks, shared state ownership, and follow-up recommendations for media, preloader, and rendering paths.

Tests:
- Extend preloader tests to cover clearing pending tasks on stop and enforcement of cache size limits via both the public cleanup wrapper and cache insertion behavior.
- Add a VideoPlayer regression test that verifies workers are safely stopped and restarted when replacing the renderer during playback.

</details>

</details>

Bug 修复：
- 在 worker 线程、GLib 超时回调和公共 API 之间同步 `VideoPlayer` 的共享状态，包括播放标志、定时器、排空（draining）状态和布局字段，防止数据竞争和不一致的播放行为。
- 将视频渲染器的替换与 worker 的生命周期进行协调，避免 worker 在线程仍运行时访问已销毁或已被替换的渲染器。
- 使用内部锁保护预加载器配置、缓存清理和队列管理，确保 worker 线程看到一致的设置，并防止共享结构被并发修改。
- 将由终端单元格几何信息推导出的 MuPDF 页面目标像素尺寸限制在合理范围内，避免无效或溢出的尺寸。
- 修正媒体缓冲区拒绝日志的限制，使日志抑制行为与预期的最大日志条数保持一致。

增强：
- 为 `VideoPlayer` 引入线程安全的访问器和围绕共享标志及渲染器存在性的辅助函数，以封装并发访问模式。
- 在处理任务之前，将可变的预加载器配置快照到 worker 本地的渲染器配置中，使长时间运行的工作与实时配置变更解耦。

文档：
- 在 `docs/project` 下添加一份详细的代码审查报告，说明并发风险、共享状态所有权问题，以及针对媒体、预加载和渲染路径的后续建议。

测试：
- 扩展预加载器测试，用于验证在停止预加载器时会清除所有挂起任务，并且公共的缓存清理封装函数会强制执行已配置的缓存大小上限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在视频播放、图片预加载、文档渲染和媒体缓冲等多媒体模块中加强并发与资源管理，同时新增书面代码审查报告。

Bug 修复：
- 在工作线程、GLib 超时回调以及公共 API 之间同步 VideoPlayer 共享状态、计时器、draining 标志和渲染器的使用，防止在播放和更换渲染器过程中出现竞态条件和无效访问。
- 使用内部锁保护预加载器配置、队列操作和缓存清理，确保工作线程看到一致的设置，并避免共享结构被并发修改。
- 限制从终端几何信息推导出的 MuPDF 目标页面像素尺寸，使其处于安全范围内，以避免尺寸非法或溢出。
- 修正媒体缓冲拒绝日志的限流逻辑，使日志抑制行为与配置的最大日志条数保持一致。

增强：
- 为 VideoPlayer 增加线程安全的访问器和辅助方法，用于访问播放标志、渲染器存在与否、draining 状态以及渲染布局，从而封装并发访问模式。
- 将可变的预加载器配置快照到工作线程本地的渲染器设置中，使长时间运行的任务与实时配置变更解耦，并依赖一致的参数。

文档：
- 在 docs/project 下添加详细的代码审查报告，描述并发风险、共享状态的所有权，以及对媒体、预加载器和渲染路径的后续改进建议。

测试：
- 扩展预加载器测试，用于覆盖在 stop 时清理待处理任务，以及通过公共清理封装器和缓存插入行为两种途径来验证缓存大小限制的执行。
- 添加一个 VideoPlayer 回归测试，用于验证在播放过程中更换渲染器时，工作线程能够安全地停止并重新启动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden multimedia concurrency and resource management across video playback, image preloading, document rendering, and media buffering while adding a written code review report.

Bug Fixes:
- Synchronize VideoPlayer shared state, timers, draining flag, and renderer usage across worker threads, GLib timeouts, and public APIs to prevent races and invalid access during playback and renderer replacement.
- Guard preloader configuration, queue operations, and cache cleanup with internal locking so workers see consistent settings and shared structures are not modified concurrently.
- Clamp MuPDF target page pixel dimensions derived from terminal geometry to a safe range to avoid invalid or overflowing sizes.
- Correct media buffer rejection log limiting so suppression behavior matches the configured maximum number of log messages.

Enhancements:
- Introduce thread-safe VideoPlayer accessors and helpers around playback flags, renderer presence, draining state, and render layout to encapsulate concurrent access patterns.
- Snapshot mutable preloader configuration into worker-local renderer settings so long-running tasks are decoupled from live configuration changes and rely on consistent parameters.

Documentation:
- Add a detailed code review report under docs/project describing concurrency risks, shared state ownership, and follow-up recommendations for media, preloader, and rendering paths.

Tests:
- Extend preloader tests to cover clearing pending tasks on stop and enforcement of cache size limits via both the public cleanup wrapper and cache insertion behavior.
- Add a VideoPlayer regression test that verifies workers are safely stopped and restarted when replacing the renderer during playback.

</details>

**Bug 修复：**
- 在各个工作线程与 GLib 超时回调之间，对 `VideoPlayer` 的共享状态、定时器和 draining 标志进行同步，并将渲染器替换流程与工作线程生命周期进行协调，以避免竞争条件和非法访问。
- 使用内部锁机制保护预加载器配置、缓存清理以及任务队列操作，并对由终端几何尺寸推导出的 MuPDF 页面目标像素尺寸进行限制，使其保持在安全范围内。
- 修正媒体缓冲区拒绝日志的限制逻辑，使日志抑制行为与配置的最大值一致。

**增强：**
- 为 `VideoPlayer` 引入线程安全的访问器和辅助工具，用于围绕播放标志、渲染器存在性以及 draining 状态进行操作，并将预加载器配置快照进工作线程本地的渲染器设置，从而将长时间运行的任务与实时配置变更解耦。

**文档：**
- 在 `docs/project` 下新增一份详细的代码审查报告，描述并发风险、共享状态的所有权以及在媒体、预加载和渲染路径上的后续改进建议。

**测试：**
- 扩展预加载器测试，覆盖在停止时清理未决任务以及缓存大小限制的执行情况，并新增一个视频播放器回归测试，以确保在播放期间更换渲染器时，工作线程能够被安全地重启。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在视频播放、图片预加载、文档渲染和媒体缓冲等多媒体模块中加强并发与资源管理，同时新增书面代码审查报告。

Bug 修复：
- 在工作线程、GLib 超时回调以及公共 API 之间同步 VideoPlayer 共享状态、计时器、draining 标志和渲染器的使用，防止在播放和更换渲染器过程中出现竞态条件和无效访问。
- 使用内部锁保护预加载器配置、队列操作和缓存清理，确保工作线程看到一致的设置，并避免共享结构被并发修改。
- 限制从终端几何信息推导出的 MuPDF 目标页面像素尺寸，使其处于安全范围内，以避免尺寸非法或溢出。
- 修正媒体缓冲拒绝日志的限流逻辑，使日志抑制行为与配置的最大日志条数保持一致。

增强：
- 为 VideoPlayer 增加线程安全的访问器和辅助方法，用于访问播放标志、渲染器存在与否、draining 状态以及渲染布局，从而封装并发访问模式。
- 将可变的预加载器配置快照到工作线程本地的渲染器设置中，使长时间运行的任务与实时配置变更解耦，并依赖一致的参数。

文档：
- 在 docs/project 下添加详细的代码审查报告，描述并发风险、共享状态的所有权，以及对媒体、预加载器和渲染路径的后续改进建议。

测试：
- 扩展预加载器测试，用于覆盖在 stop 时清理待处理任务，以及通过公共清理封装器和缓存插入行为两种途径来验证缓存大小限制的执行。
- 添加一个 VideoPlayer 回归测试，用于验证在播放过程中更换渲染器时，工作线程能够安全地停止并重新启动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden multimedia concurrency and resource management across video playback, image preloading, document rendering, and media buffering while adding a written code review report.

Bug Fixes:
- Synchronize VideoPlayer shared state, timers, draining flag, and renderer usage across worker threads, GLib timeouts, and public APIs to prevent races and invalid access during playback and renderer replacement.
- Guard preloader configuration, queue operations, and cache cleanup with internal locking so workers see consistent settings and shared structures are not modified concurrently.
- Clamp MuPDF target page pixel dimensions derived from terminal geometry to a safe range to avoid invalid or overflowing sizes.
- Correct media buffer rejection log limiting so suppression behavior matches the configured maximum number of log messages.

Enhancements:
- Introduce thread-safe VideoPlayer accessors and helpers around playback flags, renderer presence, draining state, and render layout to encapsulate concurrent access patterns.
- Snapshot mutable preloader configuration into worker-local renderer settings so long-running tasks are decoupled from live configuration changes and rely on consistent parameters.

Documentation:
- Add a detailed code review report under docs/project describing concurrency risks, shared state ownership, and follow-up recommendations for media, preloader, and rendering paths.

Tests:
- Extend preloader tests to cover clearing pending tasks on stop and enforcement of cache size limits via both the public cleanup wrapper and cache insertion behavior.
- Add a VideoPlayer regression test that verifies workers are safely stopped and restarted when replacing the renderer during playback.

</details>

</details>

</details>

</details>