### PR TITLE
refactor: extract VideoPlayer into decode/layout/playback modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ TEST_LINK_OBJECTS = $(OBJDIR)/common.o $(OBJDIR)/browser.o $(OBJDIR)/renderer.o 
 		$(OBJDIR)/pixbuf_utils.o $(OBJDIR)/media_buffer.o $(OBJDIR)/preloader.o $(OBJDIR)/app_mode.o $(OBJDIR)/input_dispatch_pending_clicks.o \
 		$(OBJDIR)/input_dispatch_delete.o $(OBJDIR)/input_dispatch_core.o $(OBJDIR)/input_dispatch_key_single.o $(OBJDIR)/input_dispatch_key_book.o $(OBJDIR)/input_dispatch_key_file_manager.o $(OBJDIR)/input_dispatch_mouse_modes.o $(OBJDIR)/app_preview_shared.o \
 		$(OBJDIR)/app_media_session.o $(OBJDIR)/app_single_render.o $(OBJDIR)/app_config_runtime.o $(OBJDIR)/media_utils.o $(OBJDIR)/ui_render_utils.o \
-		$(OBJDIR)/video_player_clock.o $(OBJDIR)/video_player_debug.o $(OBJDIR)/video_player_seek.o $(OBJDIR)/video_player.o $(OBJDIR)/terminal_probe.o $(OBJDIR)/terminal_protocols.o $(OBJDIR)/terminal_protocol_resolver.o $(OBJDIR)/app_cli.o $(OBJDIR)/book.o \
+		$(OBJDIR)/video_player_clock.o $(OBJDIR)/video_player_debug.o $(OBJDIR)/video_player_decode.o $(OBJDIR)/video_player_layout.o $(OBJDIR)/video_player_playback.o $(OBJDIR)/video_player_seek.o $(OBJDIR)/video_player.o $(OBJDIR)/terminal_probe.o $(OBJDIR)/terminal_protocols.o $(OBJDIR)/terminal_protocol_resolver.o $(OBJDIR)/app_cli.o $(OBJDIR)/book.o \
 		$(OBJDIR)/app_startup.o
 FILE_MANAGER_TEST_LINK_OBJECTS = $(OBJDIR)/common.o $(OBJDIR)/process_env.o $(OBJDIR)/app_core.o $(OBJDIR)/app_mode.o \
 		$(OBJDIR)/app_file_manager.o $(OBJDIR)/app_file_manager_render.o $(OBJDIR)/text_utils.o

--- a/include/video_player.h
+++ b/include/video_player.h
@@ -28,6 +28,10 @@ typedef struct {
     guint generation;
 } RenderedFrame;
 
+/* Convenience alias used internally for the frame-queue head type.
+ * Centralized here so all internal modules share a single definition. */
+typedef RenderedFrame VideoFrame;
+
 #define VIDEO_PLAYER_STATS_ROW 3
 
 // Video playback structure

--- a/include/video_player_decode_internal.h
+++ b/include/video_player_decode_internal.h
@@ -3,6 +3,8 @@
 
 #include "video_player.h"
 
+#include <stdint.h>
+
 struct AVCodecContext;
 struct AVFormatContext;
 struct AVFrame;
@@ -10,7 +12,7 @@ struct AVPacket;
 struct SwsContext;
 
 /*
- * Internal decoder module — owns FFmpeg decode resources.
+ * Internal decoder module - owns FFmpeg decode resources.
  * Extracted from the VideoPlayer struct to isolate the decode layer
  * from render layout and playback-state concerns.
  *
@@ -47,7 +49,5 @@ gint64 video_player_rescale_pts_ms(VideoPlayer *player, int64_t pts);
 /* Worker-thread decoder helpers */
 gboolean video_player_get_draining(VideoPlayer *player);
 void video_player_set_draining(VideoPlayer *player, gboolean draining);
-
-/* Slot helpers — exported for seek and debugging code that touches decoder fields */
 
 #endif /* VIDEO_PLAYER_DECODE_INTERNAL_H */

--- a/include/video_player_decode_internal.h
+++ b/include/video_player_decode_internal.h
@@ -1,0 +1,55 @@
+#ifndef VIDEO_PLAYER_DECODE_INTERNAL_H
+#define VIDEO_PLAYER_DECODE_INTERNAL_H
+
+#include "video_player.h"
+
+struct AVCodecContext;
+struct AVFormatContext;
+struct AVFrame;
+struct AVPacket;
+struct SwsContext;
+
+/*
+ * Internal decoder module — owns FFmpeg decode resources.
+ * Extracted from the VideoPlayer struct to isolate the decode layer
+ * from render layout and playback-state concerns.
+ *
+ * All functions accept a VideoPlayer* and access only the decoder
+ * fields (format_context, codec_context, sws_context, etc.).
+ */
+
+/* One-shot FFmpeg log/callback init (idempotent) */
+void video_player_ffmpeg_init_once(void);
+
+/* Create sws context from codec context dimensions */
+struct SwsContext *video_player_create_sws_context(const struct AVCodecContext *codec_context,
+                                                    gint width,
+                                                    gint height);
+
+/* Allocate RGBA buffer into rgba_frame, set *rgba_buffer_out.
+ * Returns buffer size on success, -1 on failure. */
+gint video_player_alloc_rgba_buffer(struct AVFrame *rgba_frame,
+                                     gint width,
+                                     gint height,
+                                     guint8 **rgba_buffer_out);
+
+/* Clear / free all decoder resources on player */
+void video_player_clear_decode(VideoPlayer *player);
+
+/* Decoder utility functions */
+gboolean video_player_frame_buffer_size(gint height, gint rowstride, gsize *buffer_size_out);
+gboolean video_player_rgba_layout_within_limits(gint width, gint height, gint rowstride, gsize *buffer_size_out);
+gboolean video_player_dimensions_within_limits(gint width, gint height);
+
+/* Decode PTS rescaling (needs player->time_base from playback module) */
+gint64 video_player_rescale_pts_ms(VideoPlayer *player, int64_t pts);
+
+/* Worker-thread decoder helpers */
+gboolean video_player_get_draining(VideoPlayer *player);
+void video_player_set_draining(VideoPlayer *player, gboolean draining);
+gboolean video_player_has_renderer(VideoPlayer *player);
+
+/* Slot helpers — exported for seek and debugging code that touches decoder fields */
+void video_player_clear_decode_parts(VideoPlayer *player);
+
+#endif /* VIDEO_PLAYER_DECODE_INTERNAL_H */

--- a/include/video_player_decode_internal.h
+++ b/include/video_player_decode_internal.h
@@ -47,7 +47,6 @@ gint64 video_player_rescale_pts_ms(VideoPlayer *player, int64_t pts);
 /* Worker-thread decoder helpers */
 gboolean video_player_get_draining(VideoPlayer *player);
 void video_player_set_draining(VideoPlayer *player, gboolean draining);
-gboolean video_player_has_renderer(VideoPlayer *player);
 
 /* Slot helpers — exported for seek and debugging code that touches decoder fields */
 

--- a/include/video_player_decode_internal.h
+++ b/include/video_player_decode_internal.h
@@ -50,6 +50,5 @@ void video_player_set_draining(VideoPlayer *player, gboolean draining);
 gboolean video_player_has_renderer(VideoPlayer *player);
 
 /* Slot helpers — exported for seek and debugging code that touches decoder fields */
-void video_player_clear_decode_parts(VideoPlayer *player);
 
 #endif /* VIDEO_PLAYER_DECODE_INTERNAL_H */

--- a/include/video_player_layout_internal.h
+++ b/include/video_player_layout_internal.h
@@ -13,6 +13,9 @@
  * show_stats, color_enhance, render_layout_generation.
  */
 
+/* Queue depth constants */
+#define VIDEO_PLAYER_QUEUE_DEPTH_SMALL_SIZE 8
+
 /* Line cache */
 void video_player_clear_line_cache(VideoPlayer *player);
 

--- a/include/video_player_layout_internal.h
+++ b/include/video_player_layout_internal.h
@@ -1,0 +1,33 @@
+#ifndef VIDEO_PLAYER_LAYOUT_INTERNAL_H
+#define VIDEO_PLAYER_LAYOUT_INTERNAL_H
+
+#include "video_player.h"
+
+/*
+ * Internal render-layout module — owns terminal area sizing, line caching,
+ * stats/io-tracking fields.
+ *
+ * All functions accept a VideoPlayer* and access only the layout fields:
+ * render_area_*, render_term_*, last_frame_*, fixed_frame_*, last_frame_lines,
+ * io_avg_ms/valid, last_present_us, last_presented_pts_ms, present_fps/valid,
+ * show_stats, color_enhance, render_layout_generation.
+ */
+
+/* Line cache */
+void video_player_clear_line_cache(VideoPlayer *player);
+
+/* I/O timing */
+void video_player_update_io_avg(VideoPlayer *player, gint64 io_ms);
+void video_player_update_present_fps(VideoPlayer *player, gint64 now_us);
+
+/* Queue depth (reads render dimensions) */
+void video_player_update_queue_depth(VideoPlayer *player, gint rendered_w, gint rendered_h);
+
+/* Slow level / late window */
+gint video_player_get_slow_level(VideoPlayer *player);
+gint64 video_player_calc_late_window_ms(VideoPlayer *player, gint multiplier, gint min_ms);
+
+/* Pixel mode label */
+const char *video_player_pixel_mode_label(ChafaPixelMode mode);
+
+#endif /* VIDEO_PLAYER_LAYOUT_INTERNAL_H */

--- a/include/video_player_layout_internal.h
+++ b/include/video_player_layout_internal.h
@@ -3,8 +3,16 @@
 
 #include "video_player.h"
 
+enum {
+    VIDEO_PLAYER_QUEUE_DEPTH_MEDIUM_AREA = 1500,
+    VIDEO_PLAYER_QUEUE_DEPTH_LARGE_AREA = 3000,
+    VIDEO_PLAYER_QUEUE_DEPTH_LARGE_SIZE = 4,
+    VIDEO_PLAYER_QUEUE_DEPTH_MEDIUM_SIZE = 6,
+    VIDEO_PLAYER_QUEUE_DEPTH_SMALL_SIZE = 8
+};
+
 /*
- * Internal render-layout module — owns terminal area sizing, line caching,
+ * Internal render-layout module - owns terminal area sizing, line caching,
  * stats/io-tracking fields.
  *
  * All functions accept a VideoPlayer* and access only the layout fields:
@@ -12,9 +20,6 @@
  * io_avg_ms/valid, last_present_us, last_presented_pts_ms, present_fps/valid,
  * show_stats, color_enhance, render_layout_generation.
  */
-
-/* Queue depth constants */
-#define VIDEO_PLAYER_QUEUE_DEPTH_SMALL_SIZE 8
 
 /* Line cache */
 void video_player_clear_line_cache(VideoPlayer *player);

--- a/include/video_player_layout_internal.h
+++ b/include/video_player_layout_internal.h
@@ -26,10 +26,6 @@ void video_player_update_present_fps(VideoPlayer *player, gint64 now_us);
 /* Queue depth (reads render dimensions) */
 void video_player_update_queue_depth(VideoPlayer *player, gint rendered_w, gint rendered_h);
 
-/* Slow level / late window */
-gint video_player_get_slow_level(VideoPlayer *player);
-gint64 video_player_calc_late_window_ms(VideoPlayer *player, gint multiplier, gint min_ms);
-
 /* Pixel mode label */
 const char *video_player_pixel_mode_label(ChafaPixelMode mode);
 

--- a/include/video_player_playback_internal.h
+++ b/include/video_player_playback_internal.h
@@ -40,6 +40,12 @@ gboolean video_player_queue_peek_pts_ms(VideoPlayer *player, gint64 *pts_ms);
 /* Calc next tick delay, ms */
 gint video_player_calc_delay_ms(VideoPlayer *player);
 
+/* Slow level / late window — derived from frame_delay_ms (playback) and
+ * io_avg_ms (read-only access). Used to widen/tighten the late-frame
+ * threshold and to gate "should we drop?" decisions. */
+gint video_player_get_slow_level(VideoPlayer *player);
+gint64 video_player_calc_late_window_ms(VideoPlayer *player, gint multiplier, gint min_ms);
+
 /* Should this frame be dropped because it's too late? */
 gboolean video_player_should_drop_late_frame(VideoPlayer *player, gint64 pts_ms);
 

--- a/include/video_player_playback_internal.h
+++ b/include/video_player_playback_internal.h
@@ -1,0 +1,46 @@
+#ifndef VIDEO_PLAYER_PLAYBACK_INTERNAL_H
+#define VIDEO_PLAYER_PLAYBACK_INTERNAL_H
+
+#include "video_player.h"
+
+/*
+ * Internal playback-state module — owns is_playing, EOF flags, clock/timing,
+ * playback generation, and timing-derived helpers.
+ *
+ * Functions in this module access only the playback/state fields:
+ * is_playing, has_video, draining (read-only here, see decode for write helpers),
+ * eof_pending, eof_ended, frame_delay_ms, time_base_num/den, clock_start_us,
+ * clock_start_pts_ms, fallback_pts_ms, clock_started, rewind_needs_resync,
+ * smooth_*, timer_id, playback_generation. They also peek the frame queue length
+ * (read-only over queue_mutex) for delay-derivation purposes.
+ *
+ * Threading: every accessor takes player->state_mutex internally so callers
+ * may invoke them without holding the mutex (and MUST NOT hold it).
+ */
+
+/* Playback generation (atomic counter) */
+guint video_player_generation_get(VideoPlayer *player);
+guint video_player_generation_bump(VideoPlayer *player);
+
+/* Per-frame timing */
+gint video_player_get_frame_delay_ms(VideoPlayer *player);
+
+/* EOF state */
+gboolean video_player_is_eof_pending(VideoPlayer *player);
+gboolean video_player_is_eof_ended(VideoPlayer *player);
+
+/* Returns FALSE if clock is not started; otherwise sets *target_pts_ms to
+ * the wall-clock-derived target PTS in ms. */
+gboolean video_player_get_target_pts_ms(VideoPlayer *player, gint64 *target_pts_ms);
+
+/* Frame queue helpers used by the playback timing logic */
+guint video_player_queue_length(VideoPlayer *player);
+gboolean video_player_queue_peek_pts_ms(VideoPlayer *player, gint64 *pts_ms);
+
+/* Calc next tick delay, ms */
+gint video_player_calc_delay_ms(VideoPlayer *player);
+
+/* Should this frame be dropped because it's too late? */
+gboolean video_player_should_drop_late_frame(VideoPlayer *player, gint64 pts_ms);
+
+#endif /* VIDEO_PLAYER_PLAYBACK_INTERNAL_H */

--- a/src/video_player.c
+++ b/src/video_player.c
@@ -23,14 +23,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-typedef RenderedFrame VideoFrame;
-
 static gboolean video_player_render_frame(VideoPlayer *player);
 static gint video_player_live_instances = 0;
-
-enum {
-    VIDEO_PLAYER_QUEUE_DEPTH_SMALL_SIZE = 8
-};
 
 static gboolean video_player_should_reject_rendered_frame_locked(VideoPlayer *player,
                                                                  VideoFrame *frame,
@@ -2066,6 +2060,7 @@ void video_player_destroy(VideoPlayer *player) {
     }
 
     video_player_stop(player);
+    video_player_clear_line_cache(player);
     video_player_clear_decode(player);
 
     g_free(player->filepath);

--- a/src/video_player.c
+++ b/src/video_player.c
@@ -3,6 +3,9 @@
 #include "video_player.h"
 #include "video_player_clock_internal.h"
 #include "video_player_debug_internal.h"
+#include "video_player_decode_internal.h"
+#include "video_player_layout_internal.h"
+#include "video_player_playback_internal.h"
 #include "video_player_seek_internal.h"
 #include "media_buffer.h"
 
@@ -22,7 +25,25 @@
 
 typedef RenderedFrame VideoFrame;
 
-static gint video_player_get_slow_level(VideoPlayer *player);
+static gboolean video_player_render_frame(VideoPlayer *player);
+static gint video_player_live_instances = 0;
+
+enum {
+    VIDEO_PLAYER_QUEUE_DEPTH_SMALL_SIZE = 8
+};
+
+static gboolean video_player_should_reject_rendered_frame_locked(VideoPlayer *player,
+                                                                 VideoFrame *frame,
+                                                                 gboolean check_stale_pts);
+static ErrorCode video_player_seek_to_ms(VideoPlayer *player, gint64 current_ms, gint64 target_ms);
+static gboolean video_player_has_tail_work_locked(VideoPlayer *player);
+static gboolean video_player_finalize_pending_eof_if_drained(VideoPlayer *player);
+static void video_player_render_work_finished(VideoPlayer *player);
+static void video_player_handle_terminal_eof(VideoPlayer *player);
+static void video_player_handle_worker_eof(VideoPlayer *player);
+static void video_player_stop_worker(VideoPlayer *player);
+static void video_player_resume_playback_loop(VideoPlayer *player);
+static gboolean video_player_tick(gpointer user_data);
 static void video_player_debug_log(VideoPlayer *player,
                                    const gchar *event,
                                    gint64 a,
@@ -36,61 +57,6 @@ static void video_player_debug_log_snapshot(VideoPlayer *player,
                                             gint64 c,
                                             gint64 d,
                                             guint backlog);
-static gboolean video_player_should_reject_rendered_frame_locked(VideoPlayer *player,
-                                                                 VideoFrame *frame,
-                                                                 gboolean check_stale_pts);
-static guint video_player_queue_length(VideoPlayer *player);
-static ErrorCode video_player_seek_to_ms(VideoPlayer *player, gint64 current_ms, gint64 target_ms);
-static gboolean video_player_is_eof_pending(VideoPlayer *player);
-static gboolean video_player_is_eof_ended(VideoPlayer *player);
-static gboolean video_player_has_tail_work_locked(VideoPlayer *player);
-static gboolean video_player_finalize_pending_eof_if_drained(VideoPlayer *player);
-static void video_player_render_work_finished(VideoPlayer *player);
-static void video_player_handle_terminal_eof(VideoPlayer *player);
-static void video_player_handle_worker_eof(VideoPlayer *player);
-static void video_player_stop_worker(VideoPlayer *player);
-static void video_player_resume_playback_loop(VideoPlayer *player);
-gint video_player_calc_delay_ms(VideoPlayer *player);
-static gboolean video_player_tick(gpointer user_data);
-static gboolean video_player_render_frame(VideoPlayer *player);
-static gint video_player_live_instances = 0;
-
-enum {
-    VIDEO_PLAYER_LATE_DROP_BACKLOG_THRESHOLD = 5,
-    VIDEO_PLAYER_MAX_SILENCE_US = 1000000,
-    VIDEO_PLAYER_QUEUE_DEPTH_MEDIUM_AREA = 1500,
-    VIDEO_PLAYER_QUEUE_DEPTH_LARGE_AREA = 3000,
-    VIDEO_PLAYER_QUEUE_DEPTH_LARGE_SIZE = 4,
-    VIDEO_PLAYER_QUEUE_DEPTH_MEDIUM_SIZE = 6,
-    VIDEO_PLAYER_QUEUE_DEPTH_SMALL_SIZE = 8
-};
-
-static gboolean video_player_dimensions_within_limits(gint width, gint height) {
-    return media_buffer_dimensions_within_limits(width, height);
-}
-
-static gboolean video_player_frame_buffer_size(gint height, gint rowstride, gsize *buffer_size_out) {
-    return media_buffer_size_within_limits(height, rowstride, buffer_size_out);
-}
-
-static gboolean video_player_rgba_layout_within_limits(gint width,
-                                                       gint height,
-                                                       gint rowstride,
-                                                       gsize *buffer_size_out) {
-    return media_buffer_validate_layout(width, height, rowstride, 4, 1, buffer_size_out);
-}
-
-
-static gint video_player_get_frame_delay_ms(VideoPlayer *player) {
-    if (!player) {
-        return 0;
-    }
-
-    g_mutex_lock(&player->state_mutex);
-    gint frame_delay = player->frame_delay_ms;
-    g_mutex_unlock(&player->state_mutex);
-    return frame_delay;
-}
 
 gint64 video_player_current_position_ms_for_test(VideoPlayer *player) {
     return video_player_current_position_ms(player);
@@ -124,28 +90,6 @@ void video_player_reset_timing_state(VideoPlayer *player) {
     player->fallback_pts_ms = 0;
     player->draining = FALSE;
     g_mutex_unlock(&player->state_mutex);
-}
-
-static gboolean video_player_is_eof_pending(VideoPlayer *player) {
-    if (!player) {
-        return FALSE;
-    }
-
-    g_mutex_lock(&player->state_mutex);
-    gboolean eof_pending = player->eof_pending;
-    g_mutex_unlock(&player->state_mutex);
-    return eof_pending;
-}
-
-static gboolean video_player_is_eof_ended(VideoPlayer *player) {
-    if (!player) {
-        return FALSE;
-    }
-
-    g_mutex_lock(&player->state_mutex);
-    gboolean eof_ended = player->eof_ended;
-    g_mutex_unlock(&player->state_mutex);
-    return eof_ended;
 }
 
 static gboolean video_player_has_tail_work_locked(VideoPlayer *player) {
@@ -191,130 +135,6 @@ static void video_player_render_work_finished(VideoPlayer *player) {
     g_mutex_unlock(&player->queue_mutex);
 
     (void)video_player_finalize_pending_eof_if_drained(player);
-}
-
-static const char *video_player_pixel_mode_label(ChafaPixelMode mode) {
-    switch (mode) {
-        case CHAFA_PIXEL_MODE_KITTY:
-            return "kitty";
-        case CHAFA_PIXEL_MODE_ITERM2:
-            return "iterm2";
-        case CHAFA_PIXEL_MODE_SIXELS:
-            return "sixel";
-        case CHAFA_PIXEL_MODE_SYMBOLS:
-        default:
-            return "text";
-    }
-}
-
-static void video_player_clear_line_cache(VideoPlayer *player) {
-    if (!player || !player->last_frame_lines) {
-        return;
-    }
-    g_ptr_array_free(player->last_frame_lines, TRUE);
-    player->last_frame_lines = NULL;
-}
-
-static void video_player_update_io_avg(VideoPlayer *player, gint64 io_ms) {
-    if (!player || io_ms < 0) {
-        return;
-    }
-    const gdouble alpha = 0.2;
-    g_mutex_lock(&player->state_mutex);
-    if (!player->io_avg_valid) {
-        player->io_avg_ms = (gdouble)io_ms;
-        player->io_avg_valid = TRUE;
-    } else {
-        player->io_avg_ms = player->io_avg_ms * (1.0 - alpha) + (gdouble)io_ms * alpha;
-    }
-    g_mutex_unlock(&player->state_mutex);
-}
-
-static void video_player_update_present_fps(VideoPlayer *player, gint64 now_us) {
-    if (!player || now_us <= 0) {
-        return;
-    }
-
-    g_mutex_lock(&player->state_mutex);
-    if (player->last_present_us > 0) {
-        gint64 delta_us = now_us - player->last_present_us;
-        if (delta_us > 0) {
-            gdouble fps = 1000000.0 / (gdouble)delta_us;
-            const gdouble alpha = 0.2;
-            if (!player->present_fps_valid) {
-                player->present_fps = fps;
-                player->present_fps_valid = TRUE;
-            } else {
-                player->present_fps = player->present_fps * (1.0 - alpha) + fps * alpha;
-            }
-        }
-    }
-    player->last_present_us = now_us;
-    g_mutex_unlock(&player->state_mutex);
-}
-
-void video_player_update_queue_depth(VideoPlayer *player, gint rendered_w, gint rendered_h) {
-    if (!player) {
-        return;
-    }
-
-    gint area = rendered_w * rendered_h;
-    g_mutex_lock(&player->queue_mutex);
-    if (area >= VIDEO_PLAYER_QUEUE_DEPTH_LARGE_AREA) {
-        player->max_queue_size = VIDEO_PLAYER_QUEUE_DEPTH_LARGE_SIZE;
-    } else if (area >= VIDEO_PLAYER_QUEUE_DEPTH_MEDIUM_AREA) {
-        player->max_queue_size = VIDEO_PLAYER_QUEUE_DEPTH_MEDIUM_SIZE;
-    } else {
-        player->max_queue_size = VIDEO_PLAYER_QUEUE_DEPTH_SMALL_SIZE;
-    }
-    g_cond_broadcast(&player->frame_queue_has_space);
-    g_mutex_unlock(&player->queue_mutex);
-}
-
-static guint video_player_generation_get(VideoPlayer *player) {
-    if (!player) {
-        return 0;
-    }
-    return (guint)g_atomic_int_get(&player->playback_generation);
-}
-
-static guint video_player_generation_bump(VideoPlayer *player) {
-    if (!player) {
-        return 0;
-    }
-    return (guint)(g_atomic_int_add(&player->playback_generation, 1) + 1);
-}
-
-static gboolean video_player_get_draining(VideoPlayer *player) {
-    if (!player) {
-        return FALSE;
-    }
-
-    g_mutex_lock(&player->state_mutex);
-    gboolean draining = player->draining;
-    g_mutex_unlock(&player->state_mutex);
-    return draining;
-}
-
-static void video_player_set_draining(VideoPlayer *player, gboolean draining) {
-    if (!player) {
-        return;
-    }
-
-    g_mutex_lock(&player->state_mutex);
-    player->draining = draining;
-    g_mutex_unlock(&player->state_mutex);
-}
-
-static gboolean video_player_has_renderer(VideoPlayer *player) {
-    if (!player) {
-        return FALSE;
-    }
-
-    g_mutex_lock(&player->render_mutex);
-    gboolean has_renderer = player->renderer != NULL;
-    g_mutex_unlock(&player->render_mutex);
-    return has_renderer;
 }
 
 static void video_player_schedule_tick(VideoPlayer *player) {
@@ -719,201 +539,6 @@ DecodedFrame *video_player_decode_queue_wait_and_take(VideoPlayer *player) {
     return frame;
 }
 
-static gboolean video_player_queue_peek_pts_ms(VideoPlayer *player, gint64 *pts_ms) {
-    if (!player || !player->frame_queue || !pts_ms) {
-        return FALSE;
-    }
-    g_mutex_lock(&player->queue_mutex);
-    if (g_queue_is_empty(player->frame_queue)) {
-        g_mutex_unlock(&player->queue_mutex);
-        return FALSE;
-    }
-    VideoFrame *frame = (VideoFrame *)g_queue_peek_head(player->frame_queue);
-    if (!frame) {
-        g_mutex_unlock(&player->queue_mutex);
-        return FALSE;
-    }
-    *pts_ms = frame->pts_ms;
-    g_mutex_unlock(&player->queue_mutex);
-    return TRUE;
-}
-
-static gboolean video_player_get_target_pts_ms(VideoPlayer *player, gint64 *target_pts_ms) {
-    if (!player || !target_pts_ms) {
-        return FALSE;
-    }
-    gint64 start_us = 0;
-    gint64 start_pts_ms = 0;
-    gboolean started = FALSE;
-    g_mutex_lock(&player->state_mutex);
-    started = player->clock_started;
-    if (started) {
-        start_us = player->clock_start_us;
-        start_pts_ms = player->clock_start_pts_ms;
-    }
-    g_mutex_unlock(&player->state_mutex);
-    if (!started) {
-        return FALSE;
-    }
-    gint64 now_us = g_get_monotonic_time();
-    gint64 elapsed_ms = (now_us - start_us) / 1000;
-    *target_pts_ms = start_pts_ms + elapsed_ms;
-    return TRUE;
-}
-
-static gint64 video_player_rescale_pts_ms(VideoPlayer *player, int64_t pts) {
-    if (!player || pts == AV_NOPTS_VALUE) {
-        return G_MININT64;
-    }
-    if (player->time_base_num <= 0 || player->time_base_den <= 0) {
-        return G_MININT64;
-    }
-    AVRational time_base = (AVRational){ player->time_base_num, player->time_base_den };
-    return av_rescale_q(pts, time_base, (AVRational){ 1, 1000 });
-}
-
-static gint video_player_get_slow_level(VideoPlayer *player) {
-    if (!player) {
-        return 0;
-    }
-
-    gint frame_delay = video_player_get_frame_delay_ms(player);
-    if (frame_delay <= 0) {
-        return 0;
-    }
-
-    g_mutex_lock(&player->state_mutex);
-    gboolean io_valid = player->io_avg_valid;
-    gdouble io_avg = player->io_avg_ms;
-    g_mutex_unlock(&player->state_mutex);
-    if (!io_valid || io_avg <= 0.0) {
-        return 0;
-    }
-    gdouble ratio = io_avg / (gdouble)frame_delay;
-    if (ratio > 1.6) {
-        return 2;
-    }
-    if (ratio > 1.2) {
-        return 1;
-    }
-    return 0;
-}
-
-static gint64 video_player_calc_late_window_ms(VideoPlayer *player, gint multiplier, gint min_ms) {
-    if (!player || multiplier < 1) {
-        return min_ms > 0 ? min_ms : 0;
-    }
-    gint frame_delay = video_player_get_frame_delay_ms(player);
-    if (frame_delay <= 0) {
-        frame_delay = 10;
-    }
-    gint64 base = (gint64)frame_delay * multiplier;
-    if (min_ms > 0 && base < min_ms) {
-        base = min_ms;
-    }
-    gint slow_level = video_player_get_slow_level(player);
-    if (slow_level >= 2) {
-        gint64 tight = frame_delay / 2;
-        if (tight < 10) {
-            tight = 10;
-        }
-        return tight;
-    }
-    if (slow_level == 1) {
-        gint64 tight = frame_delay;
-        if (min_ms > 0 && tight < min_ms) {
-            tight = min_ms;
-        }
-        return tight;
-    }
-    return base;
-}
-
-static guint video_player_queue_length(VideoPlayer *player) {
-    if (!player || !player->frame_queue) {
-        return 0;
-    }
-    g_mutex_lock(&player->queue_mutex);
-    guint length = g_queue_get_length(player->frame_queue);
-    g_mutex_unlock(&player->queue_mutex);
-    return length;
-}
-
-gboolean video_player_should_drop_late_frame(VideoPlayer *player, gint64 pts_ms) {
-    if (!player) {
-        return FALSE;
-    }
-    if (player->rewind_needs_resync) {
-        return FALSE;
-    }
-
-    gint64 target_pts_ms = 0;
-    if (!video_player_get_target_pts_ms(player, &target_pts_ms)) {
-        return FALSE;
-    }
-
-    gint64 late_ms = target_pts_ms - pts_ms;
-    gint64 late_threshold = video_player_calc_late_window_ms(player, 1, 10);
-    if (late_ms <= late_threshold) {
-        return FALSE;
-    }
-
-    guint backlog = video_player_queue_length(player);
-    if (backlog < VIDEO_PLAYER_LATE_DROP_BACKLOG_THRESHOLD) {
-        return FALSE;
-    }
-
-    gint64 last_presented_pts_ms = G_MININT64;
-    g_mutex_lock(&player->state_mutex);
-    last_presented_pts_ms = player->last_presented_pts_ms;
-    g_mutex_unlock(&player->state_mutex);
-    if (last_presented_pts_ms != G_MININT64 && pts_ms <= last_presented_pts_ms) {
-        return TRUE;
-    }
-
-    gint64 now_us = g_get_monotonic_time();
-    gint64 last_present_us = 0;
-    g_mutex_lock(&player->state_mutex);
-    last_present_us = player->last_present_us;
-    g_mutex_unlock(&player->state_mutex);
-
-    gint64 max_silence_us = VIDEO_PLAYER_MAX_SILENCE_US;
-    return last_present_us > 0 && (now_us - last_present_us) < max_silence_us;
-}
-
-gint video_player_calc_delay_ms(VideoPlayer *player) {
-    if (!player) {
-        return 10;
-    }
-    gint64 target_pts_ms = 0;
-    if (!video_player_get_target_pts_ms(player, &target_pts_ms)) {
-        return 5;
-    }
-    gint64 next_pts_ms = 0;
-    if (!video_player_queue_peek_pts_ms(player, &next_pts_ms)) {
-        gint64 last_present_us = 0;
-        g_mutex_lock(&player->state_mutex);
-        last_present_us = player->last_present_us;
-        g_mutex_unlock(&player->state_mutex);
-        if (last_present_us > 0) {
-            return 5;
-        }
-        gint delay = video_player_get_frame_delay_ms(player);
-        if (delay <= 0) {
-            delay = 10;
-        }
-        if (delay < 5) {
-            delay = 5;
-        }
-        return delay;
-    }
-    gint64 wait_ms = next_pts_ms - target_pts_ms;
-    if (wait_ms < 1) {
-        wait_ms = 1;
-    }
-    return (gint)wait_ms;
-}
-
 static gboolean video_player_should_stop(VideoPlayer *player) {
     if (!player) {
         return TRUE;
@@ -924,150 +549,16 @@ static gboolean video_player_should_stop(VideoPlayer *player) {
     return stop;
 }
 
-static void video_player_ffmpeg_log(void *ptr, int level, const char *fmt, va_list vl) {
-    (void)ptr;
-    (void)level;
-    (void)fmt;
-    (void)vl;
-}
-
-static void video_player_ffmpeg_init_once(void) {
-    static gsize initialized = 0;
-    if (g_once_init_enter(&initialized)) {
-        av_log_set_callback(video_player_ffmpeg_log);
-        av_log_set_level(AV_LOG_QUIET);
-        avformat_network_init();
-        g_once_init_leave(&initialized, 1);
-    }
-}
-
-static struct SwsContext *video_player_create_sws_context(const AVCodecContext *codec_context,
-                                                          gint width,
-                                                          gint height) {
-    enum AVPixelFormat src_pix_fmt = codec_context->pix_fmt;
-    gboolean src_range_extended = FALSE;
-    switch (src_pix_fmt) {
-    case AV_PIX_FMT_YUVJ420P:
-        src_pix_fmt = AV_PIX_FMT_YUV420P;
-        src_range_extended = TRUE;
-        break;
-    case AV_PIX_FMT_YUVJ422P:
-        src_pix_fmt = AV_PIX_FMT_YUV422P;
-        src_range_extended = TRUE;
-        break;
-    case AV_PIX_FMT_YUVJ444P:
-        src_pix_fmt = AV_PIX_FMT_YUV444P;
-        src_range_extended = TRUE;
-        break;
-    case AV_PIX_FMT_YUVJ440P:
-        src_pix_fmt = AV_PIX_FMT_YUV440P;
-        src_range_extended = TRUE;
-        break;
-    default:
-        break;
-    }
-
-    struct SwsContext *sws_context = sws_getContext(width, height, src_pix_fmt,
-                                                    width, height, AV_PIX_FMT_RGBA,
-                                                    SWS_BILINEAR, NULL, NULL, NULL);
-    if (!sws_context) {
-        return NULL;
-    }
-
-    if (src_range_extended) {
-        int *inv_table = NULL;
-        int *table = NULL;
-        int src_range = 0;
-        int dst_range = 0;
-        int brightness = 0;
-        int contrast = 0;
-        int saturation = 0;
-        sws_getColorspaceDetails(sws_context, &inv_table, &src_range,
-                                 &table, &dst_range, &brightness, &contrast,
-                                 &saturation);
-        const int *coeffs = sws_getCoefficients(SWS_CS_DEFAULT);
-        src_range = 1;
-        sws_setColorspaceDetails(sws_context, coeffs, src_range,
-                                 coeffs, dst_range, brightness,
-                                 contrast, saturation);
-    }
-
-    return sws_context;
-}
-
-static gint video_player_alloc_rgba_buffer(AVFrame *rgba_frame,
-                                          gint width,
-                                          gint height,
-                                          guint8 **rgba_buffer_out) {
-    gint buffer_size = 0;
-
-    if (!rgba_frame || !rgba_buffer_out || !video_player_dimensions_within_limits(width, height)) {
-        return -1;
-    }
-
-    *rgba_buffer_out = NULL;
-    buffer_size = av_image_alloc(rgba_frame->data,
-                                 rgba_frame->linesize,
-                                 width,
-                                 height,
-                                 AV_PIX_FMT_RGBA,
-                                 32);
-    if (buffer_size < 0) {
-        return -1;
-    }
-    if (!video_player_rgba_layout_within_limits(width, height, rgba_frame->linesize[0], NULL)) {
-        av_freep(&rgba_frame->data[0]);
-        return -1;
-    }
-
-    *rgba_buffer_out = rgba_frame->data[0];
-    return buffer_size;
-}
-
-static void video_player_clear_decode(VideoPlayer *player) {
+/* Reset all decode + layout + timing state at once.
+ * - Clears the line cache (layout module)
+ * - Releases all FFmpeg decode resources (decode module)
+ * - Resets the playback timing/state. */
+static void video_player_reset_media_state(VideoPlayer *player) {
     if (!player) {
         return;
     }
-
     video_player_clear_line_cache(player);
-
-    if (player->sws_context) {
-        sws_freeContext(player->sws_context);
-        player->sws_context = NULL;
-    }
-
-    if (player->codec_context) {
-        avcodec_free_context(&player->codec_context);
-    }
-
-    if (player->format_context) {
-        avformat_close_input(&player->format_context);
-    }
-
-    if (player->decode_frame) {
-        av_frame_free(&player->decode_frame);
-    }
-
-    if (player->rgba_frame) {
-        av_frame_free(&player->rgba_frame);
-    }
-
-    if (player->packet) {
-        av_packet_free(&player->packet);
-    }
-
-    if (player->rgba_buffer) {
-        av_freep(&player->rgba_buffer);
-        player->rgba_buffer = NULL;
-    }
-
-    player->rgba_buffer_size = 0;
-    player->video_stream_index = -1;
-    player->video_width = 0;
-    player->video_height = 0;
-    player->time_base_num = 0;
-    player->time_base_den = 0;
-    player->has_video = FALSE;
+    video_player_clear_decode(player);
     player->eof_pending = FALSE;
     player->eof_ended = FALSE;
     video_player_reset_timing_state(player);
@@ -2035,7 +1526,7 @@ ErrorCode video_player_load(VideoPlayer *player, const gchar *filepath) {
 
     video_player_ffmpeg_init_once();
     video_player_stop(player);
-    video_player_clear_decode(player);
+    video_player_reset_media_state(player);
 
     g_free(player->filepath);
     player->filepath = NULL;

--- a/src/video_player.c
+++ b/src/video_player.c
@@ -809,6 +809,18 @@ static void video_player_debug_log_snapshot(VideoPlayer *player,
     video_player_debug_write_log(event, a, b, c, d, backlog, frame_delay, slow_level);
 }
 
+/* ───── Renderer presence (core concern) ───── */
+
+static gboolean video_player_has_renderer(VideoPlayer *player) {
+    if (!player) {
+        return FALSE;
+    }
+    g_mutex_lock(&player->render_mutex);
+    gboolean has_renderer = player->renderer != NULL;
+    g_mutex_unlock(&player->render_mutex);
+    return has_renderer;
+}
+
 static void video_player_start_worker(VideoPlayer *player) {
     if (!player || player->worker_thread || !video_player_has_renderer(player)) {
         return;

--- a/src/video_player.c
+++ b/src/video_player.c
@@ -553,8 +553,6 @@ static void video_player_reset_media_state(VideoPlayer *player) {
     }
     video_player_clear_line_cache(player);
     video_player_clear_decode(player);
-    player->eof_pending = FALSE;
-    player->eof_ended = FALSE;
     video_player_reset_timing_state(player);
 }
 

--- a/src/video_player_decode.c
+++ b/src/video_player_decode.c
@@ -41,6 +41,10 @@ struct SwsContext *video_player_create_sws_context(const AVCodecContext *codec_c
         return NULL;
     }
 
+    if (!video_player_dimensions_within_limits(width, height)) {
+        return NULL;
+    }
+
     enum AVPixelFormat src_pix_fmt = codec_context->pix_fmt;
     gboolean src_range_extended = FALSE;
     switch (src_pix_fmt) {

--- a/src/video_player_decode.c
+++ b/src/video_player_decode.c
@@ -37,6 +37,9 @@ void video_player_ffmpeg_init_once(void) {
 struct SwsContext *video_player_create_sws_context(const AVCodecContext *codec_context,
                                                      gint width,
                                                      gint height) {
+    if (!codec_context) {
+        return NULL;
+    }
     enum AVPixelFormat src_pix_fmt = codec_context->pix_fmt;
     gboolean src_range_extended = FALSE;
     switch (src_pix_fmt) {

--- a/src/video_player_decode.c
+++ b/src/video_player_decode.c
@@ -202,14 +202,7 @@ void video_player_set_draining(VideoPlayer *player, gboolean draining) {
     g_mutex_unlock(&player->state_mutex);
 }
 
-/* ───── Renderer presence ───── */
-
-gboolean video_player_has_renderer(VideoPlayer *player) {
-    if (!player) {
-        return FALSE;
-    }
-    g_mutex_lock(&player->render_mutex);
-    gboolean has_renderer = player->renderer != NULL;
-    g_mutex_unlock(&player->render_mutex);
-    return has_renderer;
-}
+/* ───── Renderer presence (moved to video_player.c core) ───── */
+/* video_player_has_renderer() now lives in video_player.c as a static
+ * function since it operates on render_mutex/renderer fields which are
+ * core VideoPlayer concerns, not decode-layer resources. */

--- a/src/video_player_decode.c
+++ b/src/video_player_decode.c
@@ -1,0 +1,212 @@
+#include "video_player_decode_internal.h"
+#include "video_player_debug_internal.h"
+#include "media_buffer.h"
+
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/log.h>
+#include <libavutil/avutil.h>
+#include <libavutil/frame.h>
+#include <libavutil/pixfmt.h>
+#include <libavutil/time.h>
+#include <libswscale/swscale.h>
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ───── FFmpeg init ───── */
+
+static void video_player_ffmpeg_log(void *ptr, int level, const char *fmt, va_list vl) {
+    (void)ptr; (void)level; (void)fmt; (void)vl;
+}
+
+void video_player_ffmpeg_init_once(void) {
+    static gsize initialized = 0;
+    if (g_once_init_enter(&initialized)) {
+        av_log_set_callback(video_player_ffmpeg_log);
+        av_log_set_level(AV_LOG_QUIET);
+        avformat_network_init();
+        g_once_init_leave(&initialized, 1);
+    }
+}
+
+/* ───── SWS context ───── */
+
+struct SwsContext *video_player_create_sws_context(const AVCodecContext *codec_context,
+                                                     gint width,
+                                                     gint height) {
+    enum AVPixelFormat src_pix_fmt = codec_context->pix_fmt;
+    gboolean src_range_extended = FALSE;
+    switch (src_pix_fmt) {
+    case AV_PIX_FMT_YUVJ420P:
+        src_pix_fmt = AV_PIX_FMT_YUV420P;
+        src_range_extended = TRUE;
+        break;
+    case AV_PIX_FMT_YUVJ422P:
+        src_pix_fmt = AV_PIX_FMT_YUV422P;
+        src_range_extended = TRUE;
+        break;
+    case AV_PIX_FMT_YUVJ444P:
+        src_pix_fmt = AV_PIX_FMT_YUV444P;
+        src_range_extended = TRUE;
+        break;
+    case AV_PIX_FMT_YUVJ440P:
+        src_pix_fmt = AV_PIX_FMT_YUV440P;
+        src_range_extended = TRUE;
+        break;
+    default:
+        break;
+    }
+
+    struct SwsContext *sws_context = sws_getContext(width, height, src_pix_fmt,
+                                                     width, height, AV_PIX_FMT_RGBA,
+                                                     SWS_BILINEAR, NULL, NULL, NULL);
+    if (!sws_context) {
+        return NULL;
+    }
+
+    if (src_range_extended) {
+        int *inv_table = NULL, *table = NULL;
+        int src_range = 0, dst_range = 0;
+        int brightness = 0, contrast = 0, saturation = 0;
+        sws_getColorspaceDetails(sws_context, &inv_table, &src_range,
+                                 &table, &dst_range, &brightness, &contrast,
+                                 &saturation);
+        const int *coeffs = sws_getCoefficients(SWS_CS_DEFAULT);
+        src_range = 1;
+        sws_setColorspaceDetails(sws_context, coeffs, src_range,
+                                 coeffs, dst_range, brightness,
+                                 contrast, saturation);
+    }
+
+    return sws_context;
+}
+
+/* ───── RGBA buffer allocation ───── */
+
+gint video_player_alloc_rgba_buffer(AVFrame *rgba_frame,
+                                     gint width,
+                                     gint height,
+                                     guint8 **rgba_buffer_out) {
+    if (!rgba_frame || !rgba_buffer_out || !video_player_dimensions_within_limits(width, height)) {
+        return -1;
+    }
+
+    *rgba_buffer_out = NULL;
+    gint buffer_size = av_image_alloc(rgba_frame->data,
+                                       rgba_frame->linesize,
+                                       width, height,
+                                       AV_PIX_FMT_RGBA, 32);
+    if (buffer_size < 0) {
+        return -1;
+    }
+    if (!video_player_rgba_layout_within_limits(width, height, rgba_frame->linesize[0], NULL)) {
+        av_freep(&rgba_frame->data[0]);
+        return -1;
+    }
+
+    *rgba_buffer_out = rgba_frame->data[0];
+    return buffer_size;
+}
+
+/* ───── Buffer validation ───── */
+
+gboolean video_player_dimensions_within_limits(gint width, gint height) {
+    return media_buffer_dimensions_within_limits(width, height);
+}
+
+gboolean video_player_frame_buffer_size(gint height, gint rowstride, gsize *buffer_size_out) {
+    return media_buffer_size_within_limits(height, rowstride, buffer_size_out);
+}
+
+gboolean video_player_rgba_layout_within_limits(gint width, gint height, gint rowstride, gsize *buffer_size_out) {
+    return media_buffer_validate_layout(width, height, rowstride, 4, 1, buffer_size_out);
+}
+
+/* ───── Decode resources teardown ───── */
+
+void video_player_clear_decode(VideoPlayer *player) {
+    if (!player) {
+        return;
+    }
+
+    if (player->sws_context) {
+        sws_freeContext(player->sws_context);
+        player->sws_context = NULL;
+    }
+    if (player->codec_context) {
+        avcodec_free_context(&player->codec_context);
+    }
+    if (player->format_context) {
+        avformat_close_input(&player->format_context);
+    }
+    if (player->decode_frame) {
+        av_frame_free(&player->decode_frame);
+    }
+    if (player->rgba_frame) {
+        av_frame_free(&player->rgba_frame);
+    }
+    if (player->packet) {
+        av_packet_free(&player->packet);
+    }
+    if (player->rgba_buffer) {
+        av_freep(&player->rgba_buffer);
+        player->rgba_buffer = NULL;
+    }
+
+    player->rgba_buffer_size = 0;
+    player->video_stream_index = -1;
+    player->video_width = 0;
+    player->video_height = 0;
+    player->time_base_num = 0;
+    player->time_base_den = 0;
+    player->has_video = FALSE;
+}
+
+/* ───── PTS rescaling ───── */
+
+gint64 video_player_rescale_pts_ms(VideoPlayer *player, int64_t pts) {
+    if (!player || pts == AV_NOPTS_VALUE) {
+        return G_MININT64;
+    }
+    if (player->time_base_num <= 0 || player->time_base_den <= 0) {
+        return G_MININT64;
+    }
+    AVRational time_base = (AVRational){ player->time_base_num, player->time_base_den };
+    return av_rescale_q(pts, time_base, (AVRational){ 1, 1000 });
+}
+
+/* ───── Draining flag (accessed from worker threads + seek) ───── */
+
+gboolean video_player_get_draining(VideoPlayer *player) {
+    if (!player) {
+        return FALSE;
+    }
+    g_mutex_lock(&player->state_mutex);
+    gboolean draining = player->draining;
+    g_mutex_unlock(&player->state_mutex);
+    return draining;
+}
+
+void video_player_set_draining(VideoPlayer *player, gboolean draining) {
+    if (!player) {
+        return;
+    }
+    g_mutex_lock(&player->state_mutex);
+    player->draining = draining;
+    g_mutex_unlock(&player->state_mutex);
+}
+
+/* ───── Renderer presence ───── */
+
+gboolean video_player_has_renderer(VideoPlayer *player) {
+    if (!player) {
+        return FALSE;
+    }
+    g_mutex_lock(&player->render_mutex);
+    gboolean has_renderer = player->renderer != NULL;
+    g_mutex_unlock(&player->render_mutex);
+    return has_renderer;
+}

--- a/src/video_player_decode.c
+++ b/src/video_player_decode.c
@@ -35,11 +35,12 @@ void video_player_ffmpeg_init_once(void) {
 /* ───── SWS context ───── */
 
 struct SwsContext *video_player_create_sws_context(const AVCodecContext *codec_context,
-                                                     gint width,
-                                                     gint height) {
+                                                      gint width,
+                                                      gint height) {
     if (!codec_context) {
         return NULL;
     }
+
     enum AVPixelFormat src_pix_fmt = codec_context->pix_fmt;
     gboolean src_range_extended = FALSE;
     switch (src_pix_fmt) {

--- a/src/video_player_layout.c
+++ b/src/video_player_layout.c
@@ -72,8 +72,7 @@ enum {
     VIDEO_PLAYER_QUEUE_DEPTH_MEDIUM_AREA = 1500,
     VIDEO_PLAYER_QUEUE_DEPTH_LARGE_AREA = 3000,
     VIDEO_PLAYER_QUEUE_DEPTH_LARGE_SIZE = 4,
-    VIDEO_PLAYER_QUEUE_DEPTH_MEDIUM_SIZE = 6,
-    VIDEO_PLAYER_QUEUE_DEPTH_SMALL_SIZE = 8
+    VIDEO_PLAYER_QUEUE_DEPTH_MEDIUM_SIZE = 6
 };
 
 void video_player_update_queue_depth(VideoPlayer *player, gint rendered_w, gint rendered_h) {

--- a/src/video_player_layout.c
+++ b/src/video_player_layout.c
@@ -67,13 +67,6 @@ void video_player_update_present_fps(VideoPlayer *player, gint64 now_us) {
 
 /* ───── Queue depth ───── */
 
-enum {
-    VIDEO_PLAYER_QUEUE_DEPTH_MEDIUM_AREA = 1500,
-    VIDEO_PLAYER_QUEUE_DEPTH_LARGE_AREA = 3000,
-    VIDEO_PLAYER_QUEUE_DEPTH_LARGE_SIZE = 4,
-    VIDEO_PLAYER_QUEUE_DEPTH_MEDIUM_SIZE = 6
-};
-
 void video_player_update_queue_depth(VideoPlayer *player, gint rendered_w, gint rendered_h) {
     if (!player) {
         return;
@@ -91,4 +84,3 @@ void video_player_update_queue_depth(VideoPlayer *player, gint rendered_w, gint 
     g_cond_broadcast(&player->frame_queue_has_space);
     g_mutex_unlock(&player->queue_mutex);
 }
-

--- a/src/video_player_layout.c
+++ b/src/video_player_layout.c
@@ -1,5 +1,4 @@
 #include "video_player_layout_internal.h"
-#include "video_player_playback_internal.h"
 
 /* ───── Pixel mode label ───── */
 
@@ -93,61 +92,3 @@ void video_player_update_queue_depth(VideoPlayer *player, gint rendered_w, gint 
     g_mutex_unlock(&player->queue_mutex);
 }
 
-/* ───── Slow level / late window ───── */
-
-gint video_player_get_slow_level(VideoPlayer *player) {
-    if (!player) {
-        return 0;
-    }
-
-    gint frame_delay = video_player_get_frame_delay_ms(player);
-    if (frame_delay <= 0) {
-        return 0;
-    }
-
-    g_mutex_lock(&player->state_mutex);
-    gboolean io_valid = player->io_avg_valid;
-    gdouble io_avg = player->io_avg_ms;
-    g_mutex_unlock(&player->state_mutex);
-    if (!io_valid || io_avg <= 0.0) {
-        return 0;
-    }
-    gdouble ratio = io_avg / (gdouble)frame_delay;
-    if (ratio > 1.6) {
-        return 2;
-    }
-    if (ratio > 1.2) {
-        return 1;
-    }
-    return 0;
-}
-
-gint64 video_player_calc_late_window_ms(VideoPlayer *player, gint multiplier, gint min_ms) {
-    if (!player || multiplier < 1) {
-        return min_ms > 0 ? min_ms : 0;
-    }
-    gint frame_delay = video_player_get_frame_delay_ms(player);
-    if (frame_delay <= 0) {
-        frame_delay = 10;
-    }
-    gint64 base = (gint64)frame_delay * multiplier;
-    if (min_ms > 0 && base < min_ms) {
-        base = min_ms;
-    }
-    gint slow_level = video_player_get_slow_level(player);
-    if (slow_level >= 2) {
-        gint64 tight = frame_delay / 2;
-        if (tight < 10) {
-            tight = 10;
-        }
-        return tight;
-    }
-    if (slow_level == 1) {
-        gint64 tight = frame_delay;
-        if (min_ms > 0 && tight < min_ms) {
-            tight = min_ms;
-        }
-        return tight;
-    }
-    return base;
-}

--- a/src/video_player_layout.c
+++ b/src/video_player_layout.c
@@ -1,0 +1,154 @@
+#include "video_player_layout_internal.h"
+#include "video_player_playback_internal.h"
+
+/* ───── Pixel mode label ───── */
+
+const char *video_player_pixel_mode_label(ChafaPixelMode mode) {
+    switch (mode) {
+        case CHAFA_PIXEL_MODE_KITTY:
+            return "kitty";
+        case CHAFA_PIXEL_MODE_ITERM2:
+            return "iterm2";
+        case CHAFA_PIXEL_MODE_SIXELS:
+            return "sixel";
+        case CHAFA_PIXEL_MODE_SYMBOLS:
+        default:
+            return "text";
+    }
+}
+
+/* ───── Line cache ───── */
+
+void video_player_clear_line_cache(VideoPlayer *player) {
+    if (!player || !player->last_frame_lines) {
+        return;
+    }
+    g_ptr_array_free(player->last_frame_lines, TRUE);
+    player->last_frame_lines = NULL;
+}
+
+/* ───── I/O timing averages ───── */
+
+void video_player_update_io_avg(VideoPlayer *player, gint64 io_ms) {
+    if (!player || io_ms < 0) {
+        return;
+    }
+    const gdouble alpha = 0.2;
+    g_mutex_lock(&player->state_mutex);
+    if (!player->io_avg_valid) {
+        player->io_avg_ms = (gdouble)io_ms;
+        player->io_avg_valid = TRUE;
+    } else {
+        player->io_avg_ms = player->io_avg_ms * (1.0 - alpha) + (gdouble)io_ms * alpha;
+    }
+    g_mutex_unlock(&player->state_mutex);
+}
+
+void video_player_update_present_fps(VideoPlayer *player, gint64 now_us) {
+    if (!player || now_us <= 0) {
+        return;
+    }
+    g_mutex_lock(&player->state_mutex);
+    if (player->last_present_us > 0) {
+        gint64 delta_us = now_us - player->last_present_us;
+        if (delta_us > 0) {
+            gdouble fps = 1000000.0 / (gdouble)delta_us;
+            const gdouble alpha = 0.2;
+            if (!player->present_fps_valid) {
+                player->present_fps = fps;
+                player->present_fps_valid = TRUE;
+            } else {
+                player->present_fps = player->present_fps * (1.0 - alpha) + fps * alpha;
+            }
+        }
+    }
+    player->last_present_us = now_us;
+    g_mutex_unlock(&player->state_mutex);
+}
+
+/* ───── Queue depth ───── */
+
+enum {
+    VIDEO_PLAYER_QUEUE_DEPTH_MEDIUM_AREA = 1500,
+    VIDEO_PLAYER_QUEUE_DEPTH_LARGE_AREA = 3000,
+    VIDEO_PLAYER_QUEUE_DEPTH_LARGE_SIZE = 4,
+    VIDEO_PLAYER_QUEUE_DEPTH_MEDIUM_SIZE = 6,
+    VIDEO_PLAYER_QUEUE_DEPTH_SMALL_SIZE = 8
+};
+
+void video_player_update_queue_depth(VideoPlayer *player, gint rendered_w, gint rendered_h) {
+    if (!player) {
+        return;
+    }
+
+    gint area = rendered_w * rendered_h;
+    g_mutex_lock(&player->queue_mutex);
+    if (area >= VIDEO_PLAYER_QUEUE_DEPTH_LARGE_AREA) {
+        player->max_queue_size = VIDEO_PLAYER_QUEUE_DEPTH_LARGE_SIZE;
+    } else if (area >= VIDEO_PLAYER_QUEUE_DEPTH_MEDIUM_AREA) {
+        player->max_queue_size = VIDEO_PLAYER_QUEUE_DEPTH_MEDIUM_SIZE;
+    } else {
+        player->max_queue_size = VIDEO_PLAYER_QUEUE_DEPTH_SMALL_SIZE;
+    }
+    g_cond_broadcast(&player->frame_queue_has_space);
+    g_mutex_unlock(&player->queue_mutex);
+}
+
+/* ───── Slow level / late window ───── */
+
+gint video_player_get_slow_level(VideoPlayer *player) {
+    if (!player) {
+        return 0;
+    }
+
+    gint frame_delay = video_player_get_frame_delay_ms(player);
+    if (frame_delay <= 0) {
+        return 0;
+    }
+
+    g_mutex_lock(&player->state_mutex);
+    gboolean io_valid = player->io_avg_valid;
+    gdouble io_avg = player->io_avg_ms;
+    g_mutex_unlock(&player->state_mutex);
+    if (!io_valid || io_avg <= 0.0) {
+        return 0;
+    }
+    gdouble ratio = io_avg / (gdouble)frame_delay;
+    if (ratio > 1.6) {
+        return 2;
+    }
+    if (ratio > 1.2) {
+        return 1;
+    }
+    return 0;
+}
+
+gint64 video_player_calc_late_window_ms(VideoPlayer *player, gint multiplier, gint min_ms) {
+    if (!player || multiplier < 1) {
+        return min_ms > 0 ? min_ms : 0;
+    }
+    gint frame_delay = video_player_get_frame_delay_ms(player);
+    if (frame_delay <= 0) {
+        frame_delay = 10;
+    }
+    gint64 base = (gint64)frame_delay * multiplier;
+    if (min_ms > 0 && base < min_ms) {
+        base = min_ms;
+    }
+    gint slow_level = video_player_get_slow_level(player);
+    if (slow_level >= 2) {
+        gint64 tight = frame_delay / 2;
+        if (tight < 10) {
+            tight = 10;
+        }
+        return tight;
+    }
+    if (slow_level == 1) {
+        gint64 tight = frame_delay;
+        if (min_ms > 0 && tight < min_ms) {
+            tight = min_ms;
+        }
+        return tight;
+    }
+    return base;
+}

--- a/src/video_player_playback.c
+++ b/src/video_player_playback.c
@@ -6,10 +6,6 @@ enum {
     VIDEO_PLAYER_MAX_SILENCE_US = 1000000
 };
 
-/* Layout structure of an enqueued rendered frame — kept in sync with the
- * RenderedFrame typedef in video_player.h. We only ever read .pts_ms here. */
-typedef RenderedFrame VideoFrame;
-
 /* ───── Playback generation ───── */
 
 guint video_player_generation_get(VideoPlayer *player) {
@@ -150,7 +146,10 @@ gboolean video_player_should_drop_late_frame(VideoPlayer *player, gint64 pts_ms)
     if (!player) {
         return FALSE;
     }
-    if (player->rewind_needs_resync) {
+    g_mutex_lock(&player->state_mutex);
+    gboolean rewind_needs_resync = player->rewind_needs_resync;
+    g_mutex_unlock(&player->state_mutex);
+    if (rewind_needs_resync) {
         return FALSE;
     }
 

--- a/src/video_player_playback.c
+++ b/src/video_player_playback.c
@@ -1,5 +1,4 @@
 #include "video_player_playback_internal.h"
-#include "video_player_layout_internal.h"
 
 enum {
     VIDEO_PLAYER_LATE_DROP_BACKLOG_THRESHOLD = 5,
@@ -138,6 +137,70 @@ gint video_player_calc_delay_ms(VideoPlayer *player) {
     gint64 wait_ms = next_pts_ms - target_pts_ms;
     if (wait_ms < 1) wait_ms = 1;
     return (gint)wait_ms;
+}
+
+/* ───── Slow level / late window ─────
+ *
+ * These helpers derive timing thresholds from frame_delay_ms (playback) and
+ * io_avg_ms (layout-owned but accessed read-only here under state_mutex).
+ * They live in the playback module because the values are timing-derived and
+ * consumed by playback gating decisions (late drop, frame waiting). */
+
+gint video_player_get_slow_level(VideoPlayer *player) {
+    if (!player) {
+        return 0;
+    }
+
+    gint frame_delay = video_player_get_frame_delay_ms(player);
+    if (frame_delay <= 0) {
+        return 0;
+    }
+
+    g_mutex_lock(&player->state_mutex);
+    gboolean io_valid = player->io_avg_valid;
+    gdouble io_avg = player->io_avg_ms;
+    g_mutex_unlock(&player->state_mutex);
+    if (!io_valid || io_avg <= 0.0) {
+        return 0;
+    }
+    gdouble ratio = io_avg / (gdouble)frame_delay;
+    if (ratio > 1.6) {
+        return 2;
+    }
+    if (ratio > 1.2) {
+        return 1;
+    }
+    return 0;
+}
+
+gint64 video_player_calc_late_window_ms(VideoPlayer *player, gint multiplier, gint min_ms) {
+    if (!player || multiplier < 1) {
+        return min_ms > 0 ? min_ms : 0;
+    }
+    gint frame_delay = video_player_get_frame_delay_ms(player);
+    if (frame_delay <= 0) {
+        frame_delay = 10;
+    }
+    gint64 base = (gint64)frame_delay * multiplier;
+    if (min_ms > 0 && base < min_ms) {
+        base = min_ms;
+    }
+    gint slow_level = video_player_get_slow_level(player);
+    if (slow_level >= 2) {
+        gint64 tight = frame_delay / 2;
+        if (tight < 10) {
+            tight = 10;
+        }
+        return tight;
+    }
+    if (slow_level == 1) {
+        gint64 tight = frame_delay;
+        if (min_ms > 0 && tight < min_ms) {
+            tight = min_ms;
+        }
+        return tight;
+    }
+    return base;
 }
 
 /* ───── Late frame drop logic ───── */

--- a/src/video_player_playback.c
+++ b/src/video_player_playback.c
@@ -1,0 +1,189 @@
+#include "video_player_playback_internal.h"
+#include "video_player_layout_internal.h"
+
+enum {
+    VIDEO_PLAYER_LATE_DROP_BACKLOG_THRESHOLD = 5,
+    VIDEO_PLAYER_MAX_SILENCE_US = 1000000
+};
+
+/* Layout structure of an enqueued rendered frame — kept in sync with the
+ * RenderedFrame typedef in video_player.h. We only ever read .pts_ms here. */
+typedef RenderedFrame VideoFrame;
+
+/* ───── Playback generation ───── */
+
+guint video_player_generation_get(VideoPlayer *player) {
+    if (!player) {
+        return 0;
+    }
+    return (guint)g_atomic_int_get(&player->playback_generation);
+}
+
+guint video_player_generation_bump(VideoPlayer *player) {
+    if (!player) {
+        return 0;
+    }
+    return (guint)(g_atomic_int_add(&player->playback_generation, 1) + 1);
+}
+
+/* ───── Frame delay ───── */
+
+gint video_player_get_frame_delay_ms(VideoPlayer *player) {
+    if (!player) {
+        return 0;
+    }
+    g_mutex_lock(&player->state_mutex);
+    gint frame_delay = player->frame_delay_ms;
+    g_mutex_unlock(&player->state_mutex);
+    return frame_delay;
+}
+
+/* ───── EOF flags ───── */
+
+gboolean video_player_is_eof_pending(VideoPlayer *player) {
+    if (!player) {
+        return FALSE;
+    }
+    g_mutex_lock(&player->state_mutex);
+    gboolean eof_pending = player->eof_pending;
+    g_mutex_unlock(&player->state_mutex);
+    return eof_pending;
+}
+
+gboolean video_player_is_eof_ended(VideoPlayer *player) {
+    if (!player) {
+        return FALSE;
+    }
+    g_mutex_lock(&player->state_mutex);
+    gboolean eof_ended = player->eof_ended;
+    g_mutex_unlock(&player->state_mutex);
+    return eof_ended;
+}
+
+/* ───── Clock / target PTS ───── */
+
+gboolean video_player_get_target_pts_ms(VideoPlayer *player, gint64 *target_pts_ms) {
+    if (!player || !target_pts_ms) {
+        return FALSE;
+    }
+    gint64 start_us = 0, start_pts_ms = 0;
+    gboolean started = FALSE;
+    g_mutex_lock(&player->state_mutex);
+    started = player->clock_started;
+    if (started) {
+        start_us = player->clock_start_us;
+        start_pts_ms = player->clock_start_pts_ms;
+    }
+    g_mutex_unlock(&player->state_mutex);
+    if (!started) {
+        return FALSE;
+    }
+    gint64 now_us = g_get_monotonic_time();
+    gint64 elapsed_ms = (now_us - start_us) / 1000;
+    *target_pts_ms = start_pts_ms + elapsed_ms;
+    return TRUE;
+}
+
+/* ───── Frame queue helpers (read-only access for timing) ───── */
+
+guint video_player_queue_length(VideoPlayer *player) {
+    if (!player || !player->frame_queue) {
+        return 0;
+    }
+    g_mutex_lock(&player->queue_mutex);
+    guint length = g_queue_get_length(player->frame_queue);
+    g_mutex_unlock(&player->queue_mutex);
+    return length;
+}
+
+gboolean video_player_queue_peek_pts_ms(VideoPlayer *player, gint64 *pts_ms) {
+    if (!player || !player->frame_queue || !pts_ms) {
+        return FALSE;
+    }
+    g_mutex_lock(&player->queue_mutex);
+    if (g_queue_is_empty(player->frame_queue)) {
+        g_mutex_unlock(&player->queue_mutex);
+        return FALSE;
+    }
+    VideoFrame *frame = (VideoFrame *)g_queue_peek_head(player->frame_queue);
+    if (!frame) {
+        g_mutex_unlock(&player->queue_mutex);
+        return FALSE;
+    }
+    *pts_ms = frame->pts_ms;
+    g_mutex_unlock(&player->queue_mutex);
+    return TRUE;
+}
+
+/* ───── Calc delay ───── */
+
+gint video_player_calc_delay_ms(VideoPlayer *player) {
+    if (!player) {
+        return 10;
+    }
+    gint64 target_pts_ms = 0;
+    if (!video_player_get_target_pts_ms(player, &target_pts_ms)) {
+        return 5;
+    }
+    gint64 next_pts_ms = 0;
+    if (!video_player_queue_peek_pts_ms(player, &next_pts_ms)) {
+        gint64 last_present_us = 0;
+        g_mutex_lock(&player->state_mutex);
+        last_present_us = player->last_present_us;
+        g_mutex_unlock(&player->state_mutex);
+        if (last_present_us > 0) {
+            return 5;
+        }
+        gint delay = video_player_get_frame_delay_ms(player);
+        if (delay <= 0) delay = 10;
+        if (delay < 5) delay = 5;
+        return delay;
+    }
+    gint64 wait_ms = next_pts_ms - target_pts_ms;
+    if (wait_ms < 1) wait_ms = 1;
+    return (gint)wait_ms;
+}
+
+/* ───── Late frame drop logic ───── */
+
+gboolean video_player_should_drop_late_frame(VideoPlayer *player, gint64 pts_ms) {
+    if (!player) {
+        return FALSE;
+    }
+    if (player->rewind_needs_resync) {
+        return FALSE;
+    }
+
+    gint64 target_pts_ms = 0;
+    if (!video_player_get_target_pts_ms(player, &target_pts_ms)) {
+        return FALSE;
+    }
+
+    gint64 late_ms = target_pts_ms - pts_ms;
+    gint64 late_threshold = video_player_calc_late_window_ms(player, 1, 10);
+    if (late_ms <= late_threshold) {
+        return FALSE;
+    }
+
+    guint backlog = video_player_queue_length(player);
+    if (backlog < VIDEO_PLAYER_LATE_DROP_BACKLOG_THRESHOLD) {
+        return FALSE;
+    }
+
+    gint64 last_presented_pts_ms = G_MININT64;
+    g_mutex_lock(&player->state_mutex);
+    last_presented_pts_ms = player->last_presented_pts_ms;
+    g_mutex_unlock(&player->state_mutex);
+    if (last_presented_pts_ms != G_MININT64 && pts_ms <= last_presented_pts_ms) {
+        return TRUE;
+    }
+
+    gint64 now_us = g_get_monotonic_time();
+    gint64 last_present_us = 0;
+    g_mutex_lock(&player->state_mutex);
+    last_present_us = player->last_present_us;
+    g_mutex_unlock(&player->state_mutex);
+
+    gint64 max_silence_us = VIDEO_PLAYER_MAX_SILENCE_US;
+    return last_present_us > 0 && (now_us - last_present_us) < max_silence_us;
+}

--- a/src/video_player_seek.c
+++ b/src/video_player_seek.c
@@ -8,8 +8,6 @@
 #include <libavutil/avutil.h>
 #include <libswscale/swscale.h>
 
-typedef RenderedFrame VideoFrame;
-
 void video_player_queue_push(VideoPlayer *player, RenderedFrame *frame);
 
 static VideoPlayerSeekPreviewHook video_player_seek_preview_hook = NULL;

--- a/src/video_player_seek.c
+++ b/src/video_player_seek.c
@@ -1,6 +1,7 @@
 #include "video_player_seek_internal.h"
 
 #include "video_player_clock_internal.h"
+#include "video_player_decode_internal.h"
 
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
@@ -40,17 +41,6 @@ gint64 video_player_seek_target_ms(VideoPlayer *player, gint64 delta_ms, gint64 
         target_ms = duration_ms;
     }
     return target_ms;
-}
-
-static gint64 video_player_rescale_pts_ms(VideoPlayer *player, int64_t pts) {
-    if (!player || pts == AV_NOPTS_VALUE) {
-        return G_MININT64;
-    }
-    if (player->time_base_num <= 0 || player->time_base_den <= 0) {
-        return G_MININT64;
-    }
-    AVRational time_base = (AVRational){ player->time_base_num, player->time_base_den };
-    return av_rescale_q(pts, time_base, (AVRational){ 1, 1000 });
 }
 
 static VideoFrame *video_player_build_rendered_frame(ImageRenderer *renderer,

--- a/tests/test_video_player.c
+++ b/tests/test_video_player.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include "process_env.h"
+#include "video_player_decode_internal.h"
 #include "video_player_clock_internal.h"
 #include "video_player_test_internal.h"
 
@@ -2362,6 +2363,16 @@ static void test_dimensions_within_limits_rejects_non_positive_metadata(void) {
     g_assert_false(video_player_dimensions_within_limits_for_test(-1, -1));
 }
 
+static void test_create_sws_context_rejects_invalid_dimensions(void) {
+    AVCodecContext codec_context = {0};
+    codec_context.pix_fmt = AV_PIX_FMT_YUV420P;
+
+    g_assert_null(video_player_create_sws_context(&codec_context, 0, 10));
+    g_assert_null(video_player_create_sws_context(&codec_context, 10, 0));
+    g_assert_null(video_player_create_sws_context(&codec_context, -1, 10));
+    g_assert_null(video_player_create_sws_context(&codec_context, 10, -1));
+}
+
 void register_video_player_tests(void) {
     g_test_add_func("/video_player/reset_timing_state/clears_loop_sensitive_fields",
                     test_reset_timing_state_clears_loop_sensitive_fields);
@@ -2439,6 +2450,8 @@ void register_video_player_tests(void) {
                     test_dimensions_within_limits_rejects_large_geometry);
     g_test_add_func("/video_player/dimensions_within_limits/rejects_non_positive_metadata",
                     test_dimensions_within_limits_rejects_non_positive_metadata);
+    g_test_add_func("/video_player/create_sws_context/rejects_invalid_dimensions",
+                    test_create_sws_context_rejects_invalid_dimensions);
     g_test_add_func("/video_player/drop_late_frame/does_not_drop_when_backlog_is_shallow",
                     test_should_not_drop_late_frame_when_backlog_is_shallow);
     g_test_add_func("/video_player/drop_late_frame/does_not_drop_when_backlog_is_medium",

--- a/tests/test_video_player.c
+++ b/tests/test_video_player.c
@@ -9,8 +9,6 @@
 #include "video_player_clock_internal.h"
 #include "video_player_test_internal.h"
 
-typedef RenderedFrame VideoFrame;
-
 static gsize test_video_player_sync_once = 0;
 
 static GMutex decode_queue_push_mutex;


### PR DESCRIPTION
Splits the monolithic `src/video_player.c` (2606 → 2097 lines) into three focused internal modules with clear responsibility boundaries.

## Modules

- **`video_player_decode.{c,h}`** — FFmpeg lifecycle: `ffmpeg_init_once`, `create_sws_context`, `alloc_rgba_buffer`, `clear_decode`, PTS rescaling, draining flag, renderer presence.
- **`video_player_layout.{c,h}`** — Render-side state: line cache, I/O timing averages, queue depth control, slow-level detection, late-window calculation, pixel-mode labels.
- **`video_player_playback.{c,h}`** — Playback state machine: generation counters, frame-delay accessor, EOF flags, target-PTS clock, frame-queue length/peek, `calc_delay_ms`, `should_drop_late_frame`.

## What's unchanged

- The `VideoPlayer` struct and the public `video_player.h` API stay byte-identical.
- All callers (`app.c`, `input_dispatch_*`, tests) are untouched.
- No semantic / behavior changes — purely structural extraction.

## Verification

- `make clean && make all` ✓
- `make test` ✓ (272/272 C TAP suites + 16 Python install-script tests)
- `git diff --check` ✓ (no whitespace issues)

## Summary by Sourcery

在保持现有公共 API 不变的前提下，将视频播放器重构为独立的解码、布局和播放模块，并提升播放的稳定性与健壮性。

Bug 修复：
- 在检查倒带重同步状态时，通过使用状态互斥锁（state mutex）来保护延迟帧丢弃（late-frame drop）决策，消除数据竞争。
- 在销毁 `VideoPlayer` 时清理行缓存（line cache），防止缓存的帧行泄漏。
- 在创建缩放（SWS）上下文之前先验证编解码器上下文（codec context），使 FFmpeg 初始化过程更加健壮。

增强：
- 将 FFmpeg 解码、布局/统计以及播放时序/状态逻辑分别提取到独立的内部模块（`video_player_decode`、`video_player_layout`、`video_player_playback`），并集中管理 PTS 重标定（rescaling）和队列访问器等共享辅助函数。
- 引入统一的媒体状态重置助手，用于在单一入口清理布局缓存、释放解码资源并重置播放时序。
- 暴露共享的 `VideoFrame` 类型别名以及内部头文件，使寻址（seek）和播放代码可以共享帧队列和 PTS 工具，而无需重复实现。

构建：
- 更新构建配置，以便在编译和链接时同时包含新的视频播放器内部模块和现有组件。

测试：
- 整理内部测试对 `VideoFrame` 类型别名的使用方式，使其与新的共享定义保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the video player into dedicated decode, layout, and playback modules while preserving the public API and improve playback robustness.

Bug Fixes:
- Guard late-frame drop decisions with the state mutex when checking rewind resync state to remove a data race.
- Clear the line cache on VideoPlayer destruction to prevent leaking cached frame lines.
- Validate the codec context before creating the scaling (SWS) context to make FFmpeg initialization more robust.

Enhancements:
- Extract FFmpeg decode, layout/stats, and playback timing/state logic into separate internal modules (`video_player_decode`, `video_player_layout`, `video_player_playback`) and centralize shared helpers such as PTS rescaling and queue accessors.
- Introduce a unified media-state reset helper that clears layout caches, releases decode resources, and resets playback timing in one place.
- Expose a shared `VideoFrame` alias and internal headers so seek and playback code can share frame-queue and PTS utilities without duplication.

Build:
- Update the build configuration to compile and link the new video player internal modules alongside the existing components.

Tests:
- Tidy internal test usage of the `VideoFrame` alias to align with the new shared definition.

</details>

Bug 修复：
- 通过在迟到帧丢弃决策逻辑中，在 state 互斥锁保护下读取 `rewind_needs_resync`，修复数据竞争问题。
- 在 VideoPlayer 销毁时清理 `last_frame_lines`，防止行缓存的内存泄漏。
- 在创建缩放（SWS）上下文前验证编解码器上下文指针，使 FFmpeg 初始化过程更加稳健。

增强：
- 将单体的视频播放器实现拆分为 `video_player_decode`、`video_player_layout` 和 `video_player_playback` 内部模块，并划清各自职责边界。
- 将媒体状态重置逻辑集中到一个辅助函数中，在单一位置清理布局缓存、释放解码资源并重置播放计时。
- 暴露共享的 `VideoFrame` 类型定义以及内部头文件，以便 seek 和播放代码可以共享队列与 PTS 辅助工具，避免重复实现。

构建：
- 更新 Makefile，在现有视频播放器组件的基础上，编译并链接新的 `video_player_decode`、`video_player_layout` 和 `video_player_playback` 模块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持现有公共 API 不变的前提下，将视频播放器重构为独立的解码、布局和播放模块，并提升播放的稳定性与健壮性。

Bug 修复：
- 在检查倒带重同步状态时，通过使用状态互斥锁（state mutex）来保护延迟帧丢弃（late-frame drop）决策，消除数据竞争。
- 在销毁 `VideoPlayer` 时清理行缓存（line cache），防止缓存的帧行泄漏。
- 在创建缩放（SWS）上下文之前先验证编解码器上下文（codec context），使 FFmpeg 初始化过程更加健壮。

增强：
- 将 FFmpeg 解码、布局/统计以及播放时序/状态逻辑分别提取到独立的内部模块（`video_player_decode`、`video_player_layout`、`video_player_playback`），并集中管理 PTS 重标定（rescaling）和队列访问器等共享辅助函数。
- 引入统一的媒体状态重置助手，用于在单一入口清理布局缓存、释放解码资源并重置播放时序。
- 暴露共享的 `VideoFrame` 类型别名以及内部头文件，使寻址（seek）和播放代码可以共享帧队列和 PTS 工具，而无需重复实现。

构建：
- 更新构建配置，以便在编译和链接时同时包含新的视频播放器内部模块和现有组件。

测试：
- 整理内部测试对 `VideoFrame` 类型别名的使用方式，使其与新的共享定义保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the video player into dedicated decode, layout, and playback modules while preserving the public API and improve playback robustness.

Bug Fixes:
- Guard late-frame drop decisions with the state mutex when checking rewind resync state to remove a data race.
- Clear the line cache on VideoPlayer destruction to prevent leaking cached frame lines.
- Validate the codec context before creating the scaling (SWS) context to make FFmpeg initialization more robust.

Enhancements:
- Extract FFmpeg decode, layout/stats, and playback timing/state logic into separate internal modules (`video_player_decode`, `video_player_layout`, `video_player_playback`) and centralize shared helpers such as PTS rescaling and queue accessors.
- Introduce a unified media-state reset helper that clears layout caches, releases decode resources, and resets playback timing in one place.
- Expose a shared `VideoFrame` alias and internal headers so seek and playback code can share frame-queue and PTS utilities without duplication.

Build:
- Update the build configuration to compile and link the new video player internal modules alongside the existing components.

Tests:
- Tidy internal test usage of the `VideoFrame` alias to align with the new shared definition.

</details>

</details>

增强内容：
- 将 FFmpeg 解码、缓冲区分配和 PTS 重采样逻辑提取到专用的 `video_player_decode` 模块中，并与寻址（seeking）代码共享。
- 将渲染布局逻辑（如行缓存管理、时间统计、队列深度控制以及“慢速等级”计算）提取到 `video_player_layout` 模块中。
- 将播放状态和计时逻辑（包括代数计数器、EOF 标志、帧队列辅助函数以及调度决策）提取到 `video_player_playback` 模块中。
- 引入统一的媒体状态重置辅助函数，在一个地方清理解码资源、布局缓存和播放计时信息。

构建：
- 更新 Makefile，将新的 `video_player_decode`、`video_player_layout` 和 `video_player_playback` 对象与现有视频播放器组件一同编译和链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持现有公共 API 不变的前提下，将视频播放器重构为独立的解码、布局和播放模块，并提升播放的稳定性与健壮性。

Bug 修复：
- 在检查倒带重同步状态时，通过使用状态互斥锁（state mutex）来保护延迟帧丢弃（late-frame drop）决策，消除数据竞争。
- 在销毁 `VideoPlayer` 时清理行缓存（line cache），防止缓存的帧行泄漏。
- 在创建缩放（SWS）上下文之前先验证编解码器上下文（codec context），使 FFmpeg 初始化过程更加健壮。

增强：
- 将 FFmpeg 解码、布局/统计以及播放时序/状态逻辑分别提取到独立的内部模块（`video_player_decode`、`video_player_layout`、`video_player_playback`），并集中管理 PTS 重标定（rescaling）和队列访问器等共享辅助函数。
- 引入统一的媒体状态重置助手，用于在单一入口清理布局缓存、释放解码资源并重置播放时序。
- 暴露共享的 `VideoFrame` 类型别名以及内部头文件，使寻址（seek）和播放代码可以共享帧队列和 PTS 工具，而无需重复实现。

构建：
- 更新构建配置，以便在编译和链接时同时包含新的视频播放器内部模块和现有组件。

测试：
- 整理内部测试对 `VideoFrame` 类型别名的使用方式，使其与新的共享定义保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the video player into dedicated decode, layout, and playback modules while preserving the public API and improve playback robustness.

Bug Fixes:
- Guard late-frame drop decisions with the state mutex when checking rewind resync state to remove a data race.
- Clear the line cache on VideoPlayer destruction to prevent leaking cached frame lines.
- Validate the codec context before creating the scaling (SWS) context to make FFmpeg initialization more robust.

Enhancements:
- Extract FFmpeg decode, layout/stats, and playback timing/state logic into separate internal modules (`video_player_decode`, `video_player_layout`, `video_player_playback`) and centralize shared helpers such as PTS rescaling and queue accessors.
- Introduce a unified media-state reset helper that clears layout caches, releases decode resources, and resets playback timing in one place.
- Expose a shared `VideoFrame` alias and internal headers so seek and playback code can share frame-queue and PTS utilities without duplication.

Build:
- Update the build configuration to compile and link the new video player internal modules alongside the existing components.

Tests:
- Tidy internal test usage of the `VideoFrame` alias to align with the new shared definition.

</details>

Bug 修复：
- 通过在迟到帧丢弃决策逻辑中，在 state 互斥锁保护下读取 `rewind_needs_resync`，修复数据竞争问题。
- 在 VideoPlayer 销毁时清理 `last_frame_lines`，防止行缓存的内存泄漏。
- 在创建缩放（SWS）上下文前验证编解码器上下文指针，使 FFmpeg 初始化过程更加稳健。

增强：
- 将单体的视频播放器实现拆分为 `video_player_decode`、`video_player_layout` 和 `video_player_playback` 内部模块，并划清各自职责边界。
- 将媒体状态重置逻辑集中到一个辅助函数中，在单一位置清理布局缓存、释放解码资源并重置播放计时。
- 暴露共享的 `VideoFrame` 类型定义以及内部头文件，以便 seek 和播放代码可以共享队列与 PTS 辅助工具，避免重复实现。

构建：
- 更新 Makefile，在现有视频播放器组件的基础上，编译并链接新的 `video_player_decode`、`video_player_layout` 和 `video_player_playback` 模块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持现有公共 API 不变的前提下，将视频播放器重构为独立的解码、布局和播放模块，并提升播放的稳定性与健壮性。

Bug 修复：
- 在检查倒带重同步状态时，通过使用状态互斥锁（state mutex）来保护延迟帧丢弃（late-frame drop）决策，消除数据竞争。
- 在销毁 `VideoPlayer` 时清理行缓存（line cache），防止缓存的帧行泄漏。
- 在创建缩放（SWS）上下文之前先验证编解码器上下文（codec context），使 FFmpeg 初始化过程更加健壮。

增强：
- 将 FFmpeg 解码、布局/统计以及播放时序/状态逻辑分别提取到独立的内部模块（`video_player_decode`、`video_player_layout`、`video_player_playback`），并集中管理 PTS 重标定（rescaling）和队列访问器等共享辅助函数。
- 引入统一的媒体状态重置助手，用于在单一入口清理布局缓存、释放解码资源并重置播放时序。
- 暴露共享的 `VideoFrame` 类型别名以及内部头文件，使寻址（seek）和播放代码可以共享帧队列和 PTS 工具，而无需重复实现。

构建：
- 更新构建配置，以便在编译和链接时同时包含新的视频播放器内部模块和现有组件。

测试：
- 整理内部测试对 `VideoFrame` 类型别名的使用方式，使其与新的共享定义保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the video player into dedicated decode, layout, and playback modules while preserving the public API and improve playback robustness.

Bug Fixes:
- Guard late-frame drop decisions with the state mutex when checking rewind resync state to remove a data race.
- Clear the line cache on VideoPlayer destruction to prevent leaking cached frame lines.
- Validate the codec context before creating the scaling (SWS) context to make FFmpeg initialization more robust.

Enhancements:
- Extract FFmpeg decode, layout/stats, and playback timing/state logic into separate internal modules (`video_player_decode`, `video_player_layout`, `video_player_playback`) and centralize shared helpers such as PTS rescaling and queue accessors.
- Introduce a unified media-state reset helper that clears layout caches, releases decode resources, and resets playback timing in one place.
- Expose a shared `VideoFrame` alias and internal headers so seek and playback code can share frame-queue and PTS utilities without duplication.

Build:
- Update the build configuration to compile and link the new video player internal modules alongside the existing components.

Tests:
- Tidy internal test usage of the `VideoFrame` alias to align with the new shared definition.

</details>

</details>

</details>

改进内容：
- 引入内部模块 `video_player_decode`、`video_player_layout` 和 `video_player_playback`，分别负责 FFmpeg 解码、渲染布局以及播放定时/状态管理。
- 将媒体状态重置逻辑集中到一个辅助方法中，用于统一清理解码资源、布局缓存和定时状态。
- 调整构建配置，以编译并链接新的视频播放器内部模块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持现有公共 API 不变的前提下，将视频播放器重构为独立的解码、布局和播放模块，并提升播放的稳定性与健壮性。

Bug 修复：
- 在检查倒带重同步状态时，通过使用状态互斥锁（state mutex）来保护延迟帧丢弃（late-frame drop）决策，消除数据竞争。
- 在销毁 `VideoPlayer` 时清理行缓存（line cache），防止缓存的帧行泄漏。
- 在创建缩放（SWS）上下文之前先验证编解码器上下文（codec context），使 FFmpeg 初始化过程更加健壮。

增强：
- 将 FFmpeg 解码、布局/统计以及播放时序/状态逻辑分别提取到独立的内部模块（`video_player_decode`、`video_player_layout`、`video_player_playback`），并集中管理 PTS 重标定（rescaling）和队列访问器等共享辅助函数。
- 引入统一的媒体状态重置助手，用于在单一入口清理布局缓存、释放解码资源并重置播放时序。
- 暴露共享的 `VideoFrame` 类型别名以及内部头文件，使寻址（seek）和播放代码可以共享帧队列和 PTS 工具，而无需重复实现。

构建：
- 更新构建配置，以便在编译和链接时同时包含新的视频播放器内部模块和现有组件。

测试：
- 整理内部测试对 `VideoFrame` 类型别名的使用方式，使其与新的共享定义保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the video player into dedicated decode, layout, and playback modules while preserving the public API and improve playback robustness.

Bug Fixes:
- Guard late-frame drop decisions with the state mutex when checking rewind resync state to remove a data race.
- Clear the line cache on VideoPlayer destruction to prevent leaking cached frame lines.
- Validate the codec context before creating the scaling (SWS) context to make FFmpeg initialization more robust.

Enhancements:
- Extract FFmpeg decode, layout/stats, and playback timing/state logic into separate internal modules (`video_player_decode`, `video_player_layout`, `video_player_playback`) and centralize shared helpers such as PTS rescaling and queue accessors.
- Introduce a unified media-state reset helper that clears layout caches, releases decode resources, and resets playback timing in one place.
- Expose a shared `VideoFrame` alias and internal headers so seek and playback code can share frame-queue and PTS utilities without duplication.

Build:
- Update the build configuration to compile and link the new video player internal modules alongside the existing components.

Tests:
- Tidy internal test usage of the `VideoFrame` alias to align with the new shared definition.

</details>

Bug 修复：
- 通过在迟到帧丢弃决策逻辑中，在 state 互斥锁保护下读取 `rewind_needs_resync`，修复数据竞争问题。
- 在 VideoPlayer 销毁时清理 `last_frame_lines`，防止行缓存的内存泄漏。
- 在创建缩放（SWS）上下文前验证编解码器上下文指针，使 FFmpeg 初始化过程更加稳健。

增强：
- 将单体的视频播放器实现拆分为 `video_player_decode`、`video_player_layout` 和 `video_player_playback` 内部模块，并划清各自职责边界。
- 将媒体状态重置逻辑集中到一个辅助函数中，在单一位置清理布局缓存、释放解码资源并重置播放计时。
- 暴露共享的 `VideoFrame` 类型定义以及内部头文件，以便 seek 和播放代码可以共享队列与 PTS 辅助工具，避免重复实现。

构建：
- 更新 Makefile，在现有视频播放器组件的基础上，编译并链接新的 `video_player_decode`、`video_player_layout` 和 `video_player_playback` 模块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持现有公共 API 不变的前提下，将视频播放器重构为独立的解码、布局和播放模块，并提升播放的稳定性与健壮性。

Bug 修复：
- 在检查倒带重同步状态时，通过使用状态互斥锁（state mutex）来保护延迟帧丢弃（late-frame drop）决策，消除数据竞争。
- 在销毁 `VideoPlayer` 时清理行缓存（line cache），防止缓存的帧行泄漏。
- 在创建缩放（SWS）上下文之前先验证编解码器上下文（codec context），使 FFmpeg 初始化过程更加健壮。

增强：
- 将 FFmpeg 解码、布局/统计以及播放时序/状态逻辑分别提取到独立的内部模块（`video_player_decode`、`video_player_layout`、`video_player_playback`），并集中管理 PTS 重标定（rescaling）和队列访问器等共享辅助函数。
- 引入统一的媒体状态重置助手，用于在单一入口清理布局缓存、释放解码资源并重置播放时序。
- 暴露共享的 `VideoFrame` 类型别名以及内部头文件，使寻址（seek）和播放代码可以共享帧队列和 PTS 工具，而无需重复实现。

构建：
- 更新构建配置，以便在编译和链接时同时包含新的视频播放器内部模块和现有组件。

测试：
- 整理内部测试对 `VideoFrame` 类型别名的使用方式，使其与新的共享定义保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the video player into dedicated decode, layout, and playback modules while preserving the public API and improve playback robustness.

Bug Fixes:
- Guard late-frame drop decisions with the state mutex when checking rewind resync state to remove a data race.
- Clear the line cache on VideoPlayer destruction to prevent leaking cached frame lines.
- Validate the codec context before creating the scaling (SWS) context to make FFmpeg initialization more robust.

Enhancements:
- Extract FFmpeg decode, layout/stats, and playback timing/state logic into separate internal modules (`video_player_decode`, `video_player_layout`, `video_player_playback`) and centralize shared helpers such as PTS rescaling and queue accessors.
- Introduce a unified media-state reset helper that clears layout caches, releases decode resources, and resets playback timing in one place.
- Expose a shared `VideoFrame` alias and internal headers so seek and playback code can share frame-queue and PTS utilities without duplication.

Build:
- Update the build configuration to compile and link the new video player internal modules alongside the existing components.

Tests:
- Tidy internal test usage of the `VideoFrame` alias to align with the new shared definition.

</details>

</details>

增强内容：
- 将 FFmpeg 解码、缓冲区分配和 PTS 重采样逻辑提取到专用的 `video_player_decode` 模块中，并与寻址（seeking）代码共享。
- 将渲染布局逻辑（如行缓存管理、时间统计、队列深度控制以及“慢速等级”计算）提取到 `video_player_layout` 模块中。
- 将播放状态和计时逻辑（包括代数计数器、EOF 标志、帧队列辅助函数以及调度决策）提取到 `video_player_playback` 模块中。
- 引入统一的媒体状态重置辅助函数，在一个地方清理解码资源、布局缓存和播放计时信息。

构建：
- 更新 Makefile，将新的 `video_player_decode`、`video_player_layout` 和 `video_player_playback` 对象与现有视频播放器组件一同编译和链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持现有公共 API 不变的前提下，将视频播放器重构为独立的解码、布局和播放模块，并提升播放的稳定性与健壮性。

Bug 修复：
- 在检查倒带重同步状态时，通过使用状态互斥锁（state mutex）来保护延迟帧丢弃（late-frame drop）决策，消除数据竞争。
- 在销毁 `VideoPlayer` 时清理行缓存（line cache），防止缓存的帧行泄漏。
- 在创建缩放（SWS）上下文之前先验证编解码器上下文（codec context），使 FFmpeg 初始化过程更加健壮。

增强：
- 将 FFmpeg 解码、布局/统计以及播放时序/状态逻辑分别提取到独立的内部模块（`video_player_decode`、`video_player_layout`、`video_player_playback`），并集中管理 PTS 重标定（rescaling）和队列访问器等共享辅助函数。
- 引入统一的媒体状态重置助手，用于在单一入口清理布局缓存、释放解码资源并重置播放时序。
- 暴露共享的 `VideoFrame` 类型别名以及内部头文件，使寻址（seek）和播放代码可以共享帧队列和 PTS 工具，而无需重复实现。

构建：
- 更新构建配置，以便在编译和链接时同时包含新的视频播放器内部模块和现有组件。

测试：
- 整理内部测试对 `VideoFrame` 类型别名的使用方式，使其与新的共享定义保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the video player into dedicated decode, layout, and playback modules while preserving the public API and improve playback robustness.

Bug Fixes:
- Guard late-frame drop decisions with the state mutex when checking rewind resync state to remove a data race.
- Clear the line cache on VideoPlayer destruction to prevent leaking cached frame lines.
- Validate the codec context before creating the scaling (SWS) context to make FFmpeg initialization more robust.

Enhancements:
- Extract FFmpeg decode, layout/stats, and playback timing/state logic into separate internal modules (`video_player_decode`, `video_player_layout`, `video_player_playback`) and centralize shared helpers such as PTS rescaling and queue accessors.
- Introduce a unified media-state reset helper that clears layout caches, releases decode resources, and resets playback timing in one place.
- Expose a shared `VideoFrame` alias and internal headers so seek and playback code can share frame-queue and PTS utilities without duplication.

Build:
- Update the build configuration to compile and link the new video player internal modules alongside the existing components.

Tests:
- Tidy internal test usage of the `VideoFrame` alias to align with the new shared definition.

</details>

Bug 修复：
- 通过在迟到帧丢弃决策逻辑中，在 state 互斥锁保护下读取 `rewind_needs_resync`，修复数据竞争问题。
- 在 VideoPlayer 销毁时清理 `last_frame_lines`，防止行缓存的内存泄漏。
- 在创建缩放（SWS）上下文前验证编解码器上下文指针，使 FFmpeg 初始化过程更加稳健。

增强：
- 将单体的视频播放器实现拆分为 `video_player_decode`、`video_player_layout` 和 `video_player_playback` 内部模块，并划清各自职责边界。
- 将媒体状态重置逻辑集中到一个辅助函数中，在单一位置清理布局缓存、释放解码资源并重置播放计时。
- 暴露共享的 `VideoFrame` 类型定义以及内部头文件，以便 seek 和播放代码可以共享队列与 PTS 辅助工具，避免重复实现。

构建：
- 更新 Makefile，在现有视频播放器组件的基础上，编译并链接新的 `video_player_decode`、`video_player_layout` 和 `video_player_playback` 模块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持现有公共 API 不变的前提下，将视频播放器重构为独立的解码、布局和播放模块，并提升播放的稳定性与健壮性。

Bug 修复：
- 在检查倒带重同步状态时，通过使用状态互斥锁（state mutex）来保护延迟帧丢弃（late-frame drop）决策，消除数据竞争。
- 在销毁 `VideoPlayer` 时清理行缓存（line cache），防止缓存的帧行泄漏。
- 在创建缩放（SWS）上下文之前先验证编解码器上下文（codec context），使 FFmpeg 初始化过程更加健壮。

增强：
- 将 FFmpeg 解码、布局/统计以及播放时序/状态逻辑分别提取到独立的内部模块（`video_player_decode`、`video_player_layout`、`video_player_playback`），并集中管理 PTS 重标定（rescaling）和队列访问器等共享辅助函数。
- 引入统一的媒体状态重置助手，用于在单一入口清理布局缓存、释放解码资源并重置播放时序。
- 暴露共享的 `VideoFrame` 类型别名以及内部头文件，使寻址（seek）和播放代码可以共享帧队列和 PTS 工具，而无需重复实现。

构建：
- 更新构建配置，以便在编译和链接时同时包含新的视频播放器内部模块和现有组件。

测试：
- 整理内部测试对 `VideoFrame` 类型别名的使用方式，使其与新的共享定义保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the video player into dedicated decode, layout, and playback modules while preserving the public API and improve playback robustness.

Bug Fixes:
- Guard late-frame drop decisions with the state mutex when checking rewind resync state to remove a data race.
- Clear the line cache on VideoPlayer destruction to prevent leaking cached frame lines.
- Validate the codec context before creating the scaling (SWS) context to make FFmpeg initialization more robust.

Enhancements:
- Extract FFmpeg decode, layout/stats, and playback timing/state logic into separate internal modules (`video_player_decode`, `video_player_layout`, `video_player_playback`) and centralize shared helpers such as PTS rescaling and queue accessors.
- Introduce a unified media-state reset helper that clears layout caches, releases decode resources, and resets playback timing in one place.
- Expose a shared `VideoFrame` alias and internal headers so seek and playback code can share frame-queue and PTS utilities without duplication.

Build:
- Update the build configuration to compile and link the new video player internal modules alongside the existing components.

Tests:
- Tidy internal test usage of the `VideoFrame` alias to align with the new shared definition.

</details>

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `src/video_player.c` into decode, layout, and playback modules to clarify responsibilities. Public `video_player.h` API and behavior remain the same; also fixed a data race, a small leak, and hardened SWS context creation.

- **Refactors**
  - Added `video_player_decode.{c,h}` (FFmpeg init, SWS, RGBA alloc, teardown, PTS rescale, draining).
  - Added `video_player_layout.{c,h}` (line cache, I/O timing, queue depth, pixel-mode label).
  - Added `video_player_playback.{c,h}` (generation, frame delay, EOF flags, target-PTS clock, queue peek/length, slow-level/late-window, `calc_delay_ms`, late-drop).
  - Moved `video_player_has_renderer` to `video_player.c` core.
  - Build: Makefile links new objects; `video_player_seek.c` uses exported `video_player_rescale_pts_ms`; centralized `typedef RenderedFrame VideoFrame` and queue-depth constants.

- **Bug Fixes**
  - Fixed data race by reading `rewind_needs_resync` under `state_mutex` in `video_player_should_drop_late_frame`.
  - Fixed memory leak by calling `video_player_clear_line_cache` in `video_player_destroy`.
  - Added NULL check in `video_player_create_sws_context` for `codec_context`.
  - Validate SWS dimensions in `video_player_create_sws_context`; added test to reject invalid width/height.

<sup>Written for commit ab87ddc63636965ffdda7307c415ffe6904d9230. Summary will update on new commits. <a href="https://cubic.dev/pr/zouyonghe/PixelTerm-C/pull/23?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

