### PR TITLE
fix: harden video player lifecycle edges

### DIFF
--- a/src/video_player.c
+++ b/src/video_player.c
@@ -140,6 +140,8 @@ static void video_player_schedule_tick(VideoPlayer *player) {
     g_mutex_lock(&player->state_mutex);
     gboolean is_playing = player->is_playing;
     g_mutex_unlock(&player->state_mutex);
+    /* video_player_has_renderer() takes render_mutex; keep renderer reads
+     * centralized so detach cannot race with tick scheduling. */
     if (!is_playing || !video_player_has_renderer(player)) {
         return;
     }
@@ -676,7 +678,8 @@ void video_player_set_renderer(VideoPlayer *player, ImageRenderer *renderer) {
     g_mutex_lock(&player->render_mutex);
     gboolean replacing_renderer = player->renderer && player->renderer != renderer;
     g_mutex_unlock(&player->render_mutex);
-    /* Replacing with NULL detaches the renderer, so playback must stop now.
+    /* Replacing with NULL detaches the renderer, so playback must stop now;
+     * a later reattach is inert until callers explicitly start playback again.
      * Replacing with a renderer pauses workers during the swap and resumes. */
     gboolean was_playing = replacing_renderer && video_player_is_playing(player);
     guint timer_id = 0;

--- a/src/video_player.c
+++ b/src/video_player.c
@@ -150,12 +150,20 @@ static void video_player_schedule_tick(VideoPlayer *player) {
     }
 
     g_mutex_lock(&player->state_mutex);
+    if (!player->is_playing || player->eof_ended) {
+        g_mutex_unlock(&player->state_mutex);
+        return;
+    }
     guint old_timer_id = player->timer_id;
     player->timer_id = g_timeout_add(delay, video_player_tick, player);
     g_mutex_unlock(&player->state_mutex);
     if (old_timer_id != 0) {
         g_source_remove(old_timer_id);
     }
+}
+
+void video_player_schedule_tick_for_test(VideoPlayer *player) {
+    video_player_schedule_tick(player);
 }
 
 void decoded_frame_destroy(DecodedFrame *frame) {
@@ -667,9 +675,21 @@ void video_player_set_renderer(VideoPlayer *player, ImageRenderer *renderer) {
     g_mutex_lock(&player->render_mutex);
     gboolean replacing_renderer = player->renderer && player->renderer != renderer;
     g_mutex_unlock(&player->render_mutex);
-    gboolean was_playing = replacing_renderer && renderer && video_player_is_playing(player);
+    gboolean was_playing = replacing_renderer && video_player_is_playing(player);
+    guint timer_id = 0;
     if (replacing_renderer) {
+        if (!renderer && was_playing) {
+            video_player_generation_bump(player);
+            g_mutex_lock(&player->state_mutex);
+            player->is_playing = FALSE;
+            timer_id = player->timer_id;
+            player->timer_id = 0;
+            g_mutex_unlock(&player->state_mutex);
+        }
         video_player_stop_worker(player);
+    }
+    if (timer_id != 0) {
+        g_source_remove(timer_id);
     }
 
     g_mutex_lock(&player->render_mutex);
@@ -680,7 +700,7 @@ void video_player_set_renderer(VideoPlayer *player, ImageRenderer *renderer) {
     player->owns_renderer = FALSE;
     g_mutex_unlock(&player->render_mutex);
 
-    if (was_playing) {
+    if (renderer && was_playing) {
         video_player_resume_playback_loop(player);
     }
 }

--- a/src/video_player.c
+++ b/src/video_player.c
@@ -29,6 +29,7 @@ static gint video_player_live_instances = 0;
 static gboolean video_player_should_reject_rendered_frame_locked(VideoPlayer *player,
                                                                  VideoFrame *frame,
                                                                  gboolean check_stale_pts);
+static gboolean video_player_has_renderer(VideoPlayer *player);
 static ErrorCode video_player_seek_to_ms(VideoPlayer *player, gint64 current_ms, gint64 target_ms);
 static gboolean video_player_has_tail_work_locked(VideoPlayer *player);
 static gboolean video_player_finalize_pending_eof_if_drained(VideoPlayer *player);
@@ -139,7 +140,7 @@ static void video_player_schedule_tick(VideoPlayer *player) {
     g_mutex_lock(&player->state_mutex);
     gboolean is_playing = player->is_playing;
     g_mutex_unlock(&player->state_mutex);
-    if (!is_playing) {
+    if (!is_playing || !video_player_has_renderer(player)) {
         return;
     }
 

--- a/src/video_player.c
+++ b/src/video_player.c
@@ -162,7 +162,7 @@ static void video_player_schedule_tick(VideoPlayer *player) {
     }
 }
 
-void video_player_schedule_tick_for_test(VideoPlayer *player) {
+G_GNUC_INTERNAL void video_player_schedule_tick_for_test(VideoPlayer *player) {
     video_player_schedule_tick(player);
 }
 
@@ -675,6 +675,8 @@ void video_player_set_renderer(VideoPlayer *player, ImageRenderer *renderer) {
     g_mutex_lock(&player->render_mutex);
     gboolean replacing_renderer = player->renderer && player->renderer != renderer;
     g_mutex_unlock(&player->render_mutex);
+    /* Replacing with NULL detaches the renderer, so playback must stop now.
+     * Replacing with a renderer pauses workers during the swap and resumes. */
     gboolean was_playing = replacing_renderer && video_player_is_playing(player);
     guint timer_id = 0;
     if (replacing_renderer) {

--- a/tests/test_video_player.c
+++ b/tests/test_video_player.c
@@ -1323,6 +1323,51 @@ static void test_set_renderer_restarts_workers_when_replacing_during_playback(vo
     video_player_destroy(player);
 }
 
+static void test_set_renderer_null_stops_playback_and_timer(void) {
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    if (!player) {
+        g_test_skip("video player unavailable");
+        return;
+    }
+
+    g_mutex_lock(&player->state_mutex);
+    player->is_playing = TRUE;
+    player->timer_id = g_timeout_add(60000, timeout_source_noop, NULL);
+    guint active_timer_id = player->timer_id;
+    g_mutex_unlock(&player->state_mutex);
+    g_assert_cmpuint(active_timer_id, !=, 0);
+
+    video_player_set_renderer(player, NULL);
+
+    g_assert_false(video_player_is_playing(player));
+    g_mutex_lock(&player->state_mutex);
+    g_assert_cmpuint(player->timer_id, ==, 0);
+    g_mutex_unlock(&player->state_mutex);
+
+    video_player_destroy(player);
+}
+
+static void test_schedule_tick_skips_when_eof_already_ended(void) {
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    if (!player) {
+        g_test_skip("video player unavailable");
+        return;
+    }
+
+    g_mutex_lock(&player->state_mutex);
+    player->is_playing = TRUE;
+    player->eof_ended = TRUE;
+    g_mutex_unlock(&player->state_mutex);
+
+    video_player_schedule_tick_for_test(player);
+
+    g_mutex_lock(&player->state_mutex);
+    g_assert_cmpuint(player->timer_id, ==, 0);
+    g_mutex_unlock(&player->state_mutex);
+
+    video_player_destroy(player);
+}
+
 static void test_seek_relative_after_eof_stops_parked_workers_before_preview(void) {
     VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
     if (!player) {
@@ -2412,6 +2457,10 @@ void register_video_player_tests(void) {
                     test_play_after_eof_rewinds_explicitly_to_start);
     g_test_add_func("/video_player/set_renderer/restarts_workers_when_replacing_during_playback",
                     test_set_renderer_restarts_workers_when_replacing_during_playback);
+    g_test_add_func("/video_player/set_renderer/null_stops_playback_and_timer",
+                    test_set_renderer_null_stops_playback_and_timer);
+    g_test_add_func("/video_player/schedule_tick/skips_when_eof_already_ended",
+                    test_schedule_tick_skips_when_eof_already_ended);
     g_test_add_func("/video_player/seek_relative/after_eof_stops_parked_workers_before_preview",
                     test_seek_relative_after_eof_stops_parked_workers_before_preview);
     g_test_add_func("/video_player/seek_relative/after_eof_real_preview_does_not_crash",

--- a/tests/test_video_player.c
+++ b/tests/test_video_player.c
@@ -1332,7 +1332,7 @@ static void test_set_renderer_null_stops_playback_and_timer(void) {
 
     g_mutex_lock(&player->state_mutex);
     player->is_playing = TRUE;
-    player->timer_id = g_timeout_add(60000, timeout_source_noop, NULL);
+    player->timer_id = g_timeout_add(10, timeout_source_noop, NULL);
     guint active_timer_id = player->timer_id;
     g_mutex_unlock(&player->state_mutex);
     g_assert_cmpuint(active_timer_id, !=, 0);
@@ -1357,6 +1357,49 @@ static void test_schedule_tick_skips_when_eof_already_ended(void) {
     g_mutex_lock(&player->state_mutex);
     player->is_playing = TRUE;
     player->eof_ended = TRUE;
+    g_mutex_unlock(&player->state_mutex);
+
+    video_player_schedule_tick_for_test(player);
+
+    g_mutex_lock(&player->state_mutex);
+    g_assert_cmpuint(player->timer_id, ==, 0);
+    g_mutex_unlock(&player->state_mutex);
+
+    video_player_destroy(player);
+}
+
+static void test_schedule_tick_skips_when_not_playing(void) {
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    if (!player) {
+        g_test_skip("video player unavailable");
+        return;
+    }
+
+    g_mutex_lock(&player->state_mutex);
+    player->is_playing = FALSE;
+    player->eof_ended = FALSE;
+    g_mutex_unlock(&player->state_mutex);
+
+    video_player_schedule_tick_for_test(player);
+
+    g_mutex_lock(&player->state_mutex);
+    g_assert_cmpuint(player->timer_id, ==, 0);
+    g_mutex_unlock(&player->state_mutex);
+
+    video_player_destroy(player);
+}
+
+static void test_schedule_tick_skips_without_renderer(void) {
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    if (!player) {
+        g_test_skip("video player unavailable");
+        return;
+    }
+
+    video_player_set_renderer(player, NULL);
+    g_mutex_lock(&player->state_mutex);
+    player->is_playing = TRUE;
+    player->eof_ended = FALSE;
     g_mutex_unlock(&player->state_mutex);
 
     video_player_schedule_tick_for_test(player);
@@ -2461,6 +2504,10 @@ void register_video_player_tests(void) {
                     test_set_renderer_null_stops_playback_and_timer);
     g_test_add_func("/video_player/schedule_tick/skips_when_eof_already_ended",
                     test_schedule_tick_skips_when_eof_already_ended);
+    g_test_add_func("/video_player/schedule_tick/skips_when_not_playing",
+                    test_schedule_tick_skips_when_not_playing);
+    g_test_add_func("/video_player/schedule_tick/skips_without_renderer",
+                    test_schedule_tick_skips_without_renderer);
     g_test_add_func("/video_player/seek_relative/after_eof_stops_parked_workers_before_preview",
                     test_seek_relative_after_eof_stops_parked_workers_before_preview);
     g_test_add_func("/video_player/seek_relative/after_eof_real_preview_does_not_crash",

--- a/tests/video_player_test_internal.h
+++ b/tests/video_player_test_internal.h
@@ -37,6 +37,7 @@ DecodedFrame *video_player_decode_queue_wait_and_take(VideoPlayer *player);
 gboolean video_player_should_drop_late_frame(VideoPlayer *player, gint64 pts_ms);
 gint video_player_calc_delay_ms(VideoPlayer *player);
 void video_player_update_queue_depth(VideoPlayer *player, gint rendered_w, gint rendered_h);
+void video_player_schedule_tick_for_test(VideoPlayer *player);
 gint64 video_player_current_position_ms_for_test(VideoPlayer *player);
 gint64 video_player_seek_target_ms_for_test(VideoPlayer *player, gint64 delta_ms, gint64 duration_ms);
 RendererConfig video_player_render_worker_config_for_test(VideoPlayer *player);

--- a/tests/video_player_test_internal.h
+++ b/tests/video_player_test_internal.h
@@ -37,7 +37,7 @@ DecodedFrame *video_player_decode_queue_wait_and_take(VideoPlayer *player);
 gboolean video_player_should_drop_late_frame(VideoPlayer *player, gint64 pts_ms);
 gint video_player_calc_delay_ms(VideoPlayer *player);
 void video_player_update_queue_depth(VideoPlayer *player, gint rendered_w, gint rendered_h);
-void video_player_schedule_tick_for_test(VideoPlayer *player);
+G_GNUC_INTERNAL void video_player_schedule_tick_for_test(VideoPlayer *player);
 gint64 video_player_current_position_ms_for_test(VideoPlayer *player);
 gint64 video_player_seek_target_ms_for_test(VideoPlayer *player, gint64 delta_ms, gint64 duration_ms);
 RendererConfig video_player_render_worker_config_for_test(VideoPlayer *player);


### PR DESCRIPTION
## Summary
- prevent video playback tick scheduling after playback has already ended
- stop playback and clear active timers when detaching the video renderer during playback
- add regression coverage for renderer detach and ended-playback scheduling paths

## Verification
- rtk make test
- rtk git diff --check

Co-Authored-By: Warp <agent@warp.dev>

## Summary by Sourcery

在渲染器分离和心跳定时调度方面强化视频播放器的生命周期处理，以避免产生多余的定时器以及出现不一致的播放状态。

Bug 修复：
- 当通过 NULL 渲染器分离渲染器时，停止播放、清除活动定时器，并避免自动恢复播放。
- 当播放处于非活动状态、已到达 EOF，或未配置渲染器时，跳过播放心跳（tick）的调度。

测试：
- 添加回归测试，以验证在活动播放过程中分离渲染器时，会停止播放并停止相关定时器。
- 添加回归测试，以确保在播放已结束、不处于活动状态或未设置渲染器时，会跳过心跳调度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden video player lifecycle handling around renderer detaches and tick scheduling to avoid stray timers and inconsistent playback state.

Bug Fixes:
- Stop playback, clear active timers, and avoid auto-resume when the renderer is detached via a NULL renderer.
- Skip scheduling playback ticks when playback is inactive, EOF has already been reached, or no renderer is configured.

Tests:
- Add regression tests to verify playback and timers are stopped when detaching the renderer during active playback.
- Add regression tests to ensure tick scheduling is skipped when playback has ended, is not active, or when no renderer is set.

</details>

Bug 修复：
- 在通过 NULL renderer 分离渲染器时，停止播放、清除所有活动计时器，并避免自动恢复播放。
- 当播放不处于活动状态、流已结束或没有可用渲染器时，跳过安排播放 tick。

测试：
- 添加回归测试，覆盖在主动播放期间分离渲染器的场景，并确保播放停止且计时器被清除。
- 添加回归测试，验证在播放已结束、不在播放状态或未配置渲染器时，会跳过 tick 调度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在渲染器分离和心跳定时调度方面强化视频播放器的生命周期处理，以避免产生多余的定时器以及出现不一致的播放状态。

Bug 修复：
- 当通过 NULL 渲染器分离渲染器时，停止播放、清除活动定时器，并避免自动恢复播放。
- 当播放处于非活动状态、已到达 EOF，或未配置渲染器时，跳过播放心跳（tick）的调度。

测试：
- 添加回归测试，以验证在活动播放过程中分离渲染器时，会停止播放并停止相关定时器。
- 添加回归测试，以确保在播放已结束、不处于活动状态或未设置渲染器时，会跳过心跳调度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden video player lifecycle handling around renderer detaches and tick scheduling to avoid stray timers and inconsistent playback state.

Bug Fixes:
- Stop playback, clear active timers, and avoid auto-resume when the renderer is detached via a NULL renderer.
- Skip scheduling playback ticks when playback is inactive, EOF has already been reached, or no renderer is configured.

Tests:
- Add regression tests to verify playback and timers are stopped when detaching the renderer during active playback.
- Add regression tests to ensure tick scheduling is skipped when playback has ended, is not active, or when no renderer is set.

</details>

</details>

Bug 修复：
- 在播放处于非活动状态或已达到文件结束（EOF）状态时，跳过播放 tick 的调度。
- 当通过 NULL 渲染器分离渲染器时，停止播放，清除任何活动定时器，并避免自动恢复播放。

测试：
- 添加回归测试，以覆盖播放过程中渲染器分离的场景，以及在播放已经结束时进行 tick 调度的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在渲染器分离和心跳定时调度方面强化视频播放器的生命周期处理，以避免产生多余的定时器以及出现不一致的播放状态。

Bug 修复：
- 当通过 NULL 渲染器分离渲染器时，停止播放、清除活动定时器，并避免自动恢复播放。
- 当播放处于非活动状态、已到达 EOF，或未配置渲染器时，跳过播放心跳（tick）的调度。

测试：
- 添加回归测试，以验证在活动播放过程中分离渲染器时，会停止播放并停止相关定时器。
- 添加回归测试，以确保在播放已结束、不处于活动状态或未设置渲染器时，会跳过心跳调度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden video player lifecycle handling around renderer detaches and tick scheduling to avoid stray timers and inconsistent playback state.

Bug Fixes:
- Stop playback, clear active timers, and avoid auto-resume when the renderer is detached via a NULL renderer.
- Skip scheduling playback ticks when playback is inactive, EOF has already been reached, or no renderer is configured.

Tests:
- Add regression tests to verify playback and timers are stopped when detaching the renderer during active playback.
- Add regression tests to ensure tick scheduling is skipped when playback has ended, is not active, or when no renderer is set.

</details>

Bug 修复：
- 在通过 NULL renderer 分离渲染器时，停止播放、清除所有活动计时器，并避免自动恢复播放。
- 当播放不处于活动状态、流已结束或没有可用渲染器时，跳过安排播放 tick。

测试：
- 添加回归测试，覆盖在主动播放期间分离渲染器的场景，并确保播放停止且计时器被清除。
- 添加回归测试，验证在播放已结束、不在播放状态或未配置渲染器时，会跳过 tick 调度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在渲染器分离和心跳定时调度方面强化视频播放器的生命周期处理，以避免产生多余的定时器以及出现不一致的播放状态。

Bug 修复：
- 当通过 NULL 渲染器分离渲染器时，停止播放、清除活动定时器，并避免自动恢复播放。
- 当播放处于非活动状态、已到达 EOF，或未配置渲染器时，跳过播放心跳（tick）的调度。

测试：
- 添加回归测试，以验证在活动播放过程中分离渲染器时，会停止播放并停止相关定时器。
- 添加回归测试，以确保在播放已结束、不处于活动状态或未设置渲染器时，会跳过心跳调度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden video player lifecycle handling around renderer detaches and tick scheduling to avoid stray timers and inconsistent playback state.

Bug Fixes:
- Stop playback, clear active timers, and avoid auto-resume when the renderer is detached via a NULL renderer.
- Skip scheduling playback ticks when playback is inactive, EOF has already been reached, or no renderer is configured.

Tests:
- Add regression tests to verify playback and timers are stopped when detaching the renderer during active playback.
- Add regression tests to ensure tick scheduling is skipped when playback has ended, is not active, or when no renderer is set.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在渲染器分离和心跳定时调度方面强化视频播放器的生命周期处理，以避免产生多余的定时器以及出现不一致的播放状态。

Bug 修复：
- 当通过 NULL 渲染器分离渲染器时，停止播放、清除活动定时器，并避免自动恢复播放。
- 当播放处于非活动状态、已到达 EOF，或未配置渲染器时，跳过播放心跳（tick）的调度。

测试：
- 添加回归测试，以验证在活动播放过程中分离渲染器时，会停止播放并停止相关定时器。
- 添加回归测试，以确保在播放已结束、不处于活动状态或未设置渲染器时，会跳过心跳调度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden video player lifecycle handling around renderer detaches and tick scheduling to avoid stray timers and inconsistent playback state.

Bug Fixes:
- Stop playback, clear active timers, and avoid auto-resume when the renderer is detached via a NULL renderer.
- Skip scheduling playback ticks when playback is inactive, EOF has already been reached, or no renderer is configured.

Tests:
- Add regression tests to verify playback and timers are stopped when detaching the renderer during active playback.
- Add regression tests to ensure tick scheduling is skipped when playback has ended, is not active, or when no renderer is set.

</details>

Bug 修复：
- 在通过 NULL renderer 分离渲染器时，停止播放、清除所有活动计时器，并避免自动恢复播放。
- 当播放不处于活动状态、流已结束或没有可用渲染器时，跳过安排播放 tick。

测试：
- 添加回归测试，覆盖在主动播放期间分离渲染器的场景，并确保播放停止且计时器被清除。
- 添加回归测试，验证在播放已结束、不在播放状态或未配置渲染器时，会跳过 tick 调度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在渲染器分离和心跳定时调度方面强化视频播放器的生命周期处理，以避免产生多余的定时器以及出现不一致的播放状态。

Bug 修复：
- 当通过 NULL 渲染器分离渲染器时，停止播放、清除活动定时器，并避免自动恢复播放。
- 当播放处于非活动状态、已到达 EOF，或未配置渲染器时，跳过播放心跳（tick）的调度。

测试：
- 添加回归测试，以验证在活动播放过程中分离渲染器时，会停止播放并停止相关定时器。
- 添加回归测试，以确保在播放已结束、不处于活动状态或未设置渲染器时，会跳过心跳调度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden video player lifecycle handling around renderer detaches and tick scheduling to avoid stray timers and inconsistent playback state.

Bug Fixes:
- Stop playback, clear active timers, and avoid auto-resume when the renderer is detached via a NULL renderer.
- Skip scheduling playback ticks when playback is inactive, EOF has already been reached, or no renderer is configured.

Tests:
- Add regression tests to verify playback and timers are stopped when detaching the renderer during active playback.
- Add regression tests to ensure tick scheduling is skipped when playback has ended, is not active, or when no renderer is set.

</details>

</details>

Bug 修复：
- 在播放处于非活动状态或已达到文件结束（EOF）状态时，跳过播放 tick 的调度。
- 当通过 NULL 渲染器分离渲染器时，停止播放，清除任何活动定时器，并避免自动恢复播放。

测试：
- 添加回归测试，以覆盖播放过程中渲染器分离的场景，以及在播放已经结束时进行 tick 调度的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在渲染器分离和心跳定时调度方面强化视频播放器的生命周期处理，以避免产生多余的定时器以及出现不一致的播放状态。

Bug 修复：
- 当通过 NULL 渲染器分离渲染器时，停止播放、清除活动定时器，并避免自动恢复播放。
- 当播放处于非活动状态、已到达 EOF，或未配置渲染器时，跳过播放心跳（tick）的调度。

测试：
- 添加回归测试，以验证在活动播放过程中分离渲染器时，会停止播放并停止相关定时器。
- 添加回归测试，以确保在播放已结束、不处于活动状态或未设置渲染器时，会跳过心跳调度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden video player lifecycle handling around renderer detaches and tick scheduling to avoid stray timers and inconsistent playback state.

Bug Fixes:
- Stop playback, clear active timers, and avoid auto-resume when the renderer is detached via a NULL renderer.
- Skip scheduling playback ticks when playback is inactive, EOF has already been reached, or no renderer is configured.

Tests:
- Add regression tests to verify playback and timers are stopped when detaching the renderer during active playback.
- Add regression tests to ensure tick scheduling is skipped when playback has ended, is not active, or when no renderer is set.

</details>

Bug 修复：
- 在通过 NULL renderer 分离渲染器时，停止播放、清除所有活动计时器，并避免自动恢复播放。
- 当播放不处于活动状态、流已结束或没有可用渲染器时，跳过安排播放 tick。

测试：
- 添加回归测试，覆盖在主动播放期间分离渲染器的场景，并确保播放停止且计时器被清除。
- 添加回归测试，验证在播放已结束、不在播放状态或未配置渲染器时，会跳过 tick 调度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在渲染器分离和心跳定时调度方面强化视频播放器的生命周期处理，以避免产生多余的定时器以及出现不一致的播放状态。

Bug 修复：
- 当通过 NULL 渲染器分离渲染器时，停止播放、清除活动定时器，并避免自动恢复播放。
- 当播放处于非活动状态、已到达 EOF，或未配置渲染器时，跳过播放心跳（tick）的调度。

测试：
- 添加回归测试，以验证在活动播放过程中分离渲染器时，会停止播放并停止相关定时器。
- 添加回归测试，以确保在播放已结束、不处于活动状态或未设置渲染器时，会跳过心跳调度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden video player lifecycle handling around renderer detaches and tick scheduling to avoid stray timers and inconsistent playback state.

Bug Fixes:
- Stop playback, clear active timers, and avoid auto-resume when the renderer is detached via a NULL renderer.
- Skip scheduling playback ticks when playback is inactive, EOF has already been reached, or no renderer is configured.

Tests:
- Add regression tests to verify playback and timers are stopped when detaching the renderer during active playback.
- Add regression tests to ensure tick scheduling is skipped when playback has ended, is not active, or when no renderer is set.

</details>

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes video player lifecycle races to prevent stray timers and inconsistent playback on renderer detach and after EOF. Clarifies renderer lifecycle guards in docs and adds tests for inactive and no-renderer scheduling.

- **Bug Fixes**
  - Skip scheduling ticks when playback is inactive, `eof_ended` is true, or no renderer is present.
  - On renderer detach (`set_renderer(NULL)`), stop playback, clear `timer_id`, remove the GLib timeout, stop workers, and only resume when a renderer is set again.

<sup>Written for commit 35e9726f55b0a6c4599dd996d848bbfac1538d94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zouyonghe/PixelTerm-C/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

