### PR TITLE
build: harden default compiler flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,22 +33,6 @@ else
   HARDENING_LDFLAGS ?=
 endif
 FORTIFY_LEVEL ?= 2
-FORTIFY_SOURCE_FLAGS := $(CFLAGS) $(EXTRA_CFLAGS) $(CPPFLAGS) $(OPTIMIZATION_CFLAGS)
-FORTIFY_OPT_FLAGS := $(filter -O1 -O2 -O3 -Og -Os -Oz -Ofast,$(FORTIFY_SOURCE_FLAGS))
-FORTIFY_O0_FLAGS := $(filter -O0,$(FORTIFY_SOURCE_FLAGS))
-ifeq ($(ENABLE_HARDENING),1)
-  ifneq ($(findstring _FORTIFY_SOURCE,$(FORTIFY_SOURCE_FLAGS)),)
-    FORTIFY_CFLAGS ?=
-  else ifneq ($(FORTIFY_O0_FLAGS),)
-    FORTIFY_CFLAGS ?=
-  else ifneq ($(FORTIFY_OPT_FLAGS),)
-    FORTIFY_CFLAGS ?= -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=$(FORTIFY_LEVEL)
-  else
-    FORTIFY_CFLAGS ?=
-  endif
-else
-  FORTIFY_CFLAGS ?=
-endif
 CFLAGS = -Wall -Wextra -std=c11 $(OPTIMIZATION_CFLAGS) -Wno-sign-compare -Wno-unused-variable -Wno-unused-but-set-variable -Wno-switch -DAPP_VERSION=\"$(VERSION)\"
 DEBUG_CFLAGS = -g -DDEBUG -fsanitize=address
 DEPFLAGS = -MMD -MP
@@ -78,10 +62,6 @@ ifeq ($(ENABLE_HARDENING),1)
 endif
 ifeq ($(DEBUG),1)
   CFLAGS += $(DEBUG_CFLAGS)
-endif
-ifeq ($(ENABLE_HARDENING),1)
-  # _FORTIFY_SOURCE needs optimization; keep OPTIMIZATION_CFLAGS at -O1 or higher for normal builds.
-  CFLAGS += $(HARDENING_CFLAGS) $(FORTIFY_CFLAGS)
 endif
 EXTRA_LIBS =
 ifneq ($(shell $(PKG_CONFIG_CMD) --exists zlib >/dev/null 2>&1 && echo yes),)
@@ -143,6 +123,26 @@ else
   else
     $(warning mupdf not found; building without book support)
   endif
+endif
+FORTIFY_SOURCE_FLAGS := $(CFLAGS) $(EXTRA_CFLAGS) $(CPPFLAGS)
+FORTIFY_OPT_FLAGS := $(filter -O1 -O2 -O3 -Og -Os -Oz -Ofast,$(FORTIFY_SOURCE_FLAGS))
+FORTIFY_O0_FLAGS := $(filter -O0,$(FORTIFY_SOURCE_FLAGS))
+ifeq ($(ENABLE_HARDENING),1)
+  ifneq ($(findstring _FORTIFY_SOURCE,$(FORTIFY_SOURCE_FLAGS)),)
+    FORTIFY_CFLAGS ?=
+  else ifneq ($(FORTIFY_O0_FLAGS),)
+    FORTIFY_CFLAGS ?=
+  else ifneq ($(FORTIFY_OPT_FLAGS),)
+    FORTIFY_CFLAGS ?= -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=$(FORTIFY_LEVEL)
+  else
+    FORTIFY_CFLAGS ?=
+  endif
+else
+  FORTIFY_CFLAGS ?=
+endif
+ifeq ($(ENABLE_HARDENING),1)
+  # _FORTIFY_SOURCE needs optimization; keep OPTIMIZATION_CFLAGS at -O1 or higher for normal builds.
+  CFLAGS += $(HARDENING_CFLAGS) $(FORTIFY_CFLAGS)
 endif
 SRCDIR = src
 OBJDIR = obj

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,15 @@ UNAME_S := $(shell uname -s)
 # GCC/Clang hardening defaults. Override these variables for toolchains that
 # do not support the flags or downstream builds that manage hardening elsewhere.
 HARDENING ?= 1
+DEBUG ?= 0
+DEBUG_HARDENING ?= 0
+EXTRA_CFLAGS ?=
 OPTIMIZATION_CFLAGS ?= -O2
 ifeq ($(HARDENING),1)
   HARDENING_CFLAGS ?= -fstack-protector-strong
   FORTIFY_LEVEL ?= 2
-  ifneq ($(findstring _FORTIFY_SOURCE,$(EXTRA_CFLAGS)),)
+  FORTIFY_SOURCE_FLAGS := $(CFLAGS) $(EXTRA_CFLAGS) $(CPPFLAGS)
+  ifneq ($(findstring _FORTIFY_SOURCE,$(FORTIFY_SOURCE_FLAGS)),)
     FORTIFY_CFLAGS ?=
   else
     FORTIFY_CFLAGS ?= -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=$(FORTIFY_LEVEL)
@@ -26,10 +30,8 @@ else
   FORTIFY_CFLAGS ?=
   HARDENING_LDFLAGS ?=
 endif
-CFLAGS = -Wall -Wextra -std=c11 $(OPTIMIZATION_CFLAGS) $(HARDENING_CFLAGS) -Wno-sign-compare -Wno-unused-variable -Wno-unused-but-set-variable -Wno-switch -DAPP_VERSION=\"$(VERSION)\"
+CFLAGS = -Wall -Wextra -std=c11 $(OPTIMIZATION_CFLAGS) -Wno-sign-compare -Wno-unused-variable -Wno-unused-but-set-variable -Wno-switch -DAPP_VERSION=\"$(VERSION)\"
 DEBUG_CFLAGS = -g -DDEBUG -fsanitize=address
-DEBUG ?= 0
-EXTRA_CFLAGS ?=
 DEPFLAGS = -MMD -MP
 # Prefer the locally installed Chafa when both system and /usr/local versions exist
 LDFLAGS += -Wl,-rpath -Wl,/usr/local/lib
@@ -55,9 +57,12 @@ endif
 LDFLAGS += $(HARDENING_LDFLAGS)
 ifeq ($(DEBUG),1)
   CFLAGS += $(DEBUG_CFLAGS)
+  ifeq ($(DEBUG_HARDENING),1)
+    CFLAGS += $(HARDENING_CFLAGS)
+  endif
 else
   # _FORTIFY_SOURCE needs optimization; keep OPTIMIZATION_CFLAGS at -O1 or higher for normal builds.
-  CFLAGS += $(FORTIFY_CFLAGS)
+  CFLAGS += $(HARDENING_CFLAGS) $(FORTIFY_CFLAGS)
 endif
 EXTRA_LIBS =
 ifneq ($(shell $(PKG_CONFIG_CMD) --exists zlib >/dev/null 2>&1 && echo yes),)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,13 @@ ARCH ?= amd64
 PREFIX ?= /usr/local
 INSTALL ?= install
 VERSION = $(shell git describe --tags --exact-match 2>/dev/null || git describe --tags --always --dirty 2>/dev/null | cut -d'-' -f1 | cut -c2- || echo "unknown")
-CFLAGS = -Wall -Wextra -std=c11 -O2 -fstack-protector-strong -Wno-sign-compare -Wno-unused-variable -Wno-unused-but-set-variable -Wno-switch -DAPP_VERSION=\"$(VERSION)\"
+# GCC/Clang hardening defaults. Override these variables for toolchains that
+# do not support the flags or downstream builds that manage hardening elsewhere.
+OPTIMIZATION_CFLAGS ?= -O2
+HARDENING_CFLAGS ?= -fstack-protector-strong
+FORTIFY_CFLAGS ?= -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
+HARDENING_LDFLAGS ?=
+CFLAGS = -Wall -Wextra -std=c11 $(OPTIMIZATION_CFLAGS) $(HARDENING_CFLAGS) -Wno-sign-compare -Wno-unused-variable -Wno-unused-but-set-variable -Wno-switch -DAPP_VERSION=\"$(VERSION)\"
 DEBUG_CFLAGS = -g -DDEBUG -fsanitize=address
 DEBUG ?= 0
 EXTRA_CFLAGS ?=
@@ -26,14 +32,16 @@ INCLUDES = -Iinclude $(shell $(PKG_CONFIG_CMD) --cflags glib-2.0 $(PKG_DEPS))
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
   CFLAGS += -ffunction-sections -fdata-sections
-  LDFLAGS += -Wl,--gc-sections -Wl,-z,relro -Wl,-z,now
+  HARDENING_LDFLAGS += -Wl,-z,relro -Wl,-z,now
+  LDFLAGS += -Wl,--gc-sections $(HARDENING_LDFLAGS)
 else ifeq ($(UNAME_S),Darwin)
   LDFLAGS += -Wl,-dead_strip
 endif
 ifeq ($(DEBUG),1)
   CFLAGS += $(DEBUG_CFLAGS)
 else
-  CFLAGS += -D_FORTIFY_SOURCE=2
+  # _FORTIFY_SOURCE needs optimization; keep OPTIMIZATION_CFLAGS at -O1 or higher for normal builds.
+  CFLAGS += $(FORTIFY_CFLAGS)
 endif
 EXTRA_LIBS =
 ifneq ($(shell $(PKG_CONFIG_CMD) --exists zlib >/dev/null 2>&1 && echo yes),)

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,16 @@ DEBUG_HARDENING ?= 0
 EXTRA_CFLAGS ?=
 OPTIMIZATION_CFLAGS ?= -O2
 ifeq ($(HARDENING),1)
-  HARDENING_CFLAGS ?= -fstack-protector-strong
-  FORTIFY_LEVEL ?= 2
-  FORTIFY_SOURCE_FLAGS := $(CFLAGS) $(EXTRA_CFLAGS) $(CPPFLAGS)
-  ifneq ($(findstring _FORTIFY_SOURCE,$(FORTIFY_SOURCE_FLAGS)),)
-    FORTIFY_CFLAGS ?=
+  ifeq ($(DEBUG),1)
+    ENABLE_HARDENING := $(DEBUG_HARDENING)
   else
-    FORTIFY_CFLAGS ?= -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=$(FORTIFY_LEVEL)
+    ENABLE_HARDENING := 1
   endif
+else
+  ENABLE_HARDENING := 0
+endif
+ifeq ($(ENABLE_HARDENING),1)
+  HARDENING_CFLAGS ?= -fstack-protector-strong
   ifeq ($(UNAME_S),Linux)
     HARDENING_LDFLAGS ?= -Wl,-z,relro -Wl,-z,now
   else
@@ -29,6 +31,23 @@ else
   HARDENING_CFLAGS ?=
   FORTIFY_CFLAGS ?=
   HARDENING_LDFLAGS ?=
+endif
+FORTIFY_LEVEL ?= 2
+FORTIFY_SOURCE_FLAGS := $(CFLAGS) $(EXTRA_CFLAGS) $(CPPFLAGS) $(OPTIMIZATION_CFLAGS)
+FORTIFY_OPT_FLAGS := $(filter -O1 -O2 -O3 -Og -Os -Oz -Ofast,$(FORTIFY_SOURCE_FLAGS))
+FORTIFY_O0_FLAGS := $(filter -O0,$(FORTIFY_SOURCE_FLAGS))
+ifeq ($(ENABLE_HARDENING),1)
+  ifneq ($(findstring _FORTIFY_SOURCE,$(FORTIFY_SOURCE_FLAGS)),)
+    FORTIFY_CFLAGS ?=
+  else ifneq ($(FORTIFY_O0_FLAGS),)
+    FORTIFY_CFLAGS ?=
+  else ifneq ($(FORTIFY_OPT_FLAGS),)
+    FORTIFY_CFLAGS ?= -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=$(FORTIFY_LEVEL)
+  else
+    FORTIFY_CFLAGS ?=
+  endif
+else
+  FORTIFY_CFLAGS ?=
 endif
 CFLAGS = -Wall -Wextra -std=c11 $(OPTIMIZATION_CFLAGS) -Wno-sign-compare -Wno-unused-variable -Wno-unused-but-set-variable -Wno-switch -DAPP_VERSION=\"$(VERSION)\"
 DEBUG_CFLAGS = -g -DDEBUG -fsanitize=address
@@ -54,13 +73,13 @@ ifeq ($(UNAME_S),Linux)
 else ifeq ($(UNAME_S),Darwin)
   LDFLAGS += -Wl,-dead_strip
 endif
-LDFLAGS += $(HARDENING_LDFLAGS)
+ifeq ($(ENABLE_HARDENING),1)
+  LDFLAGS += $(HARDENING_LDFLAGS)
+endif
 ifeq ($(DEBUG),1)
   CFLAGS += $(DEBUG_CFLAGS)
-  ifeq ($(DEBUG_HARDENING),1)
-    CFLAGS += $(HARDENING_CFLAGS)
-  endif
-else
+endif
+ifeq ($(ENABLE_HARDENING),1)
   # _FORTIFY_SOURCE needs optimization; keep OPTIMIZATION_CFLAGS at -O1 or higher for normal builds.
   CFLAGS += $(HARDENING_CFLAGS) $(FORTIFY_CFLAGS)
 endif

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ARCH ?= amd64
 PREFIX ?= /usr/local
 INSTALL ?= install
 VERSION = $(shell git describe --tags --exact-match 2>/dev/null || git describe --tags --always --dirty 2>/dev/null | cut -d'-' -f1 | cut -c2- || echo "unknown")
-CFLAGS = -Wall -Wextra -std=c11 -O2 -Wno-sign-compare -Wno-unused-variable -Wno-unused-but-set-variable -Wno-switch -DAPP_VERSION=\"$(VERSION)\"
+CFLAGS = -Wall -Wextra -std=c11 -O2 -fstack-protector-strong -Wno-sign-compare -Wno-unused-variable -Wno-unused-but-set-variable -Wno-switch -DAPP_VERSION=\"$(VERSION)\"
 DEBUG_CFLAGS = -g -DDEBUG -fsanitize=address
 DEBUG ?= 0
 EXTRA_CFLAGS ?=
@@ -26,12 +26,14 @@ INCLUDES = -Iinclude $(shell $(PKG_CONFIG_CMD) --cflags glib-2.0 $(PKG_DEPS))
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
   CFLAGS += -ffunction-sections -fdata-sections
-  LDFLAGS += -Wl,--gc-sections
+  LDFLAGS += -Wl,--gc-sections -Wl,-z,relro -Wl,-z,now
 else ifeq ($(UNAME_S),Darwin)
   LDFLAGS += -Wl,-dead_strip
 endif
 ifeq ($(DEBUG),1)
   CFLAGS += $(DEBUG_CFLAGS)
+else
+  CFLAGS += -D_FORTIFY_SOURCE=2
 endif
 EXTRA_LIBS =
 ifneq ($(shell $(PKG_CONFIG_CMD) --exists zlib >/dev/null 2>&1 && echo yes),)

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,8 @@ else
   endif
 endif
 FORTIFY_SOURCE_FLAGS := $(CFLAGS) $(EXTRA_CFLAGS) $(CPPFLAGS)
-FORTIFY_OPT_FLAGS := $(filter -O1 -O2 -O3 -Og -Os -Oz -Ofast,$(FORTIFY_SOURCE_FLAGS))
+# Any -O* optimization flag counts as optimized for default FORTIFY.
+FORTIFY_OPT_FLAGS := $(filter -O%,$(FORTIFY_SOURCE_FLAGS))
 FORTIFY_O0_FLAGS := $(filter -O0,$(FORTIFY_SOURCE_FLAGS))
 ifeq ($(ENABLE_HARDENING),1)
   ifneq ($(findstring _FORTIFY_SOURCE,$(FORTIFY_SOURCE_FLAGS)),)

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,29 @@ ARCH ?= amd64
 PREFIX ?= /usr/local
 INSTALL ?= install
 VERSION = $(shell git describe --tags --exact-match 2>/dev/null || git describe --tags --always --dirty 2>/dev/null | cut -d'-' -f1 | cut -c2- || echo "unknown")
+UNAME_S := $(shell uname -s)
 # GCC/Clang hardening defaults. Override these variables for toolchains that
 # do not support the flags or downstream builds that manage hardening elsewhere.
+HARDENING ?= 1
 OPTIMIZATION_CFLAGS ?= -O2
-HARDENING_CFLAGS ?= -fstack-protector-strong
-FORTIFY_CFLAGS ?= -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
-HARDENING_LDFLAGS ?=
+ifeq ($(HARDENING),1)
+  HARDENING_CFLAGS ?= -fstack-protector-strong
+  FORTIFY_LEVEL ?= 2
+  ifneq ($(findstring _FORTIFY_SOURCE,$(EXTRA_CFLAGS)),)
+    FORTIFY_CFLAGS ?=
+  else
+    FORTIFY_CFLAGS ?= -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=$(FORTIFY_LEVEL)
+  endif
+  ifeq ($(UNAME_S),Linux)
+    HARDENING_LDFLAGS ?= -Wl,-z,relro -Wl,-z,now
+  else
+    HARDENING_LDFLAGS ?=
+  endif
+else
+  HARDENING_CFLAGS ?=
+  FORTIFY_CFLAGS ?=
+  HARDENING_LDFLAGS ?=
+endif
 CFLAGS = -Wall -Wextra -std=c11 $(OPTIMIZATION_CFLAGS) $(HARDENING_CFLAGS) -Wno-sign-compare -Wno-unused-variable -Wno-unused-but-set-variable -Wno-switch -DAPP_VERSION=\"$(VERSION)\"
 DEBUG_CFLAGS = -g -DDEBUG -fsanitize=address
 DEBUG ?= 0
@@ -29,14 +46,13 @@ PKG_DEPS = chafa gdk-pixbuf-2.0 gio-2.0 libavformat libavcodec libswscale libavu
 LIBS = $(shell $(PKG_CONFIG_CMD) --libs $(PKG_DEPS)) -lpthread -lm
 INCLUDES = -Iinclude $(shell $(PKG_CONFIG_CMD) --cflags glib-2.0 $(PKG_DEPS))
 
-UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
   CFLAGS += -ffunction-sections -fdata-sections
-  HARDENING_LDFLAGS += -Wl,-z,relro -Wl,-z,now
-  LDFLAGS += -Wl,--gc-sections $(HARDENING_LDFLAGS)
+  LDFLAGS += -Wl,--gc-sections
 else ifeq ($(UNAME_S),Darwin)
   LDFLAGS += -Wl,-dead_strip
 endif
+LDFLAGS += $(HARDENING_LDFLAGS)
 ifeq ($(DEBUG),1)
   CFLAGS += $(DEBUG_CFLAGS)
 else


### PR DESCRIPTION
## Summary
- enable stack protector for default builds
- enable FORTIFY for non-DEBUG builds
- add Linux RELRO/NOW linker hardening

## Testing
- make EXTRA_CFLAGS=-Werror test
- make EXTRA_CFLAGS=-Werror debug-test

Co-Authored-By: Warp <agent@warp.dev>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

</details>

</details>

Build：
- 引入可配置的加固变量（`HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 为非 `DEBUG` 构建启用栈保护标志以及条件性定义 `_FORTIFY_SOURCE`，同时遵循已有的 `EXTRA_CFLAGS` 设置。
- 添加 Linux 特定的 RELRO/NOW 链接器标志，并根据宿主操作系统将加固相关的链接器标志接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

</details>

</details>

Build：
- 引入可配置的加固变量（`HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 为非 `DEBUG` 构建启用栈保护标志以及条件性定义 `_FORTIFY_SOURCE`，同时遵循已有的 `EXTRA_CFLAGS` 设置。
- 添加 Linux 特定的 RELRO/NOW 链接器标志，并根据宿主操作系统将加固相关的链接器标志接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

</details>

</details>

Build：
- 引入可配置的加固变量（`HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 为非 `DEBUG` 构建启用栈保护标志以及条件性定义 `_FORTIFY_SOURCE`，同时遵循已有的 `EXTRA_CFLAGS` 设置。
- 添加 Linux 特定的 RELRO/NOW 链接器标志，并根据宿主操作系统将加固相关的链接器标志接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

</details>

</details>

Build：
- 引入可配置的加固变量（`HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 为非 `DEBUG` 构建启用栈保护标志以及条件性定义 `_FORTIFY_SOURCE`，同时遵循已有的 `EXTRA_CFLAGS` 设置。
- 添加 Linux 特定的 RELRO/NOW 链接器标志，并根据宿主操作系统将加固相关的链接器标志接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入可配置的编译器和链接器加固标志，并在非 DEBUG 构建中默认启用它们，加强默认构建配置的安全性。

Build:
- 引入与加固相关的可配置构建变量（例如 `HARDENING`、`OPTIMIZATION_CFLAGS`、`HARDENING_CFLAGS`、`FORTIFY_CFLAGS`、`HARDENING_LDFLAGS`），并提供安全的默认值。
- 在经过优化的非 DEBUG 构建中启用栈保护（stack protector）和条件性的 `_FORTIFY_SOURCE`，同时遵从现有的 `EXTRA_CFLAGS` 以及用户提供的宏定义。
- 添加 Linux 特定的 `RELRO/NOW` 链接器标志，并根据宿主平台将加固相关的链接器选项接入 `LDFLAGS`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden default build configuration by introducing configurable compiler and linker hardening flags and applying them by default to non-DEBUG builds.

Build:
- Introduce configurable hardening-related build variables (e.g., HARDENING, OPTIMIZATION_CFLAGS, HARDENING_CFLAGS, FORTIFY_CFLAGS, HARDENING_LDFLAGS) with secure defaults.
- Enable stack protector and conditional _FORTIFY_SOURCE for optimized, non-DEBUG builds while honoring existing EXTRA_CFLAGS and user-provided defines.
- Add Linux-specific RELRO/NOW linker flags and wire hardening linker options into LDFLAGS based on the host platform.

</details>

</details>

</details>

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens default compiler and linker flags behind a consistent gate so hardening only applies when enabled and compatible. Non-DEBUG builds use stack protector, Linux RELRO/NOW, and `_FORTIFY_SOURCE` when optimization is enabled; DEBUG keeps sanitizers unless opted in.

- **Build Hardening**
  - Add `ENABLE_HARDENING` derived from `HARDENING`, `DEBUG`, `DEBUG_HARDENING`; gate `HARDENING_CFLAGS`, `FORTIFY_CFLAGS`, and `HARDENING_LDFLAGS`.
  - Apply `-fstack-protector-strong` and, on Linux, `-Wl,-z,relro -Wl,-z,now` when enabled.
  - Define `_FORTIFY_SOURCE` only if not present and with any `-O*` except `-O0`; evaluate after `CFLAGS`/`EXTRA_CFLAGS`/`CPPFLAGS` are composed to honor `-O0` and existing defines; use `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=<level>` via `FORTIFY_LEVEL`.
  - All flags remain overrideable (`OPTIMIZATION_CFLAGS` default `-O2`, `HARDENING_CFLAGS`, `FORTIFY_CFLAGS`, `HARDENING_LDFLAGS`).

<sup>Written for commit f11978f5f4846bae518fb4d89818eb947970fd5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zouyonghe/PixelTerm-C/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

