### PR TITLE
video: add configurable kitty shm transfer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ TEST_LINK_OBJECTS = $(OBJDIR)/common.o $(OBJDIR)/browser.o $(OBJDIR)/renderer.o 
 		$(OBJDIR)/pixbuf_utils.o $(OBJDIR)/media_buffer.o $(OBJDIR)/preloader.o $(OBJDIR)/app_mode.o $(OBJDIR)/input_dispatch_pending_clicks.o \
 		$(OBJDIR)/input_dispatch_delete.o $(OBJDIR)/input_dispatch_core.o $(OBJDIR)/input_dispatch_key_single.o $(OBJDIR)/input_dispatch_key_book.o $(OBJDIR)/input_dispatch_key_file_manager.o $(OBJDIR)/input_dispatch_mouse_modes.o $(OBJDIR)/app_preview_shared.o \
 		$(OBJDIR)/app_media_session.o $(OBJDIR)/app_single_render.o $(OBJDIR)/app_config_runtime.o $(OBJDIR)/media_utils.o $(OBJDIR)/ui_render_utils.o \
-		$(OBJDIR)/video_player_clock.o $(OBJDIR)/video_player_debug.o $(OBJDIR)/video_player_decode.o $(OBJDIR)/video_player_layout.o $(OBJDIR)/video_player_playback.o $(OBJDIR)/video_player_seek.o $(OBJDIR)/video_player.o $(OBJDIR)/terminal_probe.o $(OBJDIR)/terminal_protocols.o $(OBJDIR)/terminal_protocol_resolver.o $(OBJDIR)/app_cli.o $(OBJDIR)/book.o \
+		$(OBJDIR)/video_player_clock.o $(OBJDIR)/video_player_debug.o $(OBJDIR)/video_player_decode.o $(OBJDIR)/video_player_layout.o $(OBJDIR)/video_player_playback.o $(OBJDIR)/video_player_seek.o $(OBJDIR)/video_player.o $(OBJDIR)/kitty_graphics.o $(OBJDIR)/terminal_probe.o $(OBJDIR)/terminal_protocols.o $(OBJDIR)/terminal_protocol_resolver.o $(OBJDIR)/app_cli.o $(OBJDIR)/book.o \
 		$(OBJDIR)/app_startup.o
 FILE_MANAGER_TEST_LINK_OBJECTS = $(OBJDIR)/common.o $(OBJDIR)/process_env.o $(OBJDIR)/app_core.o $(OBJDIR)/app_mode.o \
 		$(OBJDIR)/app_file_manager.o $(OBJDIR)/app_file_manager_render.o $(OBJDIR)/text_utils.o

--- a/config.example.ini
+++ b/config.example.ini
@@ -17,6 +17,12 @@ work_factor = 9
 # Output protocol: auto, text, sixel, kitty, iterm2.
 protocol = auto
 
+# Kitty video transfer mode: auto, direct, shm.
+# auto uses the shared-memory fast path only where PixelTerm-C considers it safe.
+# direct keeps the Chafa inline kitty path. shm forces kitty shared memory for
+# video frames and falls back to direct if setup fails.
+kitty_transfer = auto
+
 # Text-mode symbol set: auto, half, quarter.
 # Only applies when rendering through the text protocol.
 text_symbols = auto
@@ -40,3 +46,6 @@ protocol = iterm2
 # Example: enable clear workaround in Warp.
 alt_screen = false
 clear_workaround = true
+# Warp's inline kitty path can be slower for video; try shm if your Warp build
+# supports kitty shared-memory graphics reliably.
+kitty_transfer = shm

--- a/config.example.ini
+++ b/config.example.ini
@@ -46,6 +46,6 @@ protocol = iterm2
 # Example: enable clear workaround in Warp.
 alt_screen = false
 clear_workaround = true
-# Warp's inline kitty path can be slower for video; try shm if your Warp build
-# supports kitty shared-memory graphics reliably.
-kitty_transfer = shm
+# Keep direct kitty transfer by default in Warp. Some Warp builds can become
+# sluggish when forced to consume many kitty shared-memory video frames.
+kitty_transfer = direct

--- a/docs/guides/TERMINAL_PROTOCOL_SUPPORT.md
+++ b/docs/guides/TERMINAL_PROTOCOL_SUPPORT.md
@@ -71,7 +71,7 @@ You can also set `protocol = auto|text|sixel|kitty|iterm2` in `config.ini`. For 
 - `direct`: always use Chafa's inline kitty output. This is useful for comparing behavior or avoiding terminal-specific shared-memory issues.
 - `shm`: force the kitty shared-memory path for video frames. If shared-memory setup fails for a frame, PixelTerm-C falls back to direct rendering.
 - `PIXELTERM_KITTY_SHM=1` remains available as a debug override for `auto`, but `config.ini` or `--kitty-transfer` is preferred for normal use.
-- If a kitty-compatible terminal becomes sluggish outside PixelTerm-C itself, for example mouse cursor changes to a loading state or tabs become hard to switch, use `kitty_transfer = direct`. That usually means the terminal's own shared-memory graphics consumer is overloaded.
+- If a kitty-compatible terminal becomes sluggish outside PixelTerm-C itself, for example, if the mouse cursor changes to a loading state or tabs become hard to switch, use `kitty_transfer = direct`. That usually means the terminal's own shared-memory graphics consumer is overloaded.
 
 ## Scope notes
 

--- a/docs/guides/TERMINAL_PROTOCOL_SUPPORT.md
+++ b/docs/guides/TERMINAL_PROTOCOL_SUPPORT.md
@@ -25,7 +25,7 @@ This page summarizes the terminal and graphics-protocol support notes currently 
 | iTerm2 | iTerm2, sixel | Documented | You can force it with `--protocol iterm2`. |
 | Ghostty | kitty | Partially documented | If `auto` stays in text, try `--protocol kitty`. |
 | Rio | sixel | Partially documented | If `auto` stays in text, try `--protocol sixel`. |
-| Warp | kitty | Partially documented | `config.example.ini` includes a `[WarpTerminal]` example with extra compatibility settings and optional kitty shared-memory video transfer. |
+| Warp | kitty | Partially documented | `config.example.ini` includes a `[WarpTerminal]` example with extra compatibility settings. Prefer `kitty_transfer = direct` if shared-memory video makes the Warp UI sluggish. |
 | Contour | sixel | Partially documented | If `auto` stays in text, try `--protocol sixel`. |
 | Konsole | kitty | Partially documented | If `auto` stays in text, try `--protocol kitty`. |
 | EAT | sixel | Partially documented | If `auto` stays in text, try `--protocol sixel`. |
@@ -71,6 +71,7 @@ You can also set `protocol = auto|text|sixel|kitty|iterm2` in `config.ini`. For 
 - `direct`: always use Chafa's inline kitty output. This is useful for comparing behavior or avoiding terminal-specific shared-memory issues.
 - `shm`: force the kitty shared-memory path for video frames. If shared-memory setup fails for a frame, PixelTerm-C falls back to direct rendering.
 - `PIXELTERM_KITTY_SHM=1` remains available as a debug override for `auto`, but `config.ini` or `--kitty-transfer` is preferred for normal use.
+- If a kitty-compatible terminal becomes sluggish outside PixelTerm-C itself, for example mouse cursor changes to a loading state or tabs become hard to switch, use `kitty_transfer = direct`. That usually means the terminal's own shared-memory graphics consumer is overloaded.
 
 ## Scope notes
 

--- a/docs/guides/TERMINAL_PROTOCOL_SUPPORT.md
+++ b/docs/guides/TERMINAL_PROTOCOL_SUPPORT.md
@@ -21,11 +21,11 @@ This page summarizes the terminal and graphics-protocol support notes currently 
 | Terminal | Protocol notes | Status | Notes |
 |----------|----------------|--------|-------|
 | WezTerm | kitty, sixel, optional iTerm2 override | Documented | `config.example.ini` includes a `[WezTerm] protocol = iterm2` example. |
-| kitty | kitty | Documented | You can force it with `--protocol kitty`. |
+| kitty | kitty | Documented | You can force it with `--protocol kitty`. Native kitty may show little difference between direct and shared-memory transfer at modest terminal sizes. |
 | iTerm2 | iTerm2, sixel | Documented | You can force it with `--protocol iterm2`. |
 | Ghostty | kitty | Partially documented | If `auto` stays in text, try `--protocol kitty`. |
 | Rio | sixel | Partially documented | If `auto` stays in text, try `--protocol sixel`. |
-| Warp | kitty | Partially documented | `config.example.ini` includes a `[WarpTerminal]` example with extra compatibility settings. |
+| Warp | kitty | Partially documented | `config.example.ini` includes a `[WarpTerminal]` example with extra compatibility settings and optional kitty shared-memory video transfer. |
 | Contour | sixel | Partially documented | If `auto` stays in text, try `--protocol sixel`. |
 | Konsole | kitty | Partially documented | If `auto` stays in text, try `--protocol kitty`. |
 | EAT | sixel | Partially documented | If `auto` stays in text, try `--protocol sixel`. |
@@ -57,9 +57,20 @@ pixelterm --protocol text --text-symbols quarter /path/to/image.jpg
 
 # Available values
 pixelterm --protocol auto|text|sixel|kitty|iterm2 /path/to/image.jpg
+
+# Compare kitty video transfer paths
+pixelterm --protocol kitty --kitty-transfer direct /path/to/video.mp4
+pixelterm --protocol kitty --kitty-transfer shm /path/to/video.mp4
 ```
 
-You can also set `protocol = auto|text|sixel|kitty|iterm2` in `config.ini`. For text rendering, `text_symbols = auto|half|quarter` controls whether PixelTerm-C keeps the terminal-safe default symbol set or switches to stronger half-block-heavy / quad-heavy manual symbol sets. Terminal-specific sections follow the first matching value from `TERM_PROGRAM`, `LC_TERMINAL`, `TERMINAL_NAME`, or `TERM`. See [config.example.ini](../../config.example.ini) and [USAGE.md](USAGE.md) for the current CLI and config syntax.
+You can also set `protocol = auto|text|sixel|kitty|iterm2` in `config.ini`. For kitty video rendering, `kitty_transfer = auto|direct|shm` controls whether PixelTerm-C uses the regular inline kitty path or the kitty shared-memory fast path. For text rendering, `text_symbols = auto|half|quarter` controls whether PixelTerm-C keeps the terminal-safe default symbol set or switches to stronger half-block-heavy / quad-heavy manual symbol sets. Terminal-specific sections follow the first matching value from `TERM_PROGRAM`, `LC_TERMINAL`, `TERMINAL_NAME`, or `TERM`. See [config.example.ini](../../config.example.ini) and [USAGE.md](USAGE.md) for the current CLI and config syntax.
+
+## Kitty transfer modes
+
+- `auto`: default. PixelTerm-C uses conservative shared-memory detection for kitty video and otherwise keeps the direct inline path.
+- `direct`: always use Chafa's inline kitty output. This is useful for comparing behavior or avoiding terminal-specific shared-memory issues.
+- `shm`: force the kitty shared-memory path for video frames. If shared-memory setup fails for a frame, PixelTerm-C falls back to direct rendering.
+- `PIXELTERM_KITTY_SHM=1` remains available as a debug override for `auto`, but `config.ini` or `--kitty-transfer` is preferred for normal use.
 
 ## Scope notes
 
@@ -67,3 +78,4 @@ You can also set `protocol = auto|text|sixel|kitty|iterm2` in `config.ini`. For 
 - Rendering behavior can still vary by terminal version, local settings, remote session setup, and whether protocol probing succeeds at runtime.
 - Direct SSH fallback currently stays conservative on purpose. If a remote, tmux, or screen setup hides the affirmative probe response you expect, prefer an explicit override.
 - If your terminal works better with an explicit protocol than with `auto`, prefer a local config override for that terminal.
+- Shared-memory kitty transfer is local-only by design. Avoid forcing it through SSH, tmux, or screen unless you are deliberately testing a setup that supports it.

--- a/docs/guides/USAGE.md
+++ b/docs/guides/USAGE.md
@@ -46,6 +46,9 @@ pixelterm --work-factor 7 /path/to/image.jpg
 # Force output protocol (auto, text, sixel, kitty, iterm2)
 pixelterm --protocol kitty /path/to/image.jpg
 
+# Select kitty video transfer mode (auto, direct, shm)
+pixelterm --protocol kitty --kitty-transfer shm /path/to/video.mp4
+
 # Tune text-mode symbol selection (auto, half, quarter)
 pixelterm --protocol text --text-symbols quarter /path/to/image.jpg
 
@@ -74,9 +77,11 @@ pixelterm -- --config=gallery.txt
 - CLI flags override config file values because config loading happens before argument parsing.
 - `--preload` and `--alt-screen` accept `true/false`, `yes/no`, `on/off`, and `1/0`.
 - `--text-symbols` only affects text rendering, whether selected explicitly with `--protocol text` or chosen by the automatic fallback.
+- `--kitty-transfer` only affects video frames rendered through the kitty protocol. `auto` is the normal choice, `direct` keeps Chafa's inline kitty output, and `shm` forces the shared-memory fast path with fallback to direct rendering if setup fails.
 - `--color-enhance vivid` is a default-off pre-rendering color adjustment. It can make muted images look clearer in terminal text output, at a small CPU cost.
 - A missing default config file is ignored, but a missing file passed with `--config` is treated as an error.
 - Config groups are applied in this order: `[default]`, then the first matching terminal-specific group from `TERM_PROGRAM`, `LC_TERMINAL`, `TERMINAL_NAME`, or `TERM`.
 - If `PATH` is an unsupported regular file, PixelTerm-C falls back to that file's canonical parent directory and opens file manager mode there.
 - A directory path is never treated as a valid book file; directories open in file manager mode instead.
 - If rendering looks wrong, try an explicit `--protocol` value or see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
+- For repeatable kitty video tuning, prefer `kitty_transfer = auto|direct|shm` in `config.ini`; use `--kitty-transfer` for one-off A/B tests.

--- a/include/app_state.h
+++ b/include/app_state.h
@@ -2,6 +2,7 @@
 #define APP_STATE_H
 
 #include "common.h"
+#include "kitty_transfer.h"
 #include "preloader.h"
 #include "gif_player.h"
 #include "video_player.h"

--- a/include/app_state.h
+++ b/include/app_state.h
@@ -45,6 +45,7 @@ typedef struct {
     gboolean force_iterm2;
     TextSymbolMode text_symbol_mode;
     ColorEnhanceMode color_enhance;
+    KittyTransferMode kitty_transfer;
 } AppConfig;
 
 typedef struct {
@@ -145,6 +146,7 @@ typedef struct {
     gboolean force_iterm2;
     TextSymbolMode text_symbol_mode;
     ColorEnhanceMode color_enhance;
+    KittyTransferMode kitty_transfer;
     gboolean needs_redraw;
     AppMode mode;  // Current UI mode (single/preview/file manager/book)
     gboolean show_hidden_files;  // Toggle visibility of dotfiles in file manager

--- a/include/kitty_graphics.h
+++ b/include/kitty_graphics.h
@@ -1,0 +1,35 @@
+#ifndef KITTY_GRAPHICS_H
+#define KITTY_GRAPHICS_H
+
+#include "common.h"
+#include "video_player.h"
+
+typedef struct {
+    GString *command;
+    gchar *shm_name;
+    gint display_width_cells;
+    gint display_height_cells;
+} KittyGraphicsFrame;
+
+gboolean kitty_graphics_shm_auto_enabled(void);
+gboolean kitty_graphics_should_use_shm(KittyTransferMode mode);
+
+KittyGraphicsFrame *kitty_graphics_frame_new_shm_rgba(const guint8 *pixels,
+                                                       gint width,
+                                                       gint height,
+                                                       gint rowstride,
+                                                       gint display_width_cells,
+                                                       gint display_height_cells);
+
+void kitty_graphics_frame_free(KittyGraphicsFrame *frame);
+
+void kitty_graphics_shm_unlink(const gchar *shm_name);
+
+GString *kitty_graphics_build_shm_command_for_test(const gchar *shm_name,
+                                                   gint width,
+                                                   gint height,
+                                                   gint display_width_cells,
+                                                   gint display_height_cells,
+                                                   gsize payload_size);
+
+#endif // KITTY_GRAPHICS_H

--- a/include/kitty_graphics.h
+++ b/include/kitty_graphics.h
@@ -25,11 +25,11 @@ void kitty_graphics_frame_free(KittyGraphicsFrame *frame);
 
 void kitty_graphics_shm_unlink(const gchar *shm_name);
 
-GString *kitty_graphics_build_shm_command_for_test(const gchar *shm_name,
-                                                   gint width,
-                                                   gint height,
-                                                   gint display_width_cells,
-                                                   gint display_height_cells,
-                                                   gsize payload_size);
+GString *kitty_graphics_build_shm_command(const gchar *shm_name,
+                                          gint width,
+                                          gint height,
+                                          gint display_width_cells,
+                                          gint display_height_cells,
+                                          gsize payload_size);
 
 #endif // KITTY_GRAPHICS_H

--- a/include/kitty_graphics.h
+++ b/include/kitty_graphics.h
@@ -2,7 +2,7 @@
 #define KITTY_GRAPHICS_H
 
 #include "common.h"
-#include "video_player.h"
+#include "kitty_transfer.h"
 
 typedef struct {
     GString *command;

--- a/include/kitty_transfer.h
+++ b/include/kitty_transfer.h
@@ -1,0 +1,10 @@
+#ifndef KITTY_TRANSFER_H
+#define KITTY_TRANSFER_H
+
+typedef enum {
+    KITTY_TRANSFER_AUTO = 0,
+    KITTY_TRANSFER_DIRECT,
+    KITTY_TRANSFER_SHM
+} KittyTransferMode;
+
+#endif // KITTY_TRANSFER_H

--- a/include/video_player.h
+++ b/include/video_player.h
@@ -93,6 +93,7 @@ typedef struct {
     gboolean show_stats;
     ColorEnhanceMode color_enhance;
     KittyTransferMode kitty_transfer;
+    gboolean kitty_shm_enabled;
 
     // FFmpeg state
     struct AVFormatContext *format_context;

--- a/include/video_player.h
+++ b/include/video_player.h
@@ -2,6 +2,7 @@
 #define VIDEO_PLAYER_H
 
 #include "common.h"
+#include "kitty_transfer.h"
 #include "renderer.h"
 
 struct AVCodecContext;
@@ -32,12 +33,6 @@ typedef struct {
 /* Convenience alias used internally for the frame-queue head type.
  * Centralized here so all internal modules share a single definition. */
 typedef RenderedFrame VideoFrame;
-
-typedef enum {
-    KITTY_TRANSFER_AUTO = 0,
-    KITTY_TRANSFER_DIRECT,
-    KITTY_TRANSFER_SHM
-} KittyTransferMode;
 
 #define VIDEO_PLAYER_STATS_ROW 3
 

--- a/include/video_player.h
+++ b/include/video_player.h
@@ -21,6 +21,7 @@ typedef struct {
 
 typedef struct {
     GString *rendered;
+    gchar *kitty_shm_name;
     gint rendered_width;
     gint rendered_height;
     gint64 pts_ms;
@@ -31,6 +32,12 @@ typedef struct {
 /* Convenience alias used internally for the frame-queue head type.
  * Centralized here so all internal modules share a single definition. */
 typedef RenderedFrame VideoFrame;
+
+typedef enum {
+    KITTY_TRANSFER_AUTO = 0,
+    KITTY_TRANSFER_DIRECT,
+    KITTY_TRANSFER_SHM
+} KittyTransferMode;
 
 #define VIDEO_PLAYER_STATS_ROW 3
 
@@ -85,6 +92,7 @@ typedef struct {
     gboolean present_fps_valid;
     gboolean show_stats;
     ColorEnhanceMode color_enhance;
+    KittyTransferMode kitty_transfer;
 
     // FFmpeg state
     struct AVFormatContext *format_context;
@@ -114,7 +122,8 @@ typedef struct {
   } VideoPlayer;
 
 VideoPlayer* video_player_new(gint work_factor, gboolean force_text, gboolean force_sixel, gboolean force_kitty,
-                              gboolean force_iterm2, TextSymbolMode text_symbol_mode, gdouble gamma);
+                              gboolean force_iterm2, TextSymbolMode text_symbol_mode, gdouble gamma,
+                              KittyTransferMode kitty_transfer);
 void video_player_destroy(VideoPlayer *player);
 void video_player_set_renderer(VideoPlayer *player, ImageRenderer *renderer);
 void video_player_set_render_area(VideoPlayer *player,

--- a/src/app.c
+++ b/src/app.c
@@ -79,6 +79,7 @@ static void app_init_runtime_defaults(PixelTermApp *app) {
     app->render_work_factor = 9;
     app->gamma = 1.0;
     app->text_symbol_mode = TEXT_SYMBOL_MODE_AUTO;
+    app->kitty_transfer = KITTY_TRANSFER_AUTO;
     app->needs_redraw = TRUE;
     app->mode = APP_MODE_SINGLE;
     app->return_to_mode = RETURN_MODE_NONE;
@@ -261,7 +262,8 @@ ErrorCode app_initialize(PixelTermApp *app, gboolean dither_enabled) {
 
     // Initialize video player
     app->video_player = video_player_new(app->render_work_factor, app->force_text, app->force_sixel,
-                                          app->force_kitty, app->force_iterm2, app->text_symbol_mode, app->gamma);
+                                          app->force_kitty, app->force_iterm2, app->text_symbol_mode, app->gamma,
+                                          app->kitty_transfer);
     if (!app->video_player) {
         gif_player_destroy(app->gif_player);
         app->gif_player = NULL;

--- a/src/app_cli.c
+++ b/src/app_cli.c
@@ -29,6 +29,7 @@ static void print_usage(const char *program_name) {
            "Improve UI appearance on some terminals but may reduce performance (default: disabled)");
     printf("  %-29s %s\n", "--work-factor N", "Quality/speed tradeoff (1-9, default: 9)");
     printf("  %-29s %s\n", "--protocol MODE", "Output protocol: auto, text, sixel, kitty, iterm2");
+    printf("  %-29s %s\n", "--kitty-transfer MODE", "Kitty video transfer: auto, direct, shm");
     printf("  %-29s %s\n", "--text-symbols MODE", "Text symbol set: auto, half, quarter");
     printf("  %-29s %s\n", "--color-enhance MODE", "Color enhancement: off, vivid");
     printf("  %-29s %s\n", "--config PATH",
@@ -112,6 +113,25 @@ static gboolean parse_color_enhance_mode(const char *value, ColorEnhanceMode *ou
     }
     if (g_ascii_strcasecmp(value, "vivid") == 0) {
         *out_mode = COLOR_ENHANCE_VIVID;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static gboolean parse_kitty_transfer_mode(const char *value, KittyTransferMode *out_mode) {
+    if (!value || !out_mode) {
+        return FALSE;
+    }
+    if (g_ascii_strcasecmp(value, "auto") == 0) {
+        *out_mode = KITTY_TRANSFER_AUTO;
+        return TRUE;
+    }
+    if (g_ascii_strcasecmp(value, "direct") == 0) {
+        *out_mode = KITTY_TRANSFER_DIRECT;
+        return TRUE;
+    }
+    if (g_ascii_strcasecmp(value, "shm") == 0) {
+        *out_mode = KITTY_TRANSFER_SHM;
         return TRUE;
     }
     return FALSE;
@@ -324,6 +344,25 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
             return FALSE;
         }
         config->color_enhance = mode;
+        g_free(value);
+    }
+
+    if (g_key_file_has_key(key_file, group, "kitty_transfer", NULL)) {
+        GError *error = NULL;
+        gchar *value = g_key_file_get_string(key_file, group, "kitty_transfer", &error);
+        if (error) {
+            fprintf(stderr, "Invalid 'kitty_transfer' in config file '%s': %s\n", path, error->message);
+            g_error_free(error);
+            g_free(value);
+            return FALSE;
+        }
+        KittyTransferMode mode = KITTY_TRANSFER_AUTO;
+        if (!parse_kitty_transfer_mode(value, &mode)) {
+            fprintf(stderr, "Invalid 'kitty_transfer' in config file '%s': %s\n", path, value);
+            g_free(value);
+            return FALSE;
+        }
+        config->kitty_transfer = mode;
         g_free(value);
     }
 
@@ -664,6 +703,7 @@ void app_config_init(AppConfig *config) {
     config->force_iterm2 = FALSE;
     config->text_symbol_mode = TEXT_SYMBOL_MODE_AUTO;
     config->color_enhance = COLOR_ENHANCE_OFF;
+    config->kitty_transfer = KITTY_TRANSFER_AUTO;
 }
 
 ErrorCode app_parse_arguments(int argc, char *argv[], char **path, AppConfig *config) {
@@ -681,6 +721,7 @@ ErrorCode app_parse_arguments(int argc, char *argv[], char **path, AppConfig *co
         {"config", required_argument, 0, 1007},
         {"text-symbols", required_argument, 0, 1008},
         {"color-enhance", required_argument, 0, 1009},
+        {"kitty-transfer", required_argument, 0, 1010},
         {0, 0, 0, 0}
     };
 
@@ -797,6 +838,15 @@ ErrorCode app_parse_arguments(int argc, char *argv[], char **path, AppConfig *co
                     return ERROR_INVALID_ARGS;
                 }
                 config->color_enhance = mode;
+                break;
+            }
+            case 1010: { // --kitty-transfer
+                KittyTransferMode mode = KITTY_TRANSFER_AUTO;
+                if (!parse_kitty_transfer_mode(optarg, &mode)) {
+                    fprintf(stderr, "Unknown kitty transfer mode: %s\n", optarg ? optarg : "");
+                    return ERROR_INVALID_ARGS;
+                }
+                config->kitty_transfer = mode;
                 break;
             }
             case '?':

--- a/src/app_config_runtime.c
+++ b/src/app_config_runtime.c
@@ -42,4 +42,5 @@ void app_config_apply_runtime(PixelTermApp *app, const AppConfig *config) {
     app->force_iterm2 = config->force_iterm2;
     app->text_symbol_mode = config->text_symbol_mode;
     app->color_enhance = config->color_enhance;
+    app->kitty_transfer = config->kitty_transfer;
 }

--- a/src/kitty_graphics.c
+++ b/src/kitty_graphics.c
@@ -41,12 +41,12 @@ gboolean kitty_graphics_should_use_shm(KittyTransferMode mode) {
     return kitty_graphics_shm_auto_enabled();
 }
 
-GString *kitty_graphics_build_shm_command_for_test(const gchar *shm_name,
-                                                   gint width,
-                                                   gint height,
-                                                   gint display_width_cells,
-                                                   gint display_height_cells,
-                                                   gsize payload_size) {
+GString *kitty_graphics_build_shm_command(const gchar *shm_name,
+                                          gint width,
+                                          gint height,
+                                          gint display_width_cells,
+                                          gint display_height_cells,
+                                          gsize payload_size) {
     if (!shm_name || shm_name[0] == '\0' || width <= 0 || height <= 0 ||
         display_width_cells <= 0 || display_height_cells <= 0 || payload_size == 0) {
         return NULL;
@@ -204,12 +204,12 @@ KittyGraphicsFrame *kitty_graphics_frame_new_shm_rgba(const guint8 *pixels,
     munmap(mapped, payload_size);
     close(fd);
 
-    GString *command = kitty_graphics_build_shm_command_for_test(shm_name,
-                                                                 transfer_width,
-                                                                 transfer_height,
-                                                                 display_width_cells,
-                                                                 display_height_cells,
-                                                                 payload_size);
+    GString *command = kitty_graphics_build_shm_command(shm_name,
+                                                        transfer_width,
+                                                        transfer_height,
+                                                        display_width_cells,
+                                                        display_height_cells,
+                                                        payload_size);
     if (!command) {
         kitty_graphics_shm_unlink(shm_name);
         g_free(shm_name);

--- a/src/kitty_graphics.c
+++ b/src/kitty_graphics.c
@@ -1,0 +1,245 @@
+#include "kitty_graphics.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static gboolean kitty_graphics_env_truthy(const gchar *value) {
+    if (!value || value[0] == '\0') {
+        return FALSE;
+    }
+    return g_ascii_strcasecmp(value, "0") != 0 &&
+           g_ascii_strcasecmp(value, "false") != 0 &&
+           g_ascii_strcasecmp(value, "no") != 0 &&
+           g_ascii_strcasecmp(value, "off") != 0;
+}
+
+gboolean kitty_graphics_shm_auto_enabled(void) {
+    if (kitty_graphics_env_truthy(g_getenv("PIXELTERM_KITTY_SHM"))) {
+        return TRUE;
+    }
+
+    if (g_getenv("SSH_CONNECTION") || g_getenv("SSH_CLIENT") || g_getenv("TMUX") || g_getenv("STY")) {
+        return FALSE;
+    }
+
+    const gchar *term = g_getenv("TERM");
+    const gchar *term_program = g_getenv("TERM_PROGRAM");
+    return (term && g_strcmp0(term, "xterm-kitty") == 0) ||
+           (term_program && g_ascii_strcasecmp(term_program, "kitty") == 0);
+}
+
+gboolean kitty_graphics_should_use_shm(KittyTransferMode mode) {
+    if (mode == KITTY_TRANSFER_DIRECT) {
+        return FALSE;
+    }
+    if (mode == KITTY_TRANSFER_SHM) {
+        return TRUE;
+    }
+    return kitty_graphics_shm_auto_enabled();
+}
+
+GString *kitty_graphics_build_shm_command_for_test(const gchar *shm_name,
+                                                   gint width,
+                                                   gint height,
+                                                   gint display_width_cells,
+                                                   gint display_height_cells,
+                                                   gsize payload_size) {
+    if (!shm_name || shm_name[0] == '\0' || width <= 0 || height <= 0 ||
+        display_width_cells <= 0 || display_height_cells <= 0 || payload_size == 0) {
+        return NULL;
+    }
+
+    gchar *encoded_name = g_base64_encode((const guchar *)shm_name, strlen(shm_name));
+    if (!encoded_name) {
+        return NULL;
+    }
+
+    GString *command = g_string_new(NULL);
+    g_string_printf(command,
+                    "\033_Ga=T,f=32,s=%d,v=%d,t=s,S=%" G_GSIZE_FORMAT ",c=%d,r=%d,C=1,q=2;%s\033\\",
+                    width,
+                    height,
+                    payload_size,
+                    display_width_cells,
+                    display_height_cells,
+                    encoded_name);
+    g_free(encoded_name);
+    return command;
+}
+
+static gchar *kitty_graphics_make_shm_name(void) {
+    static gint counter = 0;
+    gint serial = g_atomic_int_add(&counter, 1);
+    return g_strdup_printf("/pixelterm-kitty-%ld-%d", (long)getpid(), serial);
+}
+
+static void kitty_graphics_get_transfer_size(gint src_width,
+                                             gint src_height,
+                                             gint display_width_cells,
+                                             gint display_height_cells,
+                                             gint *width_out,
+                                             gint *height_out) {
+    gint cell_width = 0;
+    gint cell_height = 0;
+    get_terminal_cell_geometry(&cell_width, &cell_height);
+
+    gint target_width = src_width;
+    gint target_height = src_height;
+    if (cell_width > 0 && cell_height > 0 && display_width_cells > 0 && display_height_cells > 0) {
+        target_width = display_width_cells * cell_width;
+        target_height = display_height_cells * cell_height;
+        if (target_width <= 0 || target_height <= 0) {
+            target_width = src_width;
+            target_height = src_height;
+        }
+    }
+
+    /* Let the terminal upscale if needed; avoid increasing shm traffic beyond
+     * the decoded frame's native pixel count.
+     */
+    if (target_width > src_width) target_width = src_width;
+    if (target_height > src_height) target_height = src_height;
+    if (target_width < 1) target_width = 1;
+    if (target_height < 1) target_height = 1;
+
+    if (width_out) *width_out = target_width;
+    if (height_out) *height_out = target_height;
+}
+
+static void kitty_graphics_copy_scaled_rgba(guint8 *dest,
+                                            gint dest_width,
+                                            gint dest_height,
+                                            const guint8 *src,
+                                            gint src_width,
+                                            gint src_height,
+                                            gint src_rowstride) {
+    for (gint y = 0; y < dest_height; y++) {
+        gint src_y = (gint)(((gint64)y * src_height) / dest_height);
+        if (src_y >= src_height) src_y = src_height - 1;
+        const guint8 *src_row = src + ((gsize)src_y * (gsize)src_rowstride);
+        guint8 *dest_row = dest + ((gsize)y * (gsize)dest_width * 4);
+        for (gint x = 0; x < dest_width; x++) {
+            gint src_x = (gint)(((gint64)x * src_width) / dest_width);
+            if (src_x >= src_width) src_x = src_width - 1;
+            memcpy(dest_row + ((gsize)x * 4), src_row + ((gsize)src_x * 4), 4);
+        }
+    }
+}
+
+void kitty_graphics_shm_unlink(const gchar *shm_name) {
+    if (shm_name && shm_name[0] != '\0') {
+        shm_unlink(shm_name);
+    }
+}
+
+KittyGraphicsFrame *kitty_graphics_frame_new_shm_rgba(const guint8 *pixels,
+                                                       gint width,
+                                                       gint height,
+                                                       gint rowstride,
+                                                       gint display_width_cells,
+                                                       gint display_height_cells) {
+    if (!pixels || width <= 0 || height <= 0 || rowstride < width * 4 ||
+        display_width_cells <= 0 || display_height_cells <= 0) {
+        return NULL;
+    }
+
+    gint transfer_width = 0;
+    gint transfer_height = 0;
+    kitty_graphics_get_transfer_size(width,
+                                     height,
+                                     display_width_cells,
+                                     display_height_cells,
+                                     &transfer_width,
+                                     &transfer_height);
+
+    gsize payload_size = 0;
+    if (!g_size_checked_mul(&payload_size, (gsize)transfer_width, (gsize)transfer_height) ||
+        !g_size_checked_mul(&payload_size, payload_size, (gsize)4)) {
+        return NULL;
+    }
+
+    gchar *shm_name = kitty_graphics_make_shm_name();
+    if (!shm_name) {
+        return NULL;
+    }
+
+    int fd = shm_open(shm_name, O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR);
+    if (fd < 0) {
+        g_free(shm_name);
+        return NULL;
+    }
+
+    if (ftruncate(fd, (off_t)payload_size) != 0) {
+        shm_unlink(shm_name);
+        close(fd);
+        g_free(shm_name);
+        return NULL;
+    }
+
+    void *mapped = mmap(NULL, payload_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (mapped == MAP_FAILED) {
+        shm_unlink(shm_name);
+        close(fd);
+        g_free(shm_name);
+        return NULL;
+    }
+
+    if (transfer_width == width && transfer_height == height) {
+        guint8 *dest = mapped;
+        for (gint y = 0; y < height; y++) {
+            memcpy(dest + ((gsize)y * (gsize)width * 4), pixels + ((gsize)y * (gsize)rowstride), (gsize)width * 4);
+        }
+    } else {
+        kitty_graphics_copy_scaled_rgba(mapped,
+                                        transfer_width,
+                                        transfer_height,
+                                        pixels,
+                                        width,
+                                        height,
+                                        rowstride);
+    }
+    munmap(mapped, payload_size);
+    close(fd);
+
+    GString *command = kitty_graphics_build_shm_command_for_test(shm_name,
+                                                                 transfer_width,
+                                                                 transfer_height,
+                                                                 display_width_cells,
+                                                                 display_height_cells,
+                                                                 payload_size);
+    if (!command) {
+        kitty_graphics_shm_unlink(shm_name);
+        g_free(shm_name);
+        return NULL;
+    }
+
+    KittyGraphicsFrame *frame = g_new0(KittyGraphicsFrame, 1);
+    if (!frame) {
+        kitty_graphics_shm_unlink(shm_name);
+        g_free(shm_name);
+        g_string_free(command, TRUE);
+        return NULL;
+    }
+    frame->command = command;
+    frame->shm_name = shm_name;
+    frame->display_width_cells = display_width_cells;
+    frame->display_height_cells = display_height_cells;
+    return frame;
+}
+
+void kitty_graphics_frame_free(KittyGraphicsFrame *frame) {
+    if (!frame) {
+        return;
+    }
+    if (frame->command) {
+        g_string_free(frame->command, TRUE);
+    }
+    if (frame->shm_name) {
+        kitty_graphics_shm_unlink(frame->shm_name);
+        g_free(frame->shm_name);
+    }
+    g_free(frame);
+}

--- a/src/kitty_graphics.c
+++ b/src/kitty_graphics.c
@@ -1,10 +1,14 @@
 #include "kitty_graphics.h"
+#include "process_env.h"
 
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
+/* Keep shared-memory transfers bounded; larger frames fall back to direct kitty output. */
+#define KITTY_GRAPHICS_SHM_MAX_PAYLOAD_BYTES (8 * 1024 * 1024)
 
 static gboolean kitty_graphics_env_truthy(const gchar *value) {
     if (!value || value[0] == '\0') {
@@ -17,16 +21,17 @@ static gboolean kitty_graphics_env_truthy(const gchar *value) {
 }
 
 gboolean kitty_graphics_shm_auto_enabled(void) {
-    if (kitty_graphics_env_truthy(g_getenv("PIXELTERM_KITTY_SHM"))) {
+    if (kitty_graphics_env_truthy(pixelterm_getenv("PIXELTERM_KITTY_SHM"))) {
         return TRUE;
     }
 
-    if (g_getenv("SSH_CONNECTION") || g_getenv("SSH_CLIENT") || g_getenv("TMUX") || g_getenv("STY")) {
+    if (pixelterm_getenv("SSH_CONNECTION") || pixelterm_getenv("SSH_CLIENT") ||
+        pixelterm_getenv("TMUX") || pixelterm_getenv("STY")) {
         return FALSE;
     }
 
-    const gchar *term = g_getenv("TERM");
-    const gchar *term_program = g_getenv("TERM_PROGRAM");
+    const gchar *term = pixelterm_getenv("TERM");
+    const gchar *term_program = pixelterm_getenv("TERM_PROGRAM");
     return (term && g_strcmp0(term, "xterm-kitty") == 0) ||
            (term_program && g_ascii_strcasecmp(term_program, "kitty") == 0);
 }
@@ -163,17 +168,34 @@ KittyGraphicsFrame *kitty_graphics_frame_new_shm_rgba(const guint8 *pixels,
         !g_size_checked_mul(&payload_size, payload_size, (gsize)4)) {
         return NULL;
     }
+    if (payload_size > KITTY_GRAPHICS_SHM_MAX_PAYLOAD_BYTES) {
+        return NULL;
+    }
 
     gchar *shm_name = kitty_graphics_make_shm_name();
     if (!shm_name) {
         return NULL;
     }
 
-    int fd = shm_open(shm_name, O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR);
+    int flags = O_CREAT | O_EXCL | O_RDWR;
+#ifdef O_CLOEXEC
+    flags |= O_CLOEXEC;
+#endif
+
+    int fd = shm_open(shm_name, flags, S_IRUSR | S_IWUSR);
     if (fd < 0) {
         g_free(shm_name);
         return NULL;
     }
+
+#ifndef O_CLOEXEC
+    if (fcntl(fd, F_SETFD, FD_CLOEXEC) == -1) {
+        shm_unlink(shm_name);
+        close(fd);
+        g_free(shm_name);
+        return NULL;
+    }
+#endif
 
     if (ftruncate(fd, (off_t)payload_size) != 0) {
         shm_unlink(shm_name);

--- a/src/kitty_graphics.c
+++ b/src/kitty_graphics.c
@@ -141,7 +141,10 @@ KittyGraphicsFrame *kitty_graphics_frame_new_shm_rgba(const guint8 *pixels,
                                                        gint rowstride,
                                                        gint display_width_cells,
                                                        gint display_height_cells) {
-    if (!pixels || width <= 0 || height <= 0 || rowstride < width * 4 ||
+    gsize required_rowstride = 0;
+    if (!pixels || width <= 0 || height <= 0 || rowstride <= 0 ||
+        !g_size_checked_mul(&required_rowstride, (gsize)width, (gsize)4) ||
+        required_rowstride > (gsize)G_MAXINT || (gsize)rowstride < required_rowstride ||
         display_width_cells <= 0 || display_height_cells <= 0) {
         return NULL;
     }

--- a/src/video_player.c
+++ b/src/video_player.c
@@ -192,12 +192,12 @@ void video_frame_destroy(VideoFrame *frame) {
     g_free(frame);
 }
 
-static void video_frame_mark_kitty_shm_submitted(VideoFrame *frame, size_t written, size_t expected) {
-    if (frame && frame->kitty_shm_name && written == expected) {
+static void video_frame_mark_kitty_shm_submitted(VideoFrame *frame) {
+    if (frame && frame->kitty_shm_name) {
         /* Kitty t=s transfers hand unlink ownership to the terminal after the
-         * escape sequence is fully written. Unlinking here can race the
-         * terminal's shm_open(); unsubmitted frames are still cleaned up in
-         * video_frame_destroy(). */
+         * escape sequence is fully written and flushed. Unlinking here can
+         * race the terminal's shm_open(); unsubmitted frames are still cleaned
+         * up in video_frame_destroy(). */
         g_clear_pointer(&frame->kitty_shm_name, g_free);
     }
 }
@@ -1415,6 +1415,7 @@ static gboolean video_player_render_frame(VideoPlayer *player) {
     gint rendered_w = frame->rendered_width;
     gint rendered_h = frame->rendered_height;
     gboolean graphics_mode = (frame->pixel_mode != CHAFA_PIXEL_MODE_SYMBOLS);
+    gboolean kitty_shm_written = FALSE;
     video_player_debug_log(player, "render-frame", frame->pts_ms, rendered_w, rendered_h, graphics_mode ? 1 : 0);
 
     gint64 io_start_us = g_get_monotonic_time();
@@ -1465,7 +1466,7 @@ static gboolean video_player_render_frame(VideoPlayer *player) {
             if (result->len > 0) {
                 written = fwrite(result->str, 1, result->len, stdout);
             }
-            video_frame_mark_kitty_shm_submitted(frame, written, result->len);
+            kitty_shm_written = frame->kitty_shm_name && written == result->len;
             lines_printed = rendered_h > 0 ? rendered_h : 1;
         } else if (!has_newline) {
             video_player_clear_line_cache(player);
@@ -1585,14 +1586,16 @@ static gboolean video_player_render_frame(VideoPlayer *player) {
         if (result->len > 0) {
             written = fwrite(result->str, 1, result->len, stdout);
         }
-        video_frame_mark_kitty_shm_submitted(frame, written, result->len);
+        kitty_shm_written = frame->kitty_shm_name && written == result->len;
         printf("\033[J");
         player->last_frame_top_row = 0;
         player->last_frame_height = 0;
     }
     g_mutex_unlock(&player->state_mutex);
 
-    fflush(stdout);
+    if (fflush(stdout) == 0 && kitty_shm_written) {
+        video_frame_mark_kitty_shm_submitted(frame);
+    }
     gint64 io_end_us = g_get_monotonic_time();
     g_mutex_lock(&player->state_mutex);
     player->last_presented_pts_ms = frame->pts_ms;

--- a/src/video_player.c
+++ b/src/video_player.c
@@ -194,6 +194,10 @@ void video_frame_destroy(VideoFrame *frame) {
 
 static void video_frame_mark_kitty_shm_submitted(VideoFrame *frame, size_t written, size_t expected) {
     if (frame && frame->kitty_shm_name && written == expected) {
+        /* Kitty t=s transfers hand unlink ownership to the terminal after the
+         * escape sequence is fully written. Unlinking here can race the
+         * terminal's shm_open(); unsubmitted frames are still cleaned up in
+         * video_frame_destroy(). */
         g_clear_pointer(&frame->kitty_shm_name, g_free);
     }
 }

--- a/src/video_player.c
+++ b/src/video_player.c
@@ -7,6 +7,7 @@
 #include "video_player_layout_internal.h"
 #include "video_player_playback_internal.h"
 #include "video_player_seek_internal.h"
+#include "kitty_graphics.h"
 #include "media_buffer.h"
 
 #include <libavcodec/avcodec.h>
@@ -184,7 +185,17 @@ void video_frame_destroy(VideoFrame *frame) {
     if (frame->rendered) {
         g_string_free(frame->rendered, TRUE);
     }
+    if (frame->kitty_shm_name) {
+        kitty_graphics_shm_unlink(frame->kitty_shm_name);
+        g_free(frame->kitty_shm_name);
+    }
     g_free(frame);
+}
+
+static void video_frame_mark_kitty_shm_submitted(VideoFrame *frame, size_t written, size_t expected) {
+    if (frame && frame->kitty_shm_name && written == expected) {
+        g_clear_pointer(&frame->kitty_shm_name, g_free);
+    }
 }
 
 void video_player_queue_clear(VideoPlayer *player) {
@@ -568,7 +579,8 @@ static void video_player_reset_media_state(VideoPlayer *player) {
 }
 
 VideoPlayer* video_player_new(gint work_factor, gboolean force_text, gboolean force_sixel, gboolean force_kitty,
-                              gboolean force_iterm2, TextSymbolMode text_symbol_mode, gdouble gamma) {
+                              gboolean force_iterm2, TextSymbolMode text_symbol_mode, gdouble gamma,
+                              KittyTransferMode kitty_transfer) {
     VideoPlayer *player = g_new0(VideoPlayer, 1);
     if (!player) {
         return NULL;
@@ -631,6 +643,7 @@ VideoPlayer* video_player_new(gint work_factor, gboolean force_text, gboolean fo
     player->present_fps_valid = FALSE;
     player->show_stats = FALSE;
     player->color_enhance = COLOR_ENHANCE_OFF;
+    player->kitty_transfer = kitty_transfer;
 
     if (work_factor < 1) {
         work_factor = 1;
@@ -1259,19 +1272,46 @@ static gpointer video_player_render_worker_thread(gpointer user_data) {
         gint64 render_start_us = g_get_monotonic_time();
         video_player_render_worker_refresh_layout(player, renderer, &layout_generation);
 
-        GString *rendered = renderer_render_image_data(renderer,
-                                                       decoded->pixels,
-                                                       decoded->width,
-                                                       decoded->height,
-                                                       decoded->rowstride,
-                                                       4);
         gint rendered_w = 0;
         gint rendered_h = 0;
         ChafaPixelMode pixel_mode = CHAFA_PIXEL_MODE_SYMBOLS;
-        if (rendered) {
+        GString *rendered = NULL;
+        gchar *kitty_shm_name = NULL;
+        gboolean try_kitty_shm = renderer->config.force_kitty &&
+                                 !renderer->config.force_text &&
+                                 !renderer->config.force_sixel &&
+                                 !renderer->config.force_iterm2 &&
+                                 kitty_graphics_should_use_shm(player->kitty_transfer);
+        if (try_kitty_shm && renderer_setup_canvas(renderer, decoded->width, decoded->height) == ERROR_NONE) {
             renderer_get_rendered_dimensions(renderer, &rendered_w, &rendered_h);
-            if (renderer->canvas_config) {
-                pixel_mode = chafa_canvas_config_get_pixel_mode(renderer->canvas_config);
+            KittyGraphicsFrame *kitty_frame = kitty_graphics_frame_new_shm_rgba(decoded->pixels,
+                                                                               decoded->width,
+                                                                               decoded->height,
+                                                                               decoded->rowstride,
+                                                                               rendered_w,
+                                                                               rendered_h);
+            if (kitty_frame) {
+                rendered = kitty_frame->command;
+                kitty_shm_name = kitty_frame->shm_name;
+                kitty_frame->command = NULL;
+                kitty_frame->shm_name = NULL;
+                pixel_mode = CHAFA_PIXEL_MODE_KITTY;
+                kitty_graphics_frame_free(kitty_frame);
+            }
+        }
+        if (!rendered) {
+            g_clear_pointer(&kitty_shm_name, g_free);
+            rendered = renderer_render_image_data(renderer,
+                                                  decoded->pixels,
+                                                  decoded->width,
+                                                  decoded->height,
+                                                  decoded->rowstride,
+                                                  4);
+            if (rendered) {
+                renderer_get_rendered_dimensions(renderer, &rendered_w, &rendered_h);
+                if (renderer->canvas_config) {
+                    pixel_mode = chafa_canvas_config_get_pixel_mode(renderer->canvas_config);
+                }
             }
         }
         gint64 render_elapsed_us = g_get_monotonic_time() - render_start_us;
@@ -1287,11 +1327,16 @@ static gpointer video_player_render_worker_thread(gpointer user_data) {
         VideoFrame *frame = g_new0(VideoFrame, 1);
         if (!frame) {
             g_string_free(rendered, TRUE);
+            if (kitty_shm_name) {
+                kitty_graphics_shm_unlink(kitty_shm_name);
+                g_free(kitty_shm_name);
+            }
             decoded_frame_destroy(decoded);
             video_player_render_work_finished(player);
             continue;
         }
         frame->rendered = rendered;
+        frame->kitty_shm_name = kitty_shm_name;
         frame->rendered_width = rendered_w;
         frame->rendered_height = rendered_h;
         frame->pts_ms = decoded->pts_ms;
@@ -1411,9 +1456,11 @@ static gboolean video_player_render_frame(VideoPlayer *player) {
                 col = 1;
             }
             printf("\033[%d;%dH", row, col);
+            size_t written = 0;
             if (result->len > 0) {
-                fwrite(result->str, 1, result->len, stdout);
+                written = fwrite(result->str, 1, result->len, stdout);
             }
+            video_frame_mark_kitty_shm_submitted(frame, written, result->len);
             lines_printed = rendered_h > 0 ? rendered_h : 1;
         } else if (!has_newline) {
             video_player_clear_line_cache(player);
@@ -1529,7 +1576,11 @@ static gboolean video_player_render_frame(VideoPlayer *player) {
     } else {
         video_player_clear_line_cache(player);
         printf("\033[H");
-        printf("%s", result->str);
+        size_t written = 0;
+        if (result->len > 0) {
+            written = fwrite(result->str, 1, result->len, stdout);
+        }
+        video_frame_mark_kitty_shm_submitted(frame, written, result->len);
         printf("\033[J");
         player->last_frame_top_row = 0;
         player->last_frame_height = 0;

--- a/src/video_player.c
+++ b/src/video_player.c
@@ -644,6 +644,7 @@ VideoPlayer* video_player_new(gint work_factor, gboolean force_text, gboolean fo
     player->show_stats = FALSE;
     player->color_enhance = COLOR_ENHANCE_OFF;
     player->kitty_transfer = kitty_transfer;
+    player->kitty_shm_enabled = kitty_graphics_should_use_shm(kitty_transfer);
 
     if (work_factor < 1) {
         work_factor = 1;
@@ -1281,7 +1282,7 @@ static gpointer video_player_render_worker_thread(gpointer user_data) {
                                  !renderer->config.force_text &&
                                  !renderer->config.force_sixel &&
                                  !renderer->config.force_iterm2 &&
-                                 kitty_graphics_should_use_shm(player->kitty_transfer);
+                                 player->kitty_shm_enabled;
         if (try_kitty_shm && renderer_setup_canvas(renderer, decoded->width, decoded->height) == ERROR_NONE) {
             renderer_get_rendered_dimensions(renderer, &rendered_w, &rendered_h);
             KittyGraphicsFrame *kitty_frame = kitty_graphics_frame_new_shm_rgba(decoded->pixels,

--- a/tests/test_app_cli.c
+++ b/tests/test_app_cli.c
@@ -46,6 +46,11 @@ typedef struct {
 } ColorEnhanceCase;
 
 typedef struct {
+    const gchar *value;
+    KittyTransferMode expected_mode;
+} KittyTransferCase;
+
+typedef struct {
     char **argv;
     gchar **path_out;
     AppConfig *config;
@@ -727,6 +732,7 @@ static void test_cli_apply_runtime_copies_app_owned_config_fields(AppCliFixture 
     config.work_factor = 4;
     config.gamma = 1.75;
     config.color_enhance = COLOR_ENHANCE_VIVID;
+    config.kitty_transfer = KITTY_TRANSFER_SHM;
     config.force_text = TRUE;
     config.force_sixel = FALSE;
     config.force_kitty = TRUE;
@@ -744,6 +750,7 @@ static void test_cli_apply_runtime_copies_app_owned_config_fields(AppCliFixture 
     g_assert_cmpint(app.render_work_factor, ==, 4);
     g_assert_cmpfloat_with_epsilon(app.gamma, 1.75, 0.0001);
     g_assert_cmpint(app.color_enhance, ==, COLOR_ENHANCE_VIVID);
+    g_assert_cmpint(app.kitty_transfer, ==, KITTY_TRANSFER_SHM);
     g_assert_true(app.force_text);
     g_assert_false(app.force_sixel);
     g_assert_true(app.force_kitty);
@@ -766,6 +773,7 @@ static void test_cli_default_config_applies_terminal_specific_precedence(AppCliF
         "work_factor=3\n"
         "protocol=text\n"
         "text_symbols=quarter\n"
+        "kitty_transfer=direct\n"
         "color_enhance=off\n"
         "gamma=1.25\n"
         "\n"
@@ -774,6 +782,7 @@ static void test_cli_default_config_applies_terminal_specific_precedence(AppCliF
         "clear_workaround=true\n"
         "protocol=kitty\n"
         "text_symbols=half\n"
+        "kitty_transfer=shm\n"
         "color_enhance=vivid\n");
 
     pixelterm_env_set_for_test("TERM_PROGRAM", "WarpTerminal");
@@ -792,6 +801,7 @@ static void test_cli_default_config_applies_terminal_specific_precedence(AppCliF
     g_assert_cmpint(config.work_factor, ==, 3);
     g_assert_cmpint(config.protocol_mode, ==, APP_PROTOCOL_KITTY);
     g_assert_cmpint(config.text_symbol_mode, ==, TEXT_SYMBOL_MODE_HALF);
+    g_assert_cmpint(config.kitty_transfer, ==, KITTY_TRANSFER_SHM);
     g_assert_cmpint(config.color_enhance, ==, COLOR_ENHANCE_VIVID);
     g_assert_true(config.gamma_set);
     g_assert_cmpfloat_with_epsilon(config.gamma, 1.25, 0.0001);
@@ -814,6 +824,7 @@ static void test_cli_default_config_respects_runtime_xdg_after_glib_cache_prime(
         "work_factor=3\n"
         "protocol=text\n"
         "text_symbols=quarter\n"
+        "kitty_transfer=direct\n"
         "color_enhance=off\n"
         "gamma=1.25\n"
         "\n"
@@ -822,6 +833,7 @@ static void test_cli_default_config_respects_runtime_xdg_after_glib_cache_prime(
         "clear_workaround=true\n"
         "protocol=kitty\n"
         "text_symbols=half\n"
+        "kitty_transfer=shm\n"
         "color_enhance=vivid\n");
 
     pixelterm_env_set_for_test("XDG_CONFIG_HOME", config_root);
@@ -841,6 +853,7 @@ static void test_cli_default_config_respects_runtime_xdg_after_glib_cache_prime(
     g_assert_cmpint(config.work_factor, ==, 3);
     g_assert_cmpint(config.protocol_mode, ==, APP_PROTOCOL_KITTY);
     g_assert_cmpint(config.text_symbol_mode, ==, TEXT_SYMBOL_MODE_HALF);
+    g_assert_cmpint(config.kitty_transfer, ==, KITTY_TRANSFER_SHM);
     g_assert_cmpint(config.color_enhance, ==, COLOR_ENHANCE_VIVID);
     g_assert_true(config.gamma_set);
     g_assert_cmpfloat_with_epsilon(config.gamma, 1.25, 0.0001);
@@ -865,6 +878,7 @@ static void test_cli_flags_override_loaded_config_values(AppCliFixture *fixture,
         "work_factor=2\n"
         "protocol=text\n"
         "text_symbols=half\n"
+        "kitty_transfer=direct\n"
         "color_enhance=off\n"
         "gamma=1.5\n");
 
@@ -888,6 +902,8 @@ static void test_cli_flags_override_loaded_config_values(AppCliFixture *fixture,
         "sixel",
         "--text-symbols",
         "quarter",
+        "--kitty-transfer",
+        "shm",
         "--color-enhance",
         "vivid",
         "--gamma",
@@ -905,6 +921,7 @@ static void test_cli_flags_override_loaded_config_values(AppCliFixture *fixture,
     g_assert_cmpint(config.work_factor, ==, 8);
     g_assert_cmpint(config.protocol_mode, ==, APP_PROTOCOL_SIXEL);
     g_assert_cmpint(config.text_symbol_mode, ==, TEXT_SYMBOL_MODE_QUARTER);
+    g_assert_cmpint(config.kitty_transfer, ==, KITTY_TRANSFER_SHM);
     g_assert_cmpint(config.color_enhance, ==, COLOR_ENHANCE_VIVID);
     g_assert_true(config.gamma_set);
     g_assert_cmpfloat_with_epsilon(config.gamma, 2.5, 0.0001);
@@ -935,6 +952,46 @@ static void test_cli_color_enhance_argument_parses_supported_modes(AppCliFixture
         g_assert_cmpstr(path, ==, "sample.png");
         g_free(path);
     }
+}
+
+static void test_cli_kitty_transfer_argument_parses_supported_modes(AppCliFixture *fixture,
+                                                                    gconstpointer user_data) {
+    (void)fixture;
+    (void)user_data;
+
+    const KittyTransferCase cases[] = {
+        {"auto", KITTY_TRANSFER_AUTO},
+        {"DIRECT", KITTY_TRANSFER_DIRECT},
+        {"shm", KITTY_TRANSFER_SHM},
+    };
+
+    for (gsize i = 0; i < G_N_ELEMENTS(cases); i++) {
+        AppConfig config;
+        gchar *path = NULL;
+        app_config_init(&config);
+
+        char *argv[] = {"pixelterm", "--kitty-transfer", (char *)cases[i].value, "sample.mp4", NULL};
+
+        g_assert_cmpint(parse_cli_args(argv, &path, &config), ==, ERROR_NONE);
+        g_assert_cmpint(config.kitty_transfer, ==, cases[i].expected_mode);
+        g_assert_cmpstr(path, ==, "sample.mp4");
+        g_free(path);
+    }
+}
+
+static void test_cli_kitty_transfer_argument_rejects_unknown_mode(AppCliFixture *fixture,
+                                                                  gconstpointer user_data) {
+    (void)fixture;
+    (void)user_data;
+
+    AppConfig config;
+    gchar *path = NULL;
+    app_config_init(&config);
+
+    char *argv[] = {"pixelterm", "--kitty-transfer", "pipe", NULL};
+
+    g_assert_cmpint(parse_cli_args(argv, &path, &config), ==, ERROR_INVALID_ARGS);
+    g_assert_null(path);
 }
 
 static void test_cli_color_enhance_argument_rejects_unknown_mode(AppCliFixture *fixture,
@@ -1284,9 +1341,13 @@ void register_app_cli_tests(void) {
     add_app_cli_test("/app_cli/parse/text_symbols",
                      test_cli_text_symbols_argument_parses_supported_modes);
     add_app_cli_test("/app_cli/parse/color_enhance",
-                     test_cli_color_enhance_argument_parses_supported_modes);
+                      test_cli_color_enhance_argument_parses_supported_modes);
     add_app_cli_test("/app_cli/parse/color_enhance_invalid",
-                     test_cli_color_enhance_argument_rejects_unknown_mode);
+                      test_cli_color_enhance_argument_rejects_unknown_mode);
+    add_app_cli_test("/app_cli/parse/kitty_transfer",
+                     test_cli_kitty_transfer_argument_parses_supported_modes);
+    add_app_cli_test("/app_cli/parse/kitty_transfer_invalid",
+                     test_cli_kitty_transfer_argument_rejects_unknown_mode);
     add_app_cli_test("/app_cli/protocol_resolution/auto_prefers_affirmative_signal_before_generic_probe_order",
                      test_cli_protocol_resolution_auto_prefers_affirmative_signal_before_generic_probe_order);
     add_app_cli_test("/app_cli/protocol_resolution/auto_accepts_libghostty_xtversion_as_kitty_signal",

--- a/tests/test_app_media_session.c
+++ b/tests/test_app_media_session.c
@@ -21,7 +21,7 @@ static gboolean init_test_players(PixelTermApp *app) {
         return FALSE;
     }
     app->gif_player = gif_player_new(1, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
-    app->video_player = video_player_new(1, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    app->video_player = video_player_new(1, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!app->gif_player || !app->video_player) {
         destroy_test_players(app);
         return FALSE;
@@ -45,7 +45,7 @@ static gboolean init_video_player_only(PixelTermApp *app) {
     if (!app) {
         return FALSE;
     }
-    app->video_player = video_player_new(1, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    app->video_player = video_player_new(1, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!app->video_player) {
         destroy_test_players(app);
         return FALSE;

--- a/tests/test_app_mode.c
+++ b/tests/test_app_mode.c
@@ -78,7 +78,7 @@ static void test_transition_to_non_single_stops_media(void) {
     app.mode = APP_MODE_SINGLE;
 
     app.gif_player = gif_player_new(4, FALSE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
-    app.video_player = video_player_new(4, FALSE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    app.video_player = video_player_new(4, FALSE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!app.gif_player || !app.video_player) {
         if (app.gif_player) {
             gif_player_destroy(app.gif_player);

--- a/tests/test_app_single_render_integration.c
+++ b/tests/test_app_single_render_integration.c
@@ -136,7 +136,7 @@ static gboolean init_render_test_app(PixelTermApp *app) {
     }
 
     app->gif_player = gif_player_new(1, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
-    app->video_player = video_player_new(1, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    app->video_player = video_player_new(1, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!app->gif_player || !app->video_player) {
         destroy_render_test_app(app);
         return FALSE;

--- a/tests/test_common.c
+++ b/tests/test_common.c
@@ -22,6 +22,7 @@ void register_video_player_tests(void);
 void register_app_media_session_tests(void);
 void register_app_single_render_integration_tests(void);
 void register_terminal_protocols_tests(void);
+void register_kitty_graphics_tests(void);
 void register_app_cli_tests(void);
 void register_app_startup_tests(void);
 void register_book_tests(void);
@@ -315,6 +316,7 @@ int main(int argc, char **argv) {
     register_input_dispatch_mouse_modes_tests();
     register_preview_shared_tests();
     register_terminal_protocols_tests();
+    register_kitty_graphics_tests();
     register_app_cli_tests();
     register_app_startup_tests();
     register_book_tests();

--- a/tests/test_kitty_graphics.c
+++ b/tests/test_kitty_graphics.c
@@ -4,7 +4,7 @@
 #include "kitty_graphics.h"
 
 static void test_kitty_graphics_shm_command_contains_expected_controls(void) {
-    GString *command = kitty_graphics_build_shm_command_for_test("/pixelterm-test", 16, 8, 4, 2, 512);
+    GString *command = kitty_graphics_build_shm_command("/pixelterm-test", 16, 8, 4, 2, 512);
     g_assert_nonnull(command);
     g_assert_true(g_str_has_prefix(command->str, "\033_G"));
     g_assert_nonnull(strstr(command->str, "a=T"));
@@ -22,10 +22,10 @@ static void test_kitty_graphics_shm_command_contains_expected_controls(void) {
 }
 
 static void test_kitty_graphics_shm_command_rejects_invalid_input(void) {
-    g_assert_null(kitty_graphics_build_shm_command_for_test(NULL, 16, 8, 4, 2, 512));
-    g_assert_null(kitty_graphics_build_shm_command_for_test("/x", 0, 8, 4, 2, 512));
-    g_assert_null(kitty_graphics_build_shm_command_for_test("/x", 16, 8, 0, 2, 512));
-    g_assert_null(kitty_graphics_build_shm_command_for_test("/x", 16, 8, 4, 2, 0));
+    g_assert_null(kitty_graphics_build_shm_command(NULL, 16, 8, 4, 2, 512));
+    g_assert_null(kitty_graphics_build_shm_command("/x", 0, 8, 4, 2, 512));
+    g_assert_null(kitty_graphics_build_shm_command("/x", 16, 8, 0, 2, 512));
+    g_assert_null(kitty_graphics_build_shm_command("/x", 16, 8, 4, 2, 0));
 }
 
 static void test_kitty_graphics_shm_auto_enabled_rejects_remote_context(void) {

--- a/tests/test_kitty_graphics.c
+++ b/tests/test_kitty_graphics.c
@@ -29,9 +29,9 @@ static void test_kitty_graphics_shm_command_rejects_invalid_input(void) {
 }
 
 static void test_kitty_graphics_shm_auto_enabled_rejects_remote_context(void) {
-    const gchar *old_override = g_getenv("PIXELTERM_KITTY_SHM");
-    const gchar *old_ssh = g_getenv("SSH_CONNECTION");
-    const gchar *old_term = g_getenv("TERM");
+    gchar *old_override = g_strdup(g_getenv("PIXELTERM_KITTY_SHM"));
+    gchar *old_ssh = g_strdup(g_getenv("SSH_CONNECTION"));
+    gchar *old_term = g_strdup(g_getenv("TERM"));
 
     g_unsetenv("PIXELTERM_KITTY_SHM");
     g_setenv("SSH_CONNECTION", "host 1 host 2", TRUE);
@@ -42,12 +42,15 @@ static void test_kitty_graphics_shm_auto_enabled_rejects_remote_context(void) {
     if (old_override) g_setenv("PIXELTERM_KITTY_SHM", old_override, TRUE); else g_unsetenv("PIXELTERM_KITTY_SHM");
     if (old_ssh) g_setenv("SSH_CONNECTION", old_ssh, TRUE); else g_unsetenv("SSH_CONNECTION");
     if (old_term) g_setenv("TERM", old_term, TRUE); else g_unsetenv("TERM");
+    g_free(old_override);
+    g_free(old_ssh);
+    g_free(old_term);
 }
 
 static void test_kitty_graphics_shm_auto_enabled_allows_explicit_override(void) {
-    const gchar *old_override = g_getenv("PIXELTERM_KITTY_SHM");
-    const gchar *old_ssh = g_getenv("SSH_CONNECTION");
-    const gchar *old_term = g_getenv("TERM");
+    gchar *old_override = g_strdup(g_getenv("PIXELTERM_KITTY_SHM"));
+    gchar *old_ssh = g_strdup(g_getenv("SSH_CONNECTION"));
+    gchar *old_term = g_strdup(g_getenv("TERM"));
 
     g_setenv("PIXELTERM_KITTY_SHM", "1", TRUE);
     g_setenv("SSH_CONNECTION", "host 1 host 2", TRUE);
@@ -58,6 +61,20 @@ static void test_kitty_graphics_shm_auto_enabled_allows_explicit_override(void) 
     if (old_override) g_setenv("PIXELTERM_KITTY_SHM", old_override, TRUE); else g_unsetenv("PIXELTERM_KITTY_SHM");
     if (old_ssh) g_setenv("SSH_CONNECTION", old_ssh, TRUE); else g_unsetenv("SSH_CONNECTION");
     if (old_term) g_setenv("TERM", old_term, TRUE); else g_unsetenv("TERM");
+    g_free(old_override);
+    g_free(old_ssh);
+    g_free(old_term);
+}
+
+static void test_kitty_graphics_frame_rejects_rowstride_overflow(void) {
+    guint8 pixel = 0;
+
+    g_assert_null(kitty_graphics_frame_new_shm_rgba(&pixel,
+                                                    G_MAXINT,
+                                                    1,
+                                                    G_MAXINT,
+                                                    1,
+                                                    1));
 }
 
 void register_kitty_graphics_tests(void) {
@@ -65,4 +82,5 @@ void register_kitty_graphics_tests(void) {
     g_test_add_func("/kitty_graphics/shm_command/rejects_invalid_input", test_kitty_graphics_shm_command_rejects_invalid_input);
     g_test_add_func("/kitty_graphics/shm_auto/rejects_remote_context", test_kitty_graphics_shm_auto_enabled_rejects_remote_context);
     g_test_add_func("/kitty_graphics/shm_auto/allows_explicit_override", test_kitty_graphics_shm_auto_enabled_allows_explicit_override);
+    g_test_add_func("/kitty_graphics/frame/rejects_rowstride_overflow", test_kitty_graphics_frame_rejects_rowstride_overflow);
 }

--- a/tests/test_kitty_graphics.c
+++ b/tests/test_kitty_graphics.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include "kitty_graphics.h"
+#include "process_env.h"
 
 static void test_kitty_graphics_shm_command_contains_expected_controls(void) {
     GString *command = kitty_graphics_build_shm_command("/pixelterm-test", 16, 8, 4, 2, 512);
@@ -29,41 +30,23 @@ static void test_kitty_graphics_shm_command_rejects_invalid_input(void) {
 }
 
 static void test_kitty_graphics_shm_auto_enabled_rejects_remote_context(void) {
-    gchar *old_override = g_strdup(g_getenv("PIXELTERM_KITTY_SHM"));
-    gchar *old_ssh = g_strdup(g_getenv("SSH_CONNECTION"));
-    gchar *old_term = g_strdup(g_getenv("TERM"));
-
-    g_unsetenv("PIXELTERM_KITTY_SHM");
-    g_setenv("SSH_CONNECTION", "host 1 host 2", TRUE);
-    g_setenv("TERM", "xterm-kitty", TRUE);
+    pixelterm_env_unset_for_test("PIXELTERM_KITTY_SHM");
+    pixelterm_env_set_for_test("SSH_CONNECTION", "host 1 host 2");
+    pixelterm_env_set_for_test("TERM", "xterm-kitty");
 
     g_assert_false(kitty_graphics_shm_auto_enabled());
 
-    if (old_override) g_setenv("PIXELTERM_KITTY_SHM", old_override, TRUE); else g_unsetenv("PIXELTERM_KITTY_SHM");
-    if (old_ssh) g_setenv("SSH_CONNECTION", old_ssh, TRUE); else g_unsetenv("SSH_CONNECTION");
-    if (old_term) g_setenv("TERM", old_term, TRUE); else g_unsetenv("TERM");
-    g_free(old_override);
-    g_free(old_ssh);
-    g_free(old_term);
+    pixelterm_env_reset_for_test();
 }
 
 static void test_kitty_graphics_shm_auto_enabled_allows_explicit_override(void) {
-    gchar *old_override = g_strdup(g_getenv("PIXELTERM_KITTY_SHM"));
-    gchar *old_ssh = g_strdup(g_getenv("SSH_CONNECTION"));
-    gchar *old_term = g_strdup(g_getenv("TERM"));
-
-    g_setenv("PIXELTERM_KITTY_SHM", "1", TRUE);
-    g_setenv("SSH_CONNECTION", "host 1 host 2", TRUE);
-    g_setenv("TERM", "xterm-256color", TRUE);
+    pixelterm_env_set_for_test("PIXELTERM_KITTY_SHM", "1");
+    pixelterm_env_set_for_test("SSH_CONNECTION", "host 1 host 2");
+    pixelterm_env_set_for_test("TERM", "xterm-256color");
 
     g_assert_true(kitty_graphics_shm_auto_enabled());
 
-    if (old_override) g_setenv("PIXELTERM_KITTY_SHM", old_override, TRUE); else g_unsetenv("PIXELTERM_KITTY_SHM");
-    if (old_ssh) g_setenv("SSH_CONNECTION", old_ssh, TRUE); else g_unsetenv("SSH_CONNECTION");
-    if (old_term) g_setenv("TERM", old_term, TRUE); else g_unsetenv("TERM");
-    g_free(old_override);
-    g_free(old_ssh);
-    g_free(old_term);
+    pixelterm_env_reset_for_test();
 }
 
 static void test_kitty_graphics_frame_rejects_rowstride_overflow(void) {
@@ -77,10 +60,22 @@ static void test_kitty_graphics_frame_rejects_rowstride_overflow(void) {
                                                     1));
 }
 
+static void test_kitty_graphics_frame_rejects_large_payload(void) {
+    guint8 pixel[4] = {0, 0, 0, 255};
+
+    g_assert_null(kitty_graphics_frame_new_shm_rgba(pixel,
+                                                    4097,
+                                                    512,
+                                                    4097 * 4,
+                                                    4097,
+                                                    512));
+}
+
 void register_kitty_graphics_tests(void) {
     g_test_add_func("/kitty_graphics/shm_command/controls", test_kitty_graphics_shm_command_contains_expected_controls);
     g_test_add_func("/kitty_graphics/shm_command/rejects_invalid_input", test_kitty_graphics_shm_command_rejects_invalid_input);
     g_test_add_func("/kitty_graphics/shm_auto/rejects_remote_context", test_kitty_graphics_shm_auto_enabled_rejects_remote_context);
     g_test_add_func("/kitty_graphics/shm_auto/allows_explicit_override", test_kitty_graphics_shm_auto_enabled_allows_explicit_override);
     g_test_add_func("/kitty_graphics/frame/rejects_rowstride_overflow", test_kitty_graphics_frame_rejects_rowstride_overflow);
+    g_test_add_func("/kitty_graphics/frame/rejects_large_payload", test_kitty_graphics_frame_rejects_large_payload);
 }

--- a/tests/test_kitty_graphics.c
+++ b/tests/test_kitty_graphics.c
@@ -1,0 +1,68 @@
+#include <glib.h>
+#include <string.h>
+
+#include "kitty_graphics.h"
+
+static void test_kitty_graphics_shm_command_contains_expected_controls(void) {
+    GString *command = kitty_graphics_build_shm_command_for_test("/pixelterm-test", 16, 8, 4, 2, 512);
+    g_assert_nonnull(command);
+    g_assert_true(g_str_has_prefix(command->str, "\033_G"));
+    g_assert_nonnull(strstr(command->str, "a=T"));
+    g_assert_nonnull(strstr(command->str, "f=32"));
+    g_assert_nonnull(strstr(command->str, "s=16"));
+    g_assert_nonnull(strstr(command->str, "v=8"));
+    g_assert_nonnull(strstr(command->str, "t=s"));
+    g_assert_nonnull(strstr(command->str, "S=512"));
+    g_assert_nonnull(strstr(command->str, "c=4"));
+    g_assert_nonnull(strstr(command->str, "r=2"));
+    g_assert_nonnull(strstr(command->str, "C=1"));
+    g_assert_nonnull(strstr(command->str, "q=2"));
+    g_assert_true(g_str_has_suffix(command->str, "\033\\"));
+    g_string_free(command, TRUE);
+}
+
+static void test_kitty_graphics_shm_command_rejects_invalid_input(void) {
+    g_assert_null(kitty_graphics_build_shm_command_for_test(NULL, 16, 8, 4, 2, 512));
+    g_assert_null(kitty_graphics_build_shm_command_for_test("/x", 0, 8, 4, 2, 512));
+    g_assert_null(kitty_graphics_build_shm_command_for_test("/x", 16, 8, 0, 2, 512));
+    g_assert_null(kitty_graphics_build_shm_command_for_test("/x", 16, 8, 4, 2, 0));
+}
+
+static void test_kitty_graphics_shm_auto_enabled_rejects_remote_context(void) {
+    const gchar *old_override = g_getenv("PIXELTERM_KITTY_SHM");
+    const gchar *old_ssh = g_getenv("SSH_CONNECTION");
+    const gchar *old_term = g_getenv("TERM");
+
+    g_unsetenv("PIXELTERM_KITTY_SHM");
+    g_setenv("SSH_CONNECTION", "host 1 host 2", TRUE);
+    g_setenv("TERM", "xterm-kitty", TRUE);
+
+    g_assert_false(kitty_graphics_shm_auto_enabled());
+
+    if (old_override) g_setenv("PIXELTERM_KITTY_SHM", old_override, TRUE); else g_unsetenv("PIXELTERM_KITTY_SHM");
+    if (old_ssh) g_setenv("SSH_CONNECTION", old_ssh, TRUE); else g_unsetenv("SSH_CONNECTION");
+    if (old_term) g_setenv("TERM", old_term, TRUE); else g_unsetenv("TERM");
+}
+
+static void test_kitty_graphics_shm_auto_enabled_allows_explicit_override(void) {
+    const gchar *old_override = g_getenv("PIXELTERM_KITTY_SHM");
+    const gchar *old_ssh = g_getenv("SSH_CONNECTION");
+    const gchar *old_term = g_getenv("TERM");
+
+    g_setenv("PIXELTERM_KITTY_SHM", "1", TRUE);
+    g_setenv("SSH_CONNECTION", "host 1 host 2", TRUE);
+    g_setenv("TERM", "xterm-256color", TRUE);
+
+    g_assert_true(kitty_graphics_shm_auto_enabled());
+
+    if (old_override) g_setenv("PIXELTERM_KITTY_SHM", old_override, TRUE); else g_unsetenv("PIXELTERM_KITTY_SHM");
+    if (old_ssh) g_setenv("SSH_CONNECTION", old_ssh, TRUE); else g_unsetenv("SSH_CONNECTION");
+    if (old_term) g_setenv("TERM", old_term, TRUE); else g_unsetenv("TERM");
+}
+
+void register_kitty_graphics_tests(void) {
+    g_test_add_func("/kitty_graphics/shm_command/controls", test_kitty_graphics_shm_command_contains_expected_controls);
+    g_test_add_func("/kitty_graphics/shm_command/rejects_invalid_input", test_kitty_graphics_shm_command_rejects_invalid_input);
+    g_test_add_func("/kitty_graphics/shm_auto/rejects_remote_context", test_kitty_graphics_shm_auto_enabled_rejects_remote_context);
+    g_test_add_func("/kitty_graphics/shm_auto/allows_explicit_override", test_kitty_graphics_shm_auto_enabled_allows_explicit_override);
+}

--- a/tests/test_video_player.c
+++ b/tests/test_video_player.c
@@ -439,7 +439,7 @@ static void teardown_minimal_seek_context(VideoPlayer *player) {
 
 static void test_teardown_minimal_seek_context_frees_manual_format_context(void) {
     if (g_test_subprocess()) {
-        VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+        VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
         g_assert_nonnull(player);
         g_assert_true(init_minimal_seek_context(player));
 
@@ -456,7 +456,7 @@ static void test_teardown_minimal_seek_context_frees_manual_format_context(void)
 }
 
 static void test_decode_queue_clear_removes_all_decoded_frames(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -513,7 +513,7 @@ static gpointer decode_queue_wait_thread_main(gpointer user_data) {
 }
 
 static void test_decode_queue_sixel_mode_waits_instead_of_replacing_oldest(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -579,7 +579,7 @@ static void test_decode_queue_sixel_mode_waits_instead_of_replacing_oldest(void)
 }
 
 static void test_decode_queue_text_mode_waits_instead_of_replacing_oldest(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -641,7 +641,7 @@ static void test_decode_queue_text_mode_waits_instead_of_replacing_oldest(void) 
 }
 
 static void test_decode_queue_wait_and_take_blocks_until_item_arrives(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -673,7 +673,7 @@ static void test_decode_queue_wait_and_take_blocks_until_item_arrives(void) {
 }
 
 static void test_generation_counter_starts_initialized(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -685,7 +685,7 @@ static void test_generation_counter_starts_initialized(void) {
 }
 
 static void test_render_layout_generation_starts_initialized(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -697,7 +697,7 @@ static void test_render_layout_generation_starts_initialized(void) {
 }
 
 static void test_render_layout_generation_increments_only_on_layout_change(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -718,7 +718,7 @@ static void test_render_layout_generation_increments_only_on_layout_change(void)
 }
 
 static void test_reset_timing_state_clears_loop_sensitive_fields(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -758,7 +758,7 @@ static void test_reset_timing_state_clears_loop_sensitive_fields(void) {
 }
 
 static void test_set_fallback_pts_waits_on_state_mutex(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -793,7 +793,7 @@ static void test_set_fallback_pts_waits_on_state_mutex(void) {
 }
 
 static void test_resolve_and_advance_fallback_pts_waits_on_state_mutex(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -833,7 +833,7 @@ static void test_resolve_and_advance_fallback_pts_waits_on_state_mutex(void) {
 }
 
 static void test_current_position_prefers_last_presented_pts(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -852,7 +852,7 @@ static void test_current_position_prefers_last_presented_pts(void) {
 }
 
 static void test_current_position_uses_clock_when_no_presented_pts(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -878,7 +878,7 @@ static void test_current_position_uses_clock_when_no_presented_pts(void) {
 }
 
 static void test_current_position_uses_fallback_pts_when_clock_not_started(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -899,7 +899,7 @@ static void test_current_position_uses_fallback_pts_when_clock_not_started(void)
 }
 
 static void test_current_position_clamps_negative_fallback_pts_to_zero(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -920,7 +920,7 @@ static void test_current_position_clamps_negative_fallback_pts_to_zero(void) {
 }
 
 static void test_seek_target_clamps_to_zero_and_duration(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -937,7 +937,7 @@ static void test_seek_target_clamps_to_zero_and_duration(void) {
 }
 
 static void test_seek_relative_zero_delta_is_noop(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -971,7 +971,7 @@ static void test_seek_relative_zero_delta_is_noop(void) {
 }
 
 static void test_seek_relative_failed_seek_preserves_state(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1014,7 +1014,7 @@ static void test_seek_relative_failed_seek_preserves_state(void) {
 }
 
 static void test_seek_relative_paused_seek_refreshes_preview(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1057,7 +1057,7 @@ static void test_seek_relative_paused_seek_refreshes_preview(void) {
 }
 
 static void test_seek_relative_paused_repeated_seeks_preserve_latest_target(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1108,7 +1108,7 @@ static void test_seek_relative_paused_repeated_seeks_preserve_latest_target(void
 }
 
 static void test_seek_relative_preview_bails_after_decode_attempt_limit(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1152,7 +1152,7 @@ static void test_seek_preview_default_attempt_limit_is_bounded(void) {
 }
 
 static void test_render_seek_preview_uses_hook_before_decoder_setup(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1174,7 +1174,7 @@ static void test_render_seek_preview_uses_hook_before_decoder_setup(void) {
 }
 
 static void test_seek_relative_resets_visual_state_under_state_mutex(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1220,7 +1220,7 @@ static void test_seek_relative_resets_visual_state_under_state_mutex(void) {
 }
 
 static void test_play_after_eof_rewinds_explicitly_to_start(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1271,7 +1271,7 @@ static void test_play_after_eof_rewinds_explicitly_to_start(void) {
 }
 
 static void test_set_renderer_restarts_workers_when_replacing_during_playback(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1324,7 +1324,7 @@ static void test_set_renderer_restarts_workers_when_replacing_during_playback(vo
 }
 
 static void test_set_renderer_null_stops_playback_and_timer(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1348,7 +1348,7 @@ static void test_set_renderer_null_stops_playback_and_timer(void) {
 }
 
 static void test_schedule_tick_skips_when_eof_already_ended(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1369,7 +1369,7 @@ static void test_schedule_tick_skips_when_eof_already_ended(void) {
 }
 
 static void test_schedule_tick_skips_when_not_playing(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1390,7 +1390,7 @@ static void test_schedule_tick_skips_when_not_playing(void) {
 }
 
 static void test_schedule_tick_skips_without_renderer(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1412,7 +1412,7 @@ static void test_schedule_tick_skips_without_renderer(void) {
 }
 
 static void test_seek_relative_after_eof_stops_parked_workers_before_preview(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1476,7 +1476,7 @@ static void test_seek_relative_after_eof_stops_parked_workers_before_preview(voi
 
 static void test_seek_relative_after_eof_real_preview_does_not_crash(void) {
     if (g_test_subprocess()) {
-        VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+        VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
         if (!player) {
             g_test_skip("video player unavailable");
             return;
@@ -1518,7 +1518,7 @@ static void test_seek_relative_after_eof_real_preview_does_not_crash(void) {
 }
 
 static void test_render_queue_insert_sorted_orders_by_pts(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1536,7 +1536,7 @@ static void test_render_queue_insert_sorted_orders_by_pts(void) {
 }
 
 static void test_queue_clear_removes_all_rendered_frames(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1555,7 +1555,7 @@ static void test_queue_clear_removes_all_rendered_frames(void) {
 }
 
 static void test_should_not_drop_late_frame_when_backlog_is_shallow(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1587,7 +1587,7 @@ static void test_should_not_drop_late_frame_when_backlog_is_shallow(void) {
 }
 
 static void test_should_drop_late_frame_when_backlog_is_deep(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1616,7 +1616,7 @@ static void test_should_drop_late_frame_when_backlog_is_deep(void) {
 }
 
 static void test_queue_take_for_playback_waits_even_when_future_queue_is_full(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1634,7 +1634,7 @@ static void test_queue_take_for_playback_waits_even_when_future_queue_is_full(vo
 }
 
 static void test_queue_take_for_playback_waits_when_future_queue_is_not_full(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1650,7 +1650,7 @@ static void test_queue_take_for_playback_waits_when_future_queue_is_not_full(voi
 }
 
 static void test_calc_delay_uses_queue_head_even_with_high_io_avg(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1687,7 +1687,7 @@ static void test_calc_delay_uses_queue_head_even_with_high_io_avg(void) {
 }
 
 static void test_calc_delay_retries_quickly_when_playing_and_queue_is_empty(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1708,7 +1708,7 @@ static void test_calc_delay_retries_quickly_when_playing_and_queue_is_empty(void
 }
 
 static void test_should_not_drop_late_frame_when_backlog_is_medium(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1736,7 +1736,7 @@ static void test_should_not_drop_late_frame_when_backlog_is_medium(void) {
 }
 
 static void test_should_not_drop_late_frame_when_backlog_is_deep_and_silence_exceeded(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1772,7 +1772,7 @@ static gpointer queue_push_thread_main(gpointer user_data) {
 }
 
 static void test_update_queue_depth_uses_smaller_queue_for_large_render_geometry(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1786,7 +1786,7 @@ static void test_update_queue_depth_uses_smaller_queue_for_large_render_geometry
 }
 
 static void test_update_queue_depth_keeps_larger_queue_for_small_render_geometry(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1800,7 +1800,7 @@ static void test_update_queue_depth_keeps_larger_queue_for_small_render_geometry
 }
 
 static void test_update_queue_depth_uses_medium_queue_for_mid_render_geometry(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1814,7 +1814,7 @@ static void test_update_queue_depth_uses_medium_queue_for_mid_render_geometry(vo
 }
 
 static void test_update_queue_depth_uses_low_latency_queue_for_sixel_large_geometry(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1830,7 +1830,7 @@ static void test_update_queue_depth_uses_low_latency_queue_for_sixel_large_geome
 }
 
 static void test_queue_push_waits_for_capacity_instead_of_dropping_new_frame(void) {
-    VideoPlayer *player = video_player_new(2, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(2, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1881,7 +1881,7 @@ static void test_queue_push_waits_for_capacity_instead_of_dropping_new_frame(voi
 }
 
 static void test_rewind_reset_clears_timing_and_queue_state(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1916,7 +1916,7 @@ static void test_rewind_reset_clears_timing_and_queue_state(void) {
 }
 
 static void test_eof_handling_worker_eof_drains_tail_work_to_terminal_stop(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -1991,7 +1991,7 @@ static void test_eof_handling_worker_eof_drains_tail_work_to_terminal_stop(void)
 }
 
 static void test_queue_insert_sorted_rechecks_last_presented_after_full_queue_wait(void) {
-    VideoPlayer *player = video_player_new(2, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(2, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -2056,7 +2056,7 @@ static void test_queue_insert_sorted_rechecks_last_presented_after_full_queue_wa
 }
 
 static void test_queue_insert_sorted_rejects_old_generation_after_eof_invalidation(void) {
-    VideoPlayer *player = video_player_new(2, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(2, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -2117,7 +2117,7 @@ static void test_queue_insert_sorted_rejects_old_generation_after_eof_invalidati
 }
 
 static void test_queue_push_rejects_old_generation_after_eof_invalidation(void) {
-    VideoPlayer *player = video_player_new(2, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(2, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -2184,7 +2184,7 @@ static void test_debug_logging_stale_drop_completes_after_eof_handling(void) {
         return;
     }
 
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -2226,7 +2226,7 @@ static void test_debug_logging_stale_drop_completes_after_eof_handling(void) {
 }
 
 static void test_should_not_drop_late_frame_without_clock(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -2245,7 +2245,7 @@ static void test_should_not_drop_late_frame_without_clock(void) {
 }
 
 static void test_should_not_drop_late_frame_before_rewind_resync(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -2274,7 +2274,7 @@ static void test_should_not_drop_late_frame_before_rewind_resync(void) {
 }
 
 static void test_debug_logging_honors_environment_toggle(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -2295,7 +2295,7 @@ static void test_debug_logging_honors_environment_toggle(void) {
 }
 
 static void test_debug_logging_closes_stream_when_last_player_is_destroyed(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -2314,7 +2314,7 @@ static void test_debug_logging_closes_stream_when_last_player_is_destroyed(void)
 }
 
 static void test_debug_logging_disabled_skips_metric_locks_before_queue_wait(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -2365,7 +2365,7 @@ static void test_debug_logging_disabled_skips_metric_locks_before_queue_wait(voi
 }
 
 static void test_seek_frame_with_test_hook_uses_registered_callback(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;
@@ -2389,7 +2389,7 @@ static void test_seek_frame_with_test_hook_uses_registered_callback(void) {
 }
 
 static void test_render_worker_config_uses_player_color_enhance_without_renderer(void) {
-    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0);
+    VideoPlayer *player = video_player_new(4, TRUE, FALSE, FALSE, FALSE, TEXT_SYMBOL_MODE_AUTO, 1.0, KITTY_TRANSFER_AUTO);
     if (!player) {
         g_test_skip("video player unavailable");
         return;


### PR DESCRIPTION
## Summary
- add a kitty video transfer mode: `auto`, `direct`, or `shm`
- wire `kitty_transfer` through config, CLI, app runtime state, and video rendering
- add kitty shared-memory command generation/lifecycle tests and CLI/config parsing coverage
- document when to use config, `--kitty-transfer`, and the debug-only `PIXELTERM_KITTY_SHM` override

## Notes
- `auto` keeps the conservative default behavior.
- `direct` forces the existing Chafa inline kitty path.
- `shm` forces the kitty shared-memory fast path for video frames, with per-frame fallback to direct rendering if setup fails.
- `PIXELTERM_KITTY_SHM=1` remains available as a debug override for `auto`, but config/CLI are now the preferred user-facing controls.

## Testing
- `rtk make EXTRA_CFLAGS=-Werror`
- `rtk make EXTRA_CFLAGS=-Werror test`

## Summary by Sourcery

添加可配置的 kitty 视频传输模式和用于 kitty 视频播放的共享内存（shared-memory）快速路径，通过配置文件、CLI、应用运行时以及视频播放器贯通新的设置，同时安全地管理共享内存资源。

New Features:
- 引入 `kitty_transfer` 模式（`auto`、`direct`、`shm`），可通过 `config.ini`、CLI（`--kitty-transfer`）以及应用运行时状态进行配置，并将其接入视频播放器构造流程。
- 添加 kitty 共享内存视频传输路径，为 kitty 协议帧生成 kitty SHM 命令并使用这些命令传输数据，并在每帧基础上自动回退到直接渲染。

Enhancements:
- 在视频播放器和应用状态中跟踪 kitty 传输模式和共享内存启用状态，以驱动保守且对环境敏感的 SHM 使用策略。
- 确保在帧销毁或成功提交后清理 kitty SHM 段，并仅在写入和刷新完成后，将 `unlink` 的所有权交由终端处理。

Build:
- 通过 Makefile 将新的 `kitty_graphics` 模块链接到测试二进制中。

Documentation:
- 在终端协议和使用指南中记录 kitty 传输模式、CLI 与配置用法，以及针对 kitty 和 Warp 终端的推荐设置，并在示例配置中更新 `kitty_transfer` 默认值。

Tests:
- 扩展视频播放器、应用以及集成测试，以适配更新后的 `video_player_new` 函数签名和 kitty 传输支持。
- 添加针对 `--kitty-transfer` 解析、优先级以及非法模式的 CLI 测试。
- 添加针对 kitty 共享内存命令生成、自动启用行为以及安全检查（如溢出与载荷大小限制）的单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable kitty video transfer modes and a shared-memory fast path for kitty video playback, wiring the new setting through config, CLI, app runtime, and the video player while safely managing shared-memory resources.

New Features:
- Introduce a kitty_transfer mode (auto, direct, shm) that is configurable via config.ini, CLI (--kitty-transfer), and app runtime state, and plumb it into video player construction.
- Add a kitty shared-memory video transfer path that generates kitty SHM commands and uses them for kitty protocol frames with automatic per-frame fallback to direct rendering.

Enhancements:
- Track kitty transfer mode and shared-memory enablement in the video player and app state to drive conservative, environment-aware SHM usage.
- Ensure kitty SHM segments are cleaned up on frame destruction or after successful submission, delegating unlink ownership to the terminal only once writes and flushes complete.

Build:
- Link the new kitty_graphics module into the test binaries via the Makefile.

Documentation:
- Document kitty transfer modes, CLI and config usage, and recommended settings for kitty- and Warp-based terminals in the terminal protocol and usage guides, and update the example config with kitty_transfer defaults.

Tests:
- Extend video player, app, and integration tests for the updated video_player_new signature and kitty transfer support.
- Add CLI tests for --kitty-transfer parsing, precedence, and invalid modes.
- Add unit tests for kitty shared-memory command generation, auto-enable behavior, and safety checks such as overflow and payload size limits.

</details>

新功能：
- 引入 `kitty_transfer` 模式设置（auto、direct、shm），并贯穿应用配置、CLI 和视频播放器运行时。
- 实现基于 kitty 共享内存的视频传输路径，并在每帧级别回退到直接内联 kitty 渲染。

增强：
- 在视频播放器和应用状态中跟踪 kitty 传输模式，从而实现保守的共享内存自动检测，并在提交后安全清理共享内存段。
- 调整 kitty 视频渲染逻辑，仅在成功写入并刷新转义序列后，将共享内存取消链接（unlink）的所有权交由终端处理。

构建：
- 通过 Makefile 将新的 `kitty_graphics` 模块链接进测试二进制文件。

文档：
- 在终端协议指南、使用指南和示例配置中记录 kitty 传输模式、用法及注意事项，包括对 kitty 和 Warp 终端的使用建议。

测试：
- 更新视频播放器、应用及集成测试，以适配扩展后的 `video_player_new` 函数签名和 kitty 传输支持。
- 添加 `--kitty-transfer` 的 CLI 测试，覆盖解析、优先级及非法模式处理。
- 添加针对 kitty 共享内存命令生成的单元测试，以及在不同环境下自动启用 SHM 行为的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加可配置的 kitty 视频传输模式和用于 kitty 视频播放的共享内存（shared-memory）快速路径，通过配置文件、CLI、应用运行时以及视频播放器贯通新的设置，同时安全地管理共享内存资源。

New Features:
- 引入 `kitty_transfer` 模式（`auto`、`direct`、`shm`），可通过 `config.ini`、CLI（`--kitty-transfer`）以及应用运行时状态进行配置，并将其接入视频播放器构造流程。
- 添加 kitty 共享内存视频传输路径，为 kitty 协议帧生成 kitty SHM 命令并使用这些命令传输数据，并在每帧基础上自动回退到直接渲染。

Enhancements:
- 在视频播放器和应用状态中跟踪 kitty 传输模式和共享内存启用状态，以驱动保守且对环境敏感的 SHM 使用策略。
- 确保在帧销毁或成功提交后清理 kitty SHM 段，并仅在写入和刷新完成后，将 `unlink` 的所有权交由终端处理。

Build:
- 通过 Makefile 将新的 `kitty_graphics` 模块链接到测试二进制中。

Documentation:
- 在终端协议和使用指南中记录 kitty 传输模式、CLI 与配置用法，以及针对 kitty 和 Warp 终端的推荐设置，并在示例配置中更新 `kitty_transfer` 默认值。

Tests:
- 扩展视频播放器、应用以及集成测试，以适配更新后的 `video_player_new` 函数签名和 kitty 传输支持。
- 添加针对 `--kitty-transfer` 解析、优先级以及非法模式的 CLI 测试。
- 添加针对 kitty 共享内存命令生成、自动启用行为以及安全检查（如溢出与载荷大小限制）的单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable kitty video transfer modes and a shared-memory fast path for kitty video playback, wiring the new setting through config, CLI, app runtime, and the video player while safely managing shared-memory resources.

New Features:
- Introduce a kitty_transfer mode (auto, direct, shm) that is configurable via config.ini, CLI (--kitty-transfer), and app runtime state, and plumb it into video player construction.
- Add a kitty shared-memory video transfer path that generates kitty SHM commands and uses them for kitty protocol frames with automatic per-frame fallback to direct rendering.

Enhancements:
- Track kitty transfer mode and shared-memory enablement in the video player and app state to drive conservative, environment-aware SHM usage.
- Ensure kitty SHM segments are cleaned up on frame destruction or after successful submission, delegating unlink ownership to the terminal only once writes and flushes complete.

Build:
- Link the new kitty_graphics module into the test binaries via the Makefile.

Documentation:
- Document kitty transfer modes, CLI and config usage, and recommended settings for kitty- and Warp-based terminals in the terminal protocol and usage guides, and update the example config with kitty_transfer defaults.

Tests:
- Extend video player, app, and integration tests for the updated video_player_new signature and kitty transfer support.
- Add CLI tests for --kitty-transfer parsing, precedence, and invalid modes.
- Add unit tests for kitty shared-memory command generation, auto-enable behavior, and safety checks such as overflow and payload size limits.

</details>

</details>

新特性：
- 引入 kitty 视频传输模式设置（auto、direct、shm），通过配置、CLI 和应用运行时状态对外暴露。
- 添加 kitty 共享内存视频传输路径，并在每帧基础上回退到直接内联 kitty 渲染。
- 扩展视频播放器以跟踪 kitty 传输模式，并在需要时对已渲染帧使用共享内存命令。

增强：
- 确保在帧被销毁或成功提交之后清理 kitty 共享内存段。
- 通过终端特定的配置优先级和应用运行时默认值传播 `kitty_transfer`，以确保行为一致。

构建：
- 通过 Makefile 将新的 `kitty_graphics` 模块链接到测试二进制中。

文档：
- 在终端协议和使用指南中记录 `kitty_transfer` 的用法、模式和注意事项，包括针对 kitty 和 Warp 终端的说明。

测试：
- 更新视频播放器和应用测试，以适配新的 `video_player_new` 函数签名和 `kitty_transfer` 字段。
- 添加 `kitty_transfer` 解析、优先级和非法模式的 CLI 测试。
- 为 `kitty_graphics` 的共享内存命令生成和自动检测行为添加单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加可配置的 kitty 视频传输模式和用于 kitty 视频播放的共享内存（shared-memory）快速路径，通过配置文件、CLI、应用运行时以及视频播放器贯通新的设置，同时安全地管理共享内存资源。

New Features:
- 引入 `kitty_transfer` 模式（`auto`、`direct`、`shm`），可通过 `config.ini`、CLI（`--kitty-transfer`）以及应用运行时状态进行配置，并将其接入视频播放器构造流程。
- 添加 kitty 共享内存视频传输路径，为 kitty 协议帧生成 kitty SHM 命令并使用这些命令传输数据，并在每帧基础上自动回退到直接渲染。

Enhancements:
- 在视频播放器和应用状态中跟踪 kitty 传输模式和共享内存启用状态，以驱动保守且对环境敏感的 SHM 使用策略。
- 确保在帧销毁或成功提交后清理 kitty SHM 段，并仅在写入和刷新完成后，将 `unlink` 的所有权交由终端处理。

Build:
- 通过 Makefile 将新的 `kitty_graphics` 模块链接到测试二进制中。

Documentation:
- 在终端协议和使用指南中记录 kitty 传输模式、CLI 与配置用法，以及针对 kitty 和 Warp 终端的推荐设置，并在示例配置中更新 `kitty_transfer` 默认值。

Tests:
- 扩展视频播放器、应用以及集成测试，以适配更新后的 `video_player_new` 函数签名和 kitty 传输支持。
- 添加针对 `--kitty-transfer` 解析、优先级以及非法模式的 CLI 测试。
- 添加针对 kitty 共享内存命令生成、自动启用行为以及安全检查（如溢出与载荷大小限制）的单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable kitty video transfer modes and a shared-memory fast path for kitty video playback, wiring the new setting through config, CLI, app runtime, and the video player while safely managing shared-memory resources.

New Features:
- Introduce a kitty_transfer mode (auto, direct, shm) that is configurable via config.ini, CLI (--kitty-transfer), and app runtime state, and plumb it into video player construction.
- Add a kitty shared-memory video transfer path that generates kitty SHM commands and uses them for kitty protocol frames with automatic per-frame fallback to direct rendering.

Enhancements:
- Track kitty transfer mode and shared-memory enablement in the video player and app state to drive conservative, environment-aware SHM usage.
- Ensure kitty SHM segments are cleaned up on frame destruction or after successful submission, delegating unlink ownership to the terminal only once writes and flushes complete.

Build:
- Link the new kitty_graphics module into the test binaries via the Makefile.

Documentation:
- Document kitty transfer modes, CLI and config usage, and recommended settings for kitty- and Warp-based terminals in the terminal protocol and usage guides, and update the example config with kitty_transfer defaults.

Tests:
- Extend video player, app, and integration tests for the updated video_player_new signature and kitty transfer support.
- Add CLI tests for --kitty-transfer parsing, precedence, and invalid modes.
- Add unit tests for kitty shared-memory command generation, auto-enable behavior, and safety checks such as overflow and payload size limits.

</details>

新功能：
- 引入 `kitty_transfer` 模式设置（auto、direct、shm），并贯穿应用配置、CLI 和视频播放器运行时。
- 实现基于 kitty 共享内存的视频传输路径，并在每帧级别回退到直接内联 kitty 渲染。

增强：
- 在视频播放器和应用状态中跟踪 kitty 传输模式，从而实现保守的共享内存自动检测，并在提交后安全清理共享内存段。
- 调整 kitty 视频渲染逻辑，仅在成功写入并刷新转义序列后，将共享内存取消链接（unlink）的所有权交由终端处理。

构建：
- 通过 Makefile 将新的 `kitty_graphics` 模块链接进测试二进制文件。

文档：
- 在终端协议指南、使用指南和示例配置中记录 kitty 传输模式、用法及注意事项，包括对 kitty 和 Warp 终端的使用建议。

测试：
- 更新视频播放器、应用及集成测试，以适配扩展后的 `video_player_new` 函数签名和 kitty 传输支持。
- 添加 `--kitty-transfer` 的 CLI 测试，覆盖解析、优先级及非法模式处理。
- 添加针对 kitty 共享内存命令生成的单元测试，以及在不同环境下自动启用 SHM 行为的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加可配置的 kitty 视频传输模式和用于 kitty 视频播放的共享内存（shared-memory）快速路径，通过配置文件、CLI、应用运行时以及视频播放器贯通新的设置，同时安全地管理共享内存资源。

New Features:
- 引入 `kitty_transfer` 模式（`auto`、`direct`、`shm`），可通过 `config.ini`、CLI（`--kitty-transfer`）以及应用运行时状态进行配置，并将其接入视频播放器构造流程。
- 添加 kitty 共享内存视频传输路径，为 kitty 协议帧生成 kitty SHM 命令并使用这些命令传输数据，并在每帧基础上自动回退到直接渲染。

Enhancements:
- 在视频播放器和应用状态中跟踪 kitty 传输模式和共享内存启用状态，以驱动保守且对环境敏感的 SHM 使用策略。
- 确保在帧销毁或成功提交后清理 kitty SHM 段，并仅在写入和刷新完成后，将 `unlink` 的所有权交由终端处理。

Build:
- 通过 Makefile 将新的 `kitty_graphics` 模块链接到测试二进制中。

Documentation:
- 在终端协议和使用指南中记录 kitty 传输模式、CLI 与配置用法，以及针对 kitty 和 Warp 终端的推荐设置，并在示例配置中更新 `kitty_transfer` 默认值。

Tests:
- 扩展视频播放器、应用以及集成测试，以适配更新后的 `video_player_new` 函数签名和 kitty 传输支持。
- 添加针对 `--kitty-transfer` 解析、优先级以及非法模式的 CLI 测试。
- 添加针对 kitty 共享内存命令生成、自动启用行为以及安全检查（如溢出与载荷大小限制）的单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable kitty video transfer modes and a shared-memory fast path for kitty video playback, wiring the new setting through config, CLI, app runtime, and the video player while safely managing shared-memory resources.

New Features:
- Introduce a kitty_transfer mode (auto, direct, shm) that is configurable via config.ini, CLI (--kitty-transfer), and app runtime state, and plumb it into video player construction.
- Add a kitty shared-memory video transfer path that generates kitty SHM commands and uses them for kitty protocol frames with automatic per-frame fallback to direct rendering.

Enhancements:
- Track kitty transfer mode and shared-memory enablement in the video player and app state to drive conservative, environment-aware SHM usage.
- Ensure kitty SHM segments are cleaned up on frame destruction or after successful submission, delegating unlink ownership to the terminal only once writes and flushes complete.

Build:
- Link the new kitty_graphics module into the test binaries via the Makefile.

Documentation:
- Document kitty transfer modes, CLI and config usage, and recommended settings for kitty- and Warp-based terminals in the terminal protocol and usage guides, and update the example config with kitty_transfer defaults.

Tests:
- Extend video player, app, and integration tests for the updated video_player_new signature and kitty transfer support.
- Add CLI tests for --kitty-transfer parsing, precedence, and invalid modes.
- Add unit tests for kitty shared-memory command generation, auto-enable behavior, and safety checks such as overflow and payload size limits.

</details>

</details>

</details>

新特性：
- 在应用配置、CLI 和视频播放器运行时中添加可配置的 `kitty_transfer` 模式（`auto`、`direct`、`shm`）。
- 实现 kitty 共享内存视频传输路径，并在需要时自动回退到直接内联 kitty 渲染。

增强：
- 将 `kitty_transfer` 接入终端特定配置的优先级链路以及运行时应用状态。
- 确保 kitty 共享内存段在提交后或帧销毁时被清理，以避免泄漏。

构建：
- 在测试链接对象中包含 `kitty_graphics`，以正确编译新的共享内存辅助模块。

文档：
- 在终端协议与使用指南中记录 `kitty_transfer` 的用法、模式和注意事项，包括对 Warp 和 kitty 的特定说明。

测试：
- 扩展 CLI 测试以覆盖 `kitty_transfer` 的解析和优先级逻辑，添加 kitty 图形共享内存命令与自动检测测试，并更新视频/应用测试以适配新的 `video_player` 构造函数参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加可配置的 kitty 视频传输模式和用于 kitty 视频播放的共享内存（shared-memory）快速路径，通过配置文件、CLI、应用运行时以及视频播放器贯通新的设置，同时安全地管理共享内存资源。

New Features:
- 引入 `kitty_transfer` 模式（`auto`、`direct`、`shm`），可通过 `config.ini`、CLI（`--kitty-transfer`）以及应用运行时状态进行配置，并将其接入视频播放器构造流程。
- 添加 kitty 共享内存视频传输路径，为 kitty 协议帧生成 kitty SHM 命令并使用这些命令传输数据，并在每帧基础上自动回退到直接渲染。

Enhancements:
- 在视频播放器和应用状态中跟踪 kitty 传输模式和共享内存启用状态，以驱动保守且对环境敏感的 SHM 使用策略。
- 确保在帧销毁或成功提交后清理 kitty SHM 段，并仅在写入和刷新完成后，将 `unlink` 的所有权交由终端处理。

Build:
- 通过 Makefile 将新的 `kitty_graphics` 模块链接到测试二进制中。

Documentation:
- 在终端协议和使用指南中记录 kitty 传输模式、CLI 与配置用法，以及针对 kitty 和 Warp 终端的推荐设置，并在示例配置中更新 `kitty_transfer` 默认值。

Tests:
- 扩展视频播放器、应用以及集成测试，以适配更新后的 `video_player_new` 函数签名和 kitty 传输支持。
- 添加针对 `--kitty-transfer` 解析、优先级以及非法模式的 CLI 测试。
- 添加针对 kitty 共享内存命令生成、自动启用行为以及安全检查（如溢出与载荷大小限制）的单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable kitty video transfer modes and a shared-memory fast path for kitty video playback, wiring the new setting through config, CLI, app runtime, and the video player while safely managing shared-memory resources.

New Features:
- Introduce a kitty_transfer mode (auto, direct, shm) that is configurable via config.ini, CLI (--kitty-transfer), and app runtime state, and plumb it into video player construction.
- Add a kitty shared-memory video transfer path that generates kitty SHM commands and uses them for kitty protocol frames with automatic per-frame fallback to direct rendering.

Enhancements:
- Track kitty transfer mode and shared-memory enablement in the video player and app state to drive conservative, environment-aware SHM usage.
- Ensure kitty SHM segments are cleaned up on frame destruction or after successful submission, delegating unlink ownership to the terminal only once writes and flushes complete.

Build:
- Link the new kitty_graphics module into the test binaries via the Makefile.

Documentation:
- Document kitty transfer modes, CLI and config usage, and recommended settings for kitty- and Warp-based terminals in the terminal protocol and usage guides, and update the example config with kitty_transfer defaults.

Tests:
- Extend video player, app, and integration tests for the updated video_player_new signature and kitty transfer support.
- Add CLI tests for --kitty-transfer parsing, precedence, and invalid modes.
- Add unit tests for kitty shared-memory command generation, auto-enable behavior, and safety checks such as overflow and payload size limits.

</details>

新功能：
- 引入 `kitty_transfer` 模式设置（auto、direct、shm），并贯穿应用配置、CLI 和视频播放器运行时。
- 实现基于 kitty 共享内存的视频传输路径，并在每帧级别回退到直接内联 kitty 渲染。

增强：
- 在视频播放器和应用状态中跟踪 kitty 传输模式，从而实现保守的共享内存自动检测，并在提交后安全清理共享内存段。
- 调整 kitty 视频渲染逻辑，仅在成功写入并刷新转义序列后，将共享内存取消链接（unlink）的所有权交由终端处理。

构建：
- 通过 Makefile 将新的 `kitty_graphics` 模块链接进测试二进制文件。

文档：
- 在终端协议指南、使用指南和示例配置中记录 kitty 传输模式、用法及注意事项，包括对 kitty 和 Warp 终端的使用建议。

测试：
- 更新视频播放器、应用及集成测试，以适配扩展后的 `video_player_new` 函数签名和 kitty 传输支持。
- 添加 `--kitty-transfer` 的 CLI 测试，覆盖解析、优先级及非法模式处理。
- 添加针对 kitty 共享内存命令生成的单元测试，以及在不同环境下自动启用 SHM 行为的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加可配置的 kitty 视频传输模式和用于 kitty 视频播放的共享内存（shared-memory）快速路径，通过配置文件、CLI、应用运行时以及视频播放器贯通新的设置，同时安全地管理共享内存资源。

New Features:
- 引入 `kitty_transfer` 模式（`auto`、`direct`、`shm`），可通过 `config.ini`、CLI（`--kitty-transfer`）以及应用运行时状态进行配置，并将其接入视频播放器构造流程。
- 添加 kitty 共享内存视频传输路径，为 kitty 协议帧生成 kitty SHM 命令并使用这些命令传输数据，并在每帧基础上自动回退到直接渲染。

Enhancements:
- 在视频播放器和应用状态中跟踪 kitty 传输模式和共享内存启用状态，以驱动保守且对环境敏感的 SHM 使用策略。
- 确保在帧销毁或成功提交后清理 kitty SHM 段，并仅在写入和刷新完成后，将 `unlink` 的所有权交由终端处理。

Build:
- 通过 Makefile 将新的 `kitty_graphics` 模块链接到测试二进制中。

Documentation:
- 在终端协议和使用指南中记录 kitty 传输模式、CLI 与配置用法，以及针对 kitty 和 Warp 终端的推荐设置，并在示例配置中更新 `kitty_transfer` 默认值。

Tests:
- 扩展视频播放器、应用以及集成测试，以适配更新后的 `video_player_new` 函数签名和 kitty 传输支持。
- 添加针对 `--kitty-transfer` 解析、优先级以及非法模式的 CLI 测试。
- 添加针对 kitty 共享内存命令生成、自动启用行为以及安全检查（如溢出与载荷大小限制）的单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable kitty video transfer modes and a shared-memory fast path for kitty video playback, wiring the new setting through config, CLI, app runtime, and the video player while safely managing shared-memory resources.

New Features:
- Introduce a kitty_transfer mode (auto, direct, shm) that is configurable via config.ini, CLI (--kitty-transfer), and app runtime state, and plumb it into video player construction.
- Add a kitty shared-memory video transfer path that generates kitty SHM commands and uses them for kitty protocol frames with automatic per-frame fallback to direct rendering.

Enhancements:
- Track kitty transfer mode and shared-memory enablement in the video player and app state to drive conservative, environment-aware SHM usage.
- Ensure kitty SHM segments are cleaned up on frame destruction or after successful submission, delegating unlink ownership to the terminal only once writes and flushes complete.

Build:
- Link the new kitty_graphics module into the test binaries via the Makefile.

Documentation:
- Document kitty transfer modes, CLI and config usage, and recommended settings for kitty- and Warp-based terminals in the terminal protocol and usage guides, and update the example config with kitty_transfer defaults.

Tests:
- Extend video player, app, and integration tests for the updated video_player_new signature and kitty transfer support.
- Add CLI tests for --kitty-transfer parsing, precedence, and invalid modes.
- Add unit tests for kitty shared-memory command generation, auto-enable behavior, and safety checks such as overflow and payload size limits.

</details>

</details>

新特性：
- 引入 kitty 视频传输模式设置（auto、direct、shm），通过配置、CLI 和应用运行时状态对外暴露。
- 添加 kitty 共享内存视频传输路径，并在每帧基础上回退到直接内联 kitty 渲染。
- 扩展视频播放器以跟踪 kitty 传输模式，并在需要时对已渲染帧使用共享内存命令。

增强：
- 确保在帧被销毁或成功提交之后清理 kitty 共享内存段。
- 通过终端特定的配置优先级和应用运行时默认值传播 `kitty_transfer`，以确保行为一致。

构建：
- 通过 Makefile 将新的 `kitty_graphics` 模块链接到测试二进制中。

文档：
- 在终端协议和使用指南中记录 `kitty_transfer` 的用法、模式和注意事项，包括针对 kitty 和 Warp 终端的说明。

测试：
- 更新视频播放器和应用测试，以适配新的 `video_player_new` 函数签名和 `kitty_transfer` 字段。
- 添加 `kitty_transfer` 解析、优先级和非法模式的 CLI 测试。
- 为 `kitty_graphics` 的共享内存命令生成和自动检测行为添加单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加可配置的 kitty 视频传输模式和用于 kitty 视频播放的共享内存（shared-memory）快速路径，通过配置文件、CLI、应用运行时以及视频播放器贯通新的设置，同时安全地管理共享内存资源。

New Features:
- 引入 `kitty_transfer` 模式（`auto`、`direct`、`shm`），可通过 `config.ini`、CLI（`--kitty-transfer`）以及应用运行时状态进行配置，并将其接入视频播放器构造流程。
- 添加 kitty 共享内存视频传输路径，为 kitty 协议帧生成 kitty SHM 命令并使用这些命令传输数据，并在每帧基础上自动回退到直接渲染。

Enhancements:
- 在视频播放器和应用状态中跟踪 kitty 传输模式和共享内存启用状态，以驱动保守且对环境敏感的 SHM 使用策略。
- 确保在帧销毁或成功提交后清理 kitty SHM 段，并仅在写入和刷新完成后，将 `unlink` 的所有权交由终端处理。

Build:
- 通过 Makefile 将新的 `kitty_graphics` 模块链接到测试二进制中。

Documentation:
- 在终端协议和使用指南中记录 kitty 传输模式、CLI 与配置用法，以及针对 kitty 和 Warp 终端的推荐设置，并在示例配置中更新 `kitty_transfer` 默认值。

Tests:
- 扩展视频播放器、应用以及集成测试，以适配更新后的 `video_player_new` 函数签名和 kitty 传输支持。
- 添加针对 `--kitty-transfer` 解析、优先级以及非法模式的 CLI 测试。
- 添加针对 kitty 共享内存命令生成、自动启用行为以及安全检查（如溢出与载荷大小限制）的单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable kitty video transfer modes and a shared-memory fast path for kitty video playback, wiring the new setting through config, CLI, app runtime, and the video player while safely managing shared-memory resources.

New Features:
- Introduce a kitty_transfer mode (auto, direct, shm) that is configurable via config.ini, CLI (--kitty-transfer), and app runtime state, and plumb it into video player construction.
- Add a kitty shared-memory video transfer path that generates kitty SHM commands and uses them for kitty protocol frames with automatic per-frame fallback to direct rendering.

Enhancements:
- Track kitty transfer mode and shared-memory enablement in the video player and app state to drive conservative, environment-aware SHM usage.
- Ensure kitty SHM segments are cleaned up on frame destruction or after successful submission, delegating unlink ownership to the terminal only once writes and flushes complete.

Build:
- Link the new kitty_graphics module into the test binaries via the Makefile.

Documentation:
- Document kitty transfer modes, CLI and config usage, and recommended settings for kitty- and Warp-based terminals in the terminal protocol and usage guides, and update the example config with kitty_transfer defaults.

Tests:
- Extend video player, app, and integration tests for the updated video_player_new signature and kitty transfer support.
- Add CLI tests for --kitty-transfer parsing, precedence, and invalid modes.
- Add unit tests for kitty shared-memory command generation, auto-enable behavior, and safety checks such as overflow and payload size limits.

</details>

新功能：
- 引入 `kitty_transfer` 模式设置（auto、direct、shm），并贯穿应用配置、CLI 和视频播放器运行时。
- 实现基于 kitty 共享内存的视频传输路径，并在每帧级别回退到直接内联 kitty 渲染。

增强：
- 在视频播放器和应用状态中跟踪 kitty 传输模式，从而实现保守的共享内存自动检测，并在提交后安全清理共享内存段。
- 调整 kitty 视频渲染逻辑，仅在成功写入并刷新转义序列后，将共享内存取消链接（unlink）的所有权交由终端处理。

构建：
- 通过 Makefile 将新的 `kitty_graphics` 模块链接进测试二进制文件。

文档：
- 在终端协议指南、使用指南和示例配置中记录 kitty 传输模式、用法及注意事项，包括对 kitty 和 Warp 终端的使用建议。

测试：
- 更新视频播放器、应用及集成测试，以适配扩展后的 `video_player_new` 函数签名和 kitty 传输支持。
- 添加 `--kitty-transfer` 的 CLI 测试，覆盖解析、优先级及非法模式处理。
- 添加针对 kitty 共享内存命令生成的单元测试，以及在不同环境下自动启用 SHM 行为的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加可配置的 kitty 视频传输模式和用于 kitty 视频播放的共享内存（shared-memory）快速路径，通过配置文件、CLI、应用运行时以及视频播放器贯通新的设置，同时安全地管理共享内存资源。

New Features:
- 引入 `kitty_transfer` 模式（`auto`、`direct`、`shm`），可通过 `config.ini`、CLI（`--kitty-transfer`）以及应用运行时状态进行配置，并将其接入视频播放器构造流程。
- 添加 kitty 共享内存视频传输路径，为 kitty 协议帧生成 kitty SHM 命令并使用这些命令传输数据，并在每帧基础上自动回退到直接渲染。

Enhancements:
- 在视频播放器和应用状态中跟踪 kitty 传输模式和共享内存启用状态，以驱动保守且对环境敏感的 SHM 使用策略。
- 确保在帧销毁或成功提交后清理 kitty SHM 段，并仅在写入和刷新完成后，将 `unlink` 的所有权交由终端处理。

Build:
- 通过 Makefile 将新的 `kitty_graphics` 模块链接到测试二进制中。

Documentation:
- 在终端协议和使用指南中记录 kitty 传输模式、CLI 与配置用法，以及针对 kitty 和 Warp 终端的推荐设置，并在示例配置中更新 `kitty_transfer` 默认值。

Tests:
- 扩展视频播放器、应用以及集成测试，以适配更新后的 `video_player_new` 函数签名和 kitty 传输支持。
- 添加针对 `--kitty-transfer` 解析、优先级以及非法模式的 CLI 测试。
- 添加针对 kitty 共享内存命令生成、自动启用行为以及安全检查（如溢出与载荷大小限制）的单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable kitty video transfer modes and a shared-memory fast path for kitty video playback, wiring the new setting through config, CLI, app runtime, and the video player while safely managing shared-memory resources.

New Features:
- Introduce a kitty_transfer mode (auto, direct, shm) that is configurable via config.ini, CLI (--kitty-transfer), and app runtime state, and plumb it into video player construction.
- Add a kitty shared-memory video transfer path that generates kitty SHM commands and uses them for kitty protocol frames with automatic per-frame fallback to direct rendering.

Enhancements:
- Track kitty transfer mode and shared-memory enablement in the video player and app state to drive conservative, environment-aware SHM usage.
- Ensure kitty SHM segments are cleaned up on frame destruction or after successful submission, delegating unlink ownership to the terminal only once writes and flushes complete.

Build:
- Link the new kitty_graphics module into the test binaries via the Makefile.

Documentation:
- Document kitty transfer modes, CLI and config usage, and recommended settings for kitty- and Warp-based terminals in the terminal protocol and usage guides, and update the example config with kitty_transfer defaults.

Tests:
- Extend video player, app, and integration tests for the updated video_player_new signature and kitty transfer support.
- Add CLI tests for --kitty-transfer parsing, precedence, and invalid modes.
- Add unit tests for kitty shared-memory command generation, auto-enable behavior, and safety checks such as overflow and payload size limits.

</details>

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add configurable kitty video transfer modes (auto, direct, shm) and a shared-memory fast path for video frames with safe, local-only auto detection. SHM unlink is now handed off to the terminal only after a successful write+flush, with per-frame fallback to direct rendering and stricter frame validation.

- **New Features**
  - Add `--kitty-transfer auto|direct|shm` and `kitty_transfer` in config (default `auto`); CLI rejects unknown modes.
  - Implement SHM path in `kitty_graphics` and use it only when kitty is active; auto disables on SSH/tmux/screen, checks `TERM/TERM_PROGRAM`, caps payload (~8 MiB) via cell-aware scaling; `PIXELTERM_KITTY_SHM=1` remains a debug override.
  - Update docs and examples with a “Kitty transfer modes” section; set `kitty_transfer = direct` for Warp by default and note modest gains on native `kitty`.

- **Bug Fixes**
  - Harden SHM validation with overflow-safe size/rowstride checks and strict input handling; unlink after successful `fwrite`+`fflush`; add tests for auto-detect, command generation, invalid inputs, and CLI/config precedence.

<sup>Written for commit c2b2528c27766ef8cdbb7fa69f2290d9d48efbe3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zouyonghe/PixelTerm-C/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

