### PR TITLE
Improve help overlay and footer hints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ TEST_LINK_OBJECTS = $(OBJDIR)/common.o $(OBJDIR)/browser.o $(OBJDIR)/renderer.o 
 		$(OBJDIR)/video_player_clock.o $(OBJDIR)/video_player_debug.o $(OBJDIR)/video_player_decode.o $(OBJDIR)/video_player_layout.o $(OBJDIR)/video_player_playback.o $(OBJDIR)/video_player_seek.o $(OBJDIR)/video_player.o $(OBJDIR)/kitty_graphics.o $(OBJDIR)/terminal_probe.o $(OBJDIR)/terminal_protocols.o $(OBJDIR)/terminal_protocol_resolver.o $(OBJDIR)/app_cli.o $(OBJDIR)/book.o \
 		$(OBJDIR)/app_startup.o
 FILE_MANAGER_TEST_LINK_OBJECTS = $(OBJDIR)/common.o $(OBJDIR)/process_env.o $(OBJDIR)/app_core.o $(OBJDIR)/app_mode.o \
-		$(OBJDIR)/app_file_manager.o $(OBJDIR)/app_file_manager_render.o $(OBJDIR)/text_utils.o
+		$(OBJDIR)/app_file_manager.o $(OBJDIR)/app_file_manager_render.o $(OBJDIR)/text_utils.o $(OBJDIR)/ui_render_utils.o
 PREVIEW_GRID_TEST_LINK_OBJECTS = $(OBJDIR)/app_preview_grid.o $(OBJDIR)/ui_render_utils.o $(OBJDIR)/text_utils.o
 BOOK_PREVIEW_TEST_LINK_OBJECTS = $(OBJDIR)/app_preview_book.o
 

--- a/include/input.h
+++ b/include/input.h
@@ -123,6 +123,7 @@ InputHandler* input_handler_create(void);
  * @param handler A pointer to the `InputHandler` instance to destroy.
  */
 void input_handler_destroy(InputHandler *handler);
+void input_handler_reset_mouse_timing(InputHandler *handler);
 /**
  * @brief Initializes the `InputHandler` by saving the original terminal settings.
  * 

--- a/src/app_file_manager_render.c
+++ b/src/app_file_manager_render.c
@@ -1,6 +1,7 @@
 #include "app.h"
 #include "text_utils.h"
 #include "app_file_manager_internal.h"
+#include "ui_render_utils.h"
 
 typedef struct {
     gboolean has_images;
@@ -421,7 +422,6 @@ ErrorCode app_render_file_manager(PixelTermApp *app) {
     GHashTable *directory_media_cache = NULL;
     app->file_manager.scroll_offset = viewport.start_row;
     gint total_entries = viewport.total_entries;
-    const char *help_text = "↑/↓ Move   ← Parent   →/Enter Open   TAB Toggle   ? Help   ESC Exit";
     gint start_row = viewport.start_row;
     gint end_row = viewport.end_row;
     gint rows_to_render = viewport.rows_to_render;
@@ -565,16 +565,15 @@ ErrorCode app_render_file_manager(PixelTermApp *app) {
         printf("\033[%d;1H\033[2K", y);
     }
 
-    gint help_len = strlen(help_text);
-    gint help_pad = (app->term_width > help_len) ? (app->term_width - help_len) / 2 : 0;
-    printf("\033[%d;1H\033[2K", app->term_height);
-    for (gint i = 0; i < help_pad; i++) putchar(' ');
-    printf("\033[36m↑/↓\033[0m Move   ");
-    printf("\033[36m←\033[0m Parent   ");
-    printf("\033[36m→/Enter\033[0m Open   ");
-    printf("\033[36mTAB\033[0m Toggle   ");
-    printf("\033[36m?\033[0m Help   ");
-    printf("\033[36mESC\033[0m Exit");
+    const HelpSegment segments[] = {
+        {"↑/↓", "Move"},
+        {"→/Enter", "Open"},
+        {"?", "Help"},
+        {"←", "Parent"},
+        {"TAB", "Toggle"},
+        {"ESC", "Exit"}
+    };
+    ui_print_centered_help_line(app->term_height, app->term_width, segments, G_N_ELEMENTS(segments));
 
     fflush(stdout);
 

--- a/src/app_mode.c
+++ b/src/app_mode.c
@@ -116,6 +116,9 @@ ErrorCode app_transition_mode(PixelTermApp *app, AppMode mode) {
         return ERROR_INVALID_ARGS;
     }
 
+    app->info_visible = FALSE;
+    app->help_visible = FALSE;
+
     if (k_modes[current].on_exit) {
         k_modes[current].on_exit(app);
     }

--- a/src/input.c
+++ b/src/input.c
@@ -80,6 +80,24 @@ void input_handler_destroy(InputHandler *handler) {
     g_free(handler);
 }
 
+void input_handler_reset_mouse_timing(InputHandler *handler) {
+    if (!handler) {
+        return;
+    }
+
+    handler->last_click_time.tv_sec = 0;
+    handler->last_click_time.tv_usec = 0;
+    handler->last_click_x = 0;
+    handler->last_click_y = 0;
+    handler->last_click_button = (MouseButton)0;
+    handler->last_scroll_time.tv_sec = 0;
+    handler->last_scroll_time.tv_usec = 0;
+    handler->last_scroll_button = (MouseButton)0;
+    handler->last_scroll_x = 0;
+    handler->last_scroll_y = 0;
+    handler->ignore_input_until_us = 0;
+}
+
 // Initialize input handler
 ErrorCode input_handler_initialize(InputHandler *handler) {
     if (!handler) {

--- a/src/input_dispatch_core.c
+++ b/src/input_dispatch_core.c
@@ -371,6 +371,11 @@ static void handle_input_event(PixelTermApp *app, InputHandler *input_handler, c
          event->type == INPUT_MOUSE_PRESS ||
          event->type == INPUT_MOUSE_DOUBLE_CLICK ||
          event->type == INPUT_MOUSE_SCROLL)) {
+        if (event->type == INPUT_MOUSE_PRESS ||
+            event->type == INPUT_MOUSE_DOUBLE_CLICK ||
+            event->type == INPUT_MOUSE_SCROLL) {
+            input_handler_reset_mouse_timing(input_handler);
+        }
         app_display_help(app);
         return;
     }

--- a/src/input_dispatch_core.c
+++ b/src/input_dispatch_core.c
@@ -365,6 +365,16 @@ static void handle_input_event(PixelTermApp *app, InputHandler *input_handler, c
             app->input.last_mouse_y = event->mouse_y;
         }
     }
+
+    if (app && app->help_visible &&
+        (event->type == INPUT_KEY_PRESS ||
+         event->type == INPUT_MOUSE_PRESS ||
+         event->type == INPUT_MOUSE_DOUBLE_CLICK ||
+         event->type == INPUT_MOUSE_SCROLL)) {
+        app_display_help(app);
+        return;
+    }
+
     switch (event->type) {
         case INPUT_MOUSE_PRESS:
             handle_mouse_press(app, event);

--- a/src/ui_render_utils.c
+++ b/src/ui_render_utils.c
@@ -72,30 +72,93 @@ static gint ui_help_segments_visible_width(const HelpSegment *segments, gsize n)
     return width;
 }
 
+static gint ui_help_segments_visible_width_with_help(const HelpSegment *segments,
+                                                     gsize prefix_n,
+                                                     gssize help_index) {
+    gint width = ui_help_segments_visible_width(segments, prefix_n);
+    if (help_index >= 0) {
+        if (prefix_n > 0) {
+            width += 2;
+        }
+        width += utf8_display_width(segments[help_index].key);
+        width += 1;
+        width += utf8_display_width(segments[help_index].label);
+    }
+    return width;
+}
+
 void ui_print_centered_help_line(gint row, gint term_width, const HelpSegment *segments, gsize n) {
     if (term_width <= 0 || row <= 0) {
         return;
     }
     printf("\033[%d;1H\033[2K", row);
 
-    gint help_w = ui_help_segments_visible_width(segments, n);
+    if (!segments || n == 0) {
+        return;
+    }
+
+    gsize visible_n = 0;
+    for (gsize i = 1; i <= n; i++) {
+        if (ui_help_segments_visible_width(segments, i) <= term_width) {
+            visible_n = i;
+        } else {
+            break;
+        }
+    }
+
+    gssize help_index = -1;
+    for (gsize i = 0; i < n; i++) {
+        if (g_strcmp0(segments[i].key, "?") == 0) {
+            help_index = (gssize)i;
+            break;
+        }
+    }
+
+    gboolean append_help = FALSE;
+    if (visible_n < n && help_index >= 0 && (gsize)help_index >= visible_n) {
+        while (visible_n > 0 &&
+               ui_help_segments_visible_width_with_help(segments, visible_n - 1, help_index) > term_width) {
+            visible_n--;
+        }
+        if (ui_help_segments_visible_width_with_help(segments, visible_n > 0 ? visible_n - 1 : 0, help_index) <= term_width) {
+            append_help = TRUE;
+            if (visible_n > 0) {
+                visible_n--;
+            }
+        }
+    }
+
+    if (visible_n == 0 && !append_help) {
+        return;
+    }
+
+    gint help_w = append_help
+                     ? ui_help_segments_visible_width_with_help(segments, visible_n, help_index)
+                     : ui_help_segments_visible_width(segments, visible_n);
     gint pad = (help_w > 0 && term_width > help_w) ? (term_width - help_w) / 2 : 0;
     for (gint i = 0; i < pad; i++) {
         putchar(' ');
     }
 
     gint col = 1 + pad;
-    for (gsize i = 0; i < n; i++) {
+    for (gsize i = 0; i < visible_n; i++) {
         gint seg_w = utf8_display_width(segments[i].key) + 1 + utf8_display_width(segments[i].label);
-        gint trailing = (i + 1 < n) ? 2 : 0;
+        gint trailing = (i + 1 < visible_n || append_help) ? 2 : 0;
         if (col + seg_w + trailing - 1 > term_width) {
             break;
         }
         printf("\033[36m%s\033[0m %s", segments[i].key, segments[i].label);
         col += seg_w;
-        if (i + 1 < n) {
+        if (i + 1 < visible_n || append_help) {
             printf("  ");
             col += 2;
+        }
+    }
+
+    if (append_help && help_index >= 0) {
+        gint seg_w = utf8_display_width(segments[help_index].key) + 1 + utf8_display_width(segments[help_index].label);
+        if (col + seg_w - 1 <= term_width) {
+            printf("\033[36m%s\033[0m %s", segments[help_index].key, segments[help_index].label);
         }
     }
 }

--- a/src/ui_render_utils.c
+++ b/src/ui_render_utils.c
@@ -117,14 +117,11 @@ void ui_print_centered_help_line(gint row, gint term_width, const HelpSegment *s
     gboolean append_help = FALSE;
     if (visible_n < n && help_index >= 0 && (gsize)help_index >= visible_n) {
         while (visible_n > 0 &&
-               ui_help_segments_visible_width_with_help(segments, visible_n - 1, help_index) > term_width) {
+               ui_help_segments_visible_width_with_help(segments, visible_n, help_index) > term_width) {
             visible_n--;
         }
-        if (ui_help_segments_visible_width_with_help(segments, visible_n > 0 ? visible_n - 1 : 0, help_index) <= term_width) {
+        if (ui_help_segments_visible_width_with_help(segments, visible_n, help_index) <= term_width) {
             append_help = TRUE;
-            if (visible_n > 0) {
-                visible_n--;
-            }
         }
     }
 

--- a/tests/test_app_mode.c
+++ b/tests/test_app_mode.c
@@ -151,6 +151,18 @@ static void test_media_navigation_clears_overlays(void) {
     g_list_free_full(app.image_files, g_free);
 }
 
+static void test_mode_transition_clears_overlays(void) {
+    PixelTermApp app = {0};
+    app.mode = APP_MODE_SINGLE;
+    app.info_visible = TRUE;
+    app.help_visible = TRUE;
+
+    g_assert_cmpint(app_transition_mode(&app, APP_MODE_FILE_MANAGER), ==, ERROR_NONE);
+    g_assert_cmpint(app.mode, ==, APP_MODE_FILE_MANAGER);
+    g_assert_false(app.info_visible);
+    g_assert_false(app.help_visible);
+}
+
 void register_app_mode_tests(void) {
     g_test_add_func("/app_mode/transition/null_app", test_transition_null_app);
     g_test_add_func("/app_mode/transition/invalid_mode", test_transition_invalid_mode);
@@ -161,4 +173,5 @@ void register_app_mode_tests(void) {
     g_test_add_func("/app_mode/transition/to_non_single_stops_media", test_transition_to_non_single_stops_media);
     g_test_add_func("/app_mode/transition/common_round_trip_paths", test_transition_common_round_trip_paths);
     g_test_add_func("/app_mode/media_navigation/clears_overlays", test_media_navigation_clears_overlays);
+    g_test_add_func("/app_mode/transition/clears_overlays", test_mode_transition_clears_overlays);
 }

--- a/tests/test_input_dispatch_core.c
+++ b/tests/test_input_dispatch_core.c
@@ -215,7 +215,7 @@ static void test_mouse_closing_help_resets_input_timing_state(void) {
     input_handler.last_click_time.tv_usec = 200;
     input_handler.last_click_x = 12;
     input_handler.last_click_y = 6;
-    input_handler.last_click_button = MOUSE_BUTTON_LEFT;
+    input_handler.last_click_button = MOUSE_BUTTON_MIDDLE;
     input_handler.last_scroll_time.tv_sec = 300;
     input_handler.last_scroll_time.tv_usec = 400;
     input_handler.last_scroll_button = MOUSE_SCROLL_DOWN;

--- a/tests/test_input_dispatch_core.c
+++ b/tests/test_input_dispatch_core.c
@@ -177,6 +177,23 @@ static void test_question_key_opens_help_overlay(void) {
     g_assert_cmpint(g_input_dispatch_stub_state.display_image_info_calls, ==, 0);
 }
 
+static void test_any_key_closes_help_overlay_without_mode_action(void) {
+    PixelTermApp app = {0};
+    InputHandler input_handler = {0};
+    InputEvent event = make_key_event((KeyCode)'i');
+
+    app.mode = APP_MODE_SINGLE;
+    app.total_images = 1;
+    app.help_visible = TRUE;
+
+    input_dispatch_test_reset_stubs();
+    input_dispatch_core_handle_event(&app, &input_handler, &event);
+
+    g_assert_false(app.help_visible);
+    g_assert_cmpint(g_input_dispatch_stub_state.display_help_calls, ==, 1);
+    g_assert_cmpint(g_input_dispatch_stub_state.display_image_info_calls, ==, 0);
+}
+
 void register_input_dispatch_core_tests(void) {
     g_test_add_func("/input_dispatch_core/process_animations/only_runs_one_iteration_per_call",
                     test_process_animations_only_runs_one_iteration_per_call);
@@ -194,4 +211,6 @@ void register_input_dispatch_core_tests(void) {
                     test_info_key_opens_info_overlay_for_video);
     g_test_add_func("/input_dispatch_core/help_key/question_opens_help_overlay",
                     test_question_key_opens_help_overlay);
+    g_test_add_func("/input_dispatch_core/help_key/any_key_closes_without_mode_action",
+                    test_any_key_closes_help_overlay_without_mode_action);
 }

--- a/tests/test_input_dispatch_core.c
+++ b/tests/test_input_dispatch_core.c
@@ -39,6 +39,15 @@ static InputEvent make_key_event(KeyCode key_code) {
     return event;
 }
 
+static InputEvent make_mouse_event(InputEventType type, MouseButton button) {
+    InputEvent event = {0};
+    event.type = type;
+    event.mouse_button = button;
+    event.mouse_x = 12;
+    event.mouse_y = 6;
+    return event;
+}
+
 static void test_process_animations_only_runs_one_iteration_per_call(void) {
     PixelTermApp app = {0};
     GifPlayer gif = {0};
@@ -194,6 +203,44 @@ static void test_any_key_closes_help_overlay_without_mode_action(void) {
     g_assert_cmpint(g_input_dispatch_stub_state.display_image_info_calls, ==, 0);
 }
 
+static void test_mouse_closing_help_resets_input_timing_state(void) {
+    PixelTermApp app = {0};
+    InputHandler input_handler = {0};
+    InputEvent event = make_mouse_event(INPUT_MOUSE_SCROLL, MOUSE_SCROLL_DOWN);
+
+    app.mode = APP_MODE_SINGLE;
+    app.total_images = 1;
+    app.help_visible = TRUE;
+    input_handler.last_click_time.tv_sec = 100;
+    input_handler.last_click_time.tv_usec = 200;
+    input_handler.last_click_x = 12;
+    input_handler.last_click_y = 6;
+    input_handler.last_click_button = MOUSE_BUTTON_LEFT;
+    input_handler.last_scroll_time.tv_sec = 300;
+    input_handler.last_scroll_time.tv_usec = 400;
+    input_handler.last_scroll_button = MOUSE_SCROLL_DOWN;
+    input_handler.last_scroll_x = 12;
+    input_handler.last_scroll_y = 6;
+    input_handler.ignore_input_until_us = 500;
+
+    input_dispatch_test_reset_stubs();
+    input_dispatch_core_handle_event(&app, &input_handler, &event);
+
+    g_assert_false(app.help_visible);
+    g_assert_cmpint(g_input_dispatch_stub_state.display_help_calls, ==, 1);
+    g_assert_cmpint(input_handler.last_click_time.tv_sec, ==, 0);
+    g_assert_cmpint(input_handler.last_click_time.tv_usec, ==, 0);
+    g_assert_cmpint(input_handler.last_click_x, ==, 0);
+    g_assert_cmpint(input_handler.last_click_y, ==, 0);
+    g_assert_cmpint(input_handler.last_click_button, ==, 0);
+    g_assert_cmpint(input_handler.last_scroll_time.tv_sec, ==, 0);
+    g_assert_cmpint(input_handler.last_scroll_time.tv_usec, ==, 0);
+    g_assert_cmpint(input_handler.last_scroll_button, ==, 0);
+    g_assert_cmpint(input_handler.last_scroll_x, ==, 0);
+    g_assert_cmpint(input_handler.last_scroll_y, ==, 0);
+    g_assert_cmpint(input_handler.ignore_input_until_us, ==, 0);
+}
+
 void register_input_dispatch_core_tests(void) {
     g_test_add_func("/input_dispatch_core/process_animations/only_runs_one_iteration_per_call",
                     test_process_animations_only_runs_one_iteration_per_call);
@@ -213,4 +260,6 @@ void register_input_dispatch_core_tests(void) {
                     test_question_key_opens_help_overlay);
     g_test_add_func("/input_dispatch_core/help_key/any_key_closes_without_mode_action",
                     test_any_key_closes_help_overlay_without_mode_action);
+    g_test_add_func("/input_dispatch_core/help_key/mouse_closing_help_resets_input_timing_state",
+                    test_mouse_closing_help_resets_input_timing_state);
 }

--- a/tests/test_preview_shared.c
+++ b/tests/test_preview_shared.c
@@ -28,6 +28,13 @@ typedef struct {
 } UiRowCaptureArgs;
 
 typedef struct {
+    gint row;
+    gint term_width;
+    const HelpSegment *segments;
+    gsize count;
+} HelpLineCaptureArgs;
+
+typedef struct {
     gint term_width;
     gint term_height;
     UIPanel panel;
@@ -95,6 +102,11 @@ static void draw_preview_content_capture(gpointer user_data) {
 static void draw_centered_row_capture(gpointer user_data) {
     UiRowCaptureArgs *args = (UiRowCaptureArgs *)user_data;
     ui_render_centered_row(args->row, args->term_width, args->text, args->style);
+}
+
+static void draw_help_line_capture(gpointer user_data) {
+    HelpLineCaptureArgs *args = (HelpLineCaptureArgs *)user_data;
+    ui_print_centered_help_line(args->row, args->term_width, args->segments, args->count);
 }
 
 static void draw_panel_capture(gpointer user_data) {
@@ -344,6 +356,30 @@ static void test_ui_render_panel_draws_title_rows_and_truncates_columns(void) {
     g_free(output);
 }
 
+static void test_ui_help_line_keeps_help_on_narrow_width(void) {
+    const HelpSegment segments[] = {
+        {"A", "One"},
+        {"B", "Two"},
+        {"C", "Three"},
+        {"?", "Help"}
+    };
+    HelpLineCaptureArgs args = {
+        .row = 1,
+        .term_width = 16,
+        .segments = segments,
+        .count = G_N_ELEMENTS(segments)
+    };
+
+    gchar *output = capture_output(draw_help_line_capture, &args);
+
+    g_assert_nonnull(g_strstr_len(output, -1, "A\033[0m One"));
+    g_assert_nonnull(g_strstr_len(output, -1, "?\033[0m Help"));
+    g_assert_null(g_strstr_len(output, -1, "B\033[0m Two"));
+    g_assert_null(g_strstr_len(output, -1, "C\033[0m Three"));
+
+    g_free(output);
+}
+
 static void test_ui_render_panel_keeps_pair_rows_inside_narrow_panel(void) {
     const UIPanelRow rows[] = {
         {"LongShortcutName", "LongAction"}
@@ -398,6 +434,8 @@ void register_preview_shared_tests(void) {
                     test_ui_preview_header_lines_follow_visibility);
     g_test_add_func("/preview_shared/ui_render/panel_draws_title_rows_and_truncates_columns",
                     test_ui_render_panel_draws_title_rows_and_truncates_columns);
+    g_test_add_func("/preview_shared/ui_render/help_line_keeps_help_on_narrow_width",
+                    test_ui_help_line_keeps_help_on_narrow_width);
     g_test_add_func("/preview_shared/ui_render/panel_keeps_pair_rows_inside_narrow_panel",
                     test_ui_render_panel_keeps_pair_rows_inside_narrow_panel);
     g_test_add_func("/preview_shared/ui_render/panel_tolerates_null_line_and_row_arrays",

--- a/tests/test_preview_shared.c
+++ b/tests/test_preview_shared.c
@@ -380,6 +380,35 @@ static void test_ui_help_line_keeps_help_on_narrow_width(void) {
     g_free(output);
 }
 
+static void test_ui_help_line_preserves_prefix_order_before_help(void) {
+    const HelpSegment segments[] = {
+        {"A", "One"},
+        {"B", "Two"},
+        {"C", "Three"},
+        {"?", "Help"}
+    };
+    HelpLineCaptureArgs args = {
+        .row = 1,
+        .term_width = 20,
+        .segments = segments,
+        .count = G_N_ELEMENTS(segments)
+    };
+
+    gchar *output = capture_output(draw_help_line_capture, &args);
+
+    const gchar *first = g_strstr_len(output, -1, "A\033[0m One");
+    const gchar *second = g_strstr_len(output, -1, "B\033[0m Two");
+    const gchar *help = g_strstr_len(output, -1, "?\033[0m Help");
+    g_assert_nonnull(first);
+    g_assert_nonnull(second);
+    g_assert_nonnull(help);
+    g_assert_true(first < second);
+    g_assert_true(second < help);
+    g_assert_null(g_strstr_len(output, -1, "C\033[0m Three"));
+
+    g_free(output);
+}
+
 static void test_ui_render_panel_keeps_pair_rows_inside_narrow_panel(void) {
     const UIPanelRow rows[] = {
         {"LongShortcutName", "LongAction"}
@@ -436,6 +465,8 @@ void register_preview_shared_tests(void) {
                     test_ui_render_panel_draws_title_rows_and_truncates_columns);
     g_test_add_func("/preview_shared/ui_render/help_line_keeps_help_on_narrow_width",
                     test_ui_help_line_keeps_help_on_narrow_width);
+    g_test_add_func("/preview_shared/ui_render/help_line_preserves_prefix_order_before_help",
+                    test_ui_help_line_preserves_prefix_order_before_help);
     g_test_add_func("/preview_shared/ui_render/panel_keeps_pair_rows_inside_narrow_panel",
                     test_ui_render_panel_keeps_pair_rows_inside_narrow_panel);
     g_test_add_func("/preview_shared/ui_render/panel_tolerates_null_line_and_row_arrays",


### PR DESCRIPTION
## Summary
- close the help overlay on the next key or mouse input without passing that input through to the active mode
- clear help/info overlays on mode transitions so help does not leak into file manager, preview, image, or video views
- make footer hints width-aware and keep only high-priority hints on narrow terminals, with file manager using the shared hint renderer

## Review
- reviewed the diff for state-leak regressions, mode transition behavior, footer truncation behavior, and test coverage
- no blocking issues found; one intentional behavior choice is that any input closes help and is swallowed to avoid accidental actions behind the overlay

## Verification
- rtk make EXTRA_CFLAGS=-Werror
- rtk git diff --check origin/main...HEAD
- rtk make EXTRA_CFLAGS=-Werror test

## 由 Sourcery 生成的摘要

改进帮助浮层行为，以及在各模式下共享页脚帮助信息的渲染方式。

新特性：
- 在下一次键盘或鼠标输入时自动关闭帮助浮层，并且不将该输入转发给当前激活的模式。
- 使用共享的帮助行渲染器来居中并渲染文件管理器的页脚帮助提示，并根据终端宽度进行截断，优先保留帮助快捷键。

增强改进：
- 在模式切换时清除帮助和信息浮层，避免浮层在视图之间“泄漏”。
- 让通用的居中帮助行渲染器具备宽度感知能力，从而在终端较窄时仍能保留高优先级的帮助片段。

构建：
- 将文件管理器测试链接到共享的 UI 渲染工具模块，以便它们可以使用通用的帮助渲染器。

测试：
- 添加单元测试，覆盖在窄宽度下仍保留帮助片段的帮助行截断行为。
- 添加单元测试，确保任意按键都会关闭帮助浮层且不会触发当前模式的动作。
- 添加单元测试，验证模式切换会清除帮助和信息浮层。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化帮助叠加层的关闭行为，并在各模式中统一使用与宽度感知相关的页脚提示渲染逻辑。

New Features:
- 在下一个按键或鼠标输入时关闭帮助叠加层，同时吞掉该输入，以避免触发底层模式动作。
- 为文件管理器页脚提示使用共享的、支持宽度感知的帮助行渲染器。

Bug Fixes:
- 在模式切换时清除帮助和信息叠加层，避免叠加层在不同视图之间“泄漏”。

Enhancements:
- 让居中的帮助行渲染器具备宽度感知能力，在终端空间受限时仍能保留高优先级片段和“? Help”片段，并保持前缀顺序不变。

Build:
- 将文件管理器测试链接到共享的 UI 渲染工具模块，以支持通用的帮助渲染器。

Tests:
- 添加在终端宽度较窄情况下对帮助行截断和片段排序的测试。
- 添加验证任意按键都能关闭帮助叠加层且不会触发模式动作的测试。
- 添加确保模式切换时清除帮助和信息叠加层的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine help overlay dismissal and centralize width-aware footer hint rendering across modes.

New Features:
- Close the help overlay on the next key or mouse input while swallowing that input so no underlying mode action is triggered.
- Use the shared width-aware help line renderer for the file manager footer hints.

Bug Fixes:
- Clear help and info overlays on mode transitions to avoid overlays leaking between views.

Enhancements:
- Make the centered help line renderer width-aware so it preserves high-priority and “? Help” segments when space is constrained while maintaining prefix order.

Build:
- Link file manager tests against the shared UI render utilities module to support the common help renderer.

Tests:
- Add tests for help line truncation and segment ordering under narrow terminal widths.
- Add tests verifying that any key press closes the help overlay without invoking mode actions.
- Add tests ensuring mode transitions clear help and info overlays.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Help overlays now close on the next key or mouse input without triggering mode actions, and help/info are cleared on mode switches. Footer hints are width-aware and priority-based, keeping "? Help" when space is tight; mouse timing is reset on help close to avoid stray double-click/scrolls.

- **New Features**
  - Width-aware footer hints via `ui_print_centered_help_line`; preserves prefix order and appends "? Help" when possible.
  - File manager footer switched to shared renderer in `ui_render_utils`.

- **Bug Fixes**
  - Swallow dismissal input and reset mouse click/scroll timing so Help closes cleanly with no unintended actions.
  - Clear help/info overlays on all mode transitions.
  - Tests added for input swallowing, mouse timing reset (including nonzero click button), narrow-width hint selection, and hint priority before "? Help".

<sup>Written for commit 36d789fc41cbe940046e08df54b08558903d92b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zouyonghe/PixelTerm-C/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

