### PR TITLE
Build: include local pkg-config paths by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,13 @@ ifeq ($(ARCH),aarch64)
 endif
 
 PKG_CONFIG ?= pkg-config
-PKG_CONFIG_CMD = PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG)
+PKG_CONFIG_LOCAL_PATHS ?= /usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/local/share/pkgconfig
+ifneq ($(PKG_CONFIG_PATH),)
+  PKG_CONFIG_EFFECTIVE_PATH := $(PKG_CONFIG_PATH)
+else
+  PKG_CONFIG_EFFECTIVE_PATH := $(PKG_CONFIG_LOCAL_PATHS)
+endif
+PKG_CONFIG_CMD = PKG_CONFIG_PATH=$(PKG_CONFIG_EFFECTIVE_PATH) $(PKG_CONFIG)
 PKG_DEPS = chafa gdk-pixbuf-2.0 gio-2.0 libavformat libavcodec libswscale libavutil
 
 LIBS = $(shell $(PKG_CONFIG_CMD) --libs $(PKG_DEPS)) -lpthread -lm

--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,16 @@ endif
 
 PKG_CONFIG ?= pkg-config
 PKG_CONFIG_LOCAL_PATHS ?= /usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/local/share/pkgconfig
-ifneq ($(PKG_CONFIG_PATH),)
+ifeq ($(ARCH),aarch64)
   PKG_CONFIG_EFFECTIVE_PATH := $(PKG_CONFIG_PATH)
 else
-  PKG_CONFIG_EFFECTIVE_PATH := $(PKG_CONFIG_LOCAL_PATHS)
+  ifneq ($(PKG_CONFIG_PATH),)
+    PKG_CONFIG_EFFECTIVE_PATH := $(PKG_CONFIG_PATH):$(PKG_CONFIG_LOCAL_PATHS)
+  else
+    PKG_CONFIG_EFFECTIVE_PATH := $(PKG_CONFIG_LOCAL_PATHS)
+  endif
 endif
-PKG_CONFIG_CMD = PKG_CONFIG_PATH=$(PKG_CONFIG_EFFECTIVE_PATH) $(PKG_CONFIG)
+PKG_CONFIG_CMD = PKG_CONFIG_PATH="$(PKG_CONFIG_EFFECTIVE_PATH)" $(PKG_CONFIG)
 PKG_DEPS = chafa gdk-pixbuf-2.0 gio-2.0 libavformat libavcodec libswscale libavutil
 
 LIBS = $(shell $(PKG_CONFIG_CMD) --libs $(PKG_DEPS)) -lpthread -lm


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

构建：
- 当未提供 `PKG_CONFIG_PATH` 时，将 `PKG_CONFIG_PATH` 设置为默认的 `/usr/local` pkg-config 目录集合，同时保留显式指定的 `PKG_CONFIG_PATH` 值。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

调整构建时对 pkg-config 路径的处理，在保留架构特定行为的同时，将默认的 /usr/local pkg-config 目录包含进来。

构建：
- 为非 aarch64 构建设置一组默认的 /usr/local pkg-config 目录，并将它们合并到 `PKG_CONFIG_PATH` 中。
- 在 aarch64 上保持 `PKG_CONFIG_PATH` 不变，同时通过一个有效的路径变量来路由 `pkg-config` 调用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust build-time pkg-config path handling to include default /usr/local pkg-config directories while preserving architecture-specific behavior.

Build:
- Set a default set of /usr/local pkg-config directories and incorporate them into PKG_CONFIG_PATH for non-aarch64 builds.
- Keep PKG_CONFIG_PATH unchanged on aarch64 while routing pkg-config invocations through an effective path variable.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include local `/usr/local` `pkg-config` directories by default so builds find local libs. On non-`aarch64`, append them to any existing `PKG_CONFIG_PATH`; on `aarch64`, leave `PKG_CONFIG_PATH` unchanged.

<sup>Written for commit ad6a5ef8ce7f4f13448575379a1126f7c8444a07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zouyonghe/PixelTerm-C/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

