### PR TITLE
fix: harden startup and input edge cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,15 +171,29 @@ PREVIEW_GRID_TEST_SOURCE = tests/test_app_preview_grid.c
 PREVIEW_GRID_TEST_OBJECT = $(OBJDIR)/test_app_preview_grid.o
 BOOK_PREVIEW_TEST_SOURCE = tests/test_app_preview_book.c
 BOOK_PREVIEW_TEST_OBJECT = $(OBJDIR)/test_app_preview_book.o
-TEST_LINK_OBJECTS = $(OBJDIR)/common.o $(OBJDIR)/browser.o $(OBJDIR)/renderer.o \
-		$(OBJDIR)/gif_player.o $(OBJDIR)/input.o $(OBJDIR)/text_utils.o $(OBJDIR)/process_env.o \
-		$(OBJDIR)/pixbuf_utils.o $(OBJDIR)/media_buffer.o $(OBJDIR)/preloader.o $(OBJDIR)/app_mode.o $(OBJDIR)/input_dispatch_pending_clicks.o \
-		$(OBJDIR)/input_dispatch_delete.o $(OBJDIR)/input_dispatch_core.o $(OBJDIR)/input_dispatch_key_single.o $(OBJDIR)/input_dispatch_key_book.o $(OBJDIR)/input_dispatch_key_file_manager.o $(OBJDIR)/input_dispatch_mouse_modes.o $(OBJDIR)/app_preview_shared.o \
-		$(OBJDIR)/app_media_session.o $(OBJDIR)/app_single_render.o $(OBJDIR)/app_config_runtime.o $(OBJDIR)/media_utils.o $(OBJDIR)/ui_render_utils.o \
-		$(OBJDIR)/video_player_clock.o $(OBJDIR)/video_player_debug.o $(OBJDIR)/video_player_decode.o $(OBJDIR)/video_player_layout.o $(OBJDIR)/video_player_playback.o $(OBJDIR)/video_player_seek.o $(OBJDIR)/video_player.o $(OBJDIR)/kitty_graphics.o $(OBJDIR)/terminal_probe.o $(OBJDIR)/terminal_protocols.o $(OBJDIR)/terminal_protocol_resolver.o $(OBJDIR)/app_cli.o $(OBJDIR)/book.o \
-		$(OBJDIR)/app_startup.o
-FILE_MANAGER_TEST_LINK_OBJECTS = $(OBJDIR)/common.o $(OBJDIR)/process_env.o $(OBJDIR)/app_core.o $(OBJDIR)/app_mode.o \
-		$(OBJDIR)/app_file_manager.o $(OBJDIR)/app_file_manager_render.o $(OBJDIR)/text_utils.o $(OBJDIR)/ui_render_utils.o
+TEST_COMMON_LINK_OBJECTS = $(OBJDIR)/common.o $(OBJDIR)/text_utils.o $(OBJDIR)/process_env.o \
+		$(OBJDIR)/ui_render_utils.o
+TEST_RENDER_LINK_OBJECTS = $(OBJDIR)/browser.o $(OBJDIR)/renderer.o $(OBJDIR)/pixbuf_utils.o \
+		$(OBJDIR)/kitty_graphics.o
+TEST_MEDIA_LINK_OBJECTS = $(OBJDIR)/gif_player.o $(OBJDIR)/media_buffer.o $(OBJDIR)/preloader.o \
+		$(OBJDIR)/app_media_session.o $(OBJDIR)/media_utils.o \
+		$(OBJDIR)/video_player_clock.o $(OBJDIR)/video_player_debug.o $(OBJDIR)/video_player_decode.o \
+		$(OBJDIR)/video_player_layout.o $(OBJDIR)/video_player_playback.o \
+		$(OBJDIR)/video_player_seek.o $(OBJDIR)/video_player.o
+TEST_INPUT_LINK_OBJECTS = $(OBJDIR)/input.o $(OBJDIR)/input_dispatch_pending_clicks.o \
+		$(OBJDIR)/input_dispatch_delete.o $(OBJDIR)/input_dispatch_core.o \
+		$(OBJDIR)/input_dispatch_key_single.o $(OBJDIR)/input_dispatch_key_book.o \
+		$(OBJDIR)/input_dispatch_key_file_manager.o $(OBJDIR)/input_dispatch_mouse_modes.o
+TEST_APP_LINK_OBJECTS = $(OBJDIR)/app_mode.o $(OBJDIR)/app_preview_shared.o \
+		$(OBJDIR)/app_single_render.o $(OBJDIR)/app_config_runtime.o $(OBJDIR)/app_cli.o \
+		$(OBJDIR)/book.o $(OBJDIR)/app_startup.o
+TEST_TERMINAL_LINK_OBJECTS = $(OBJDIR)/terminal_probe.o $(OBJDIR)/terminal_protocols.o \
+		$(OBJDIR)/terminal_protocol_resolver.o
+TEST_LINK_OBJECTS = $(TEST_COMMON_LINK_OBJECTS) $(TEST_RENDER_LINK_OBJECTS) \
+		$(TEST_MEDIA_LINK_OBJECTS) $(TEST_INPUT_LINK_OBJECTS) $(TEST_APP_LINK_OBJECTS) \
+		$(TEST_TERMINAL_LINK_OBJECTS)
+FILE_MANAGER_TEST_LINK_OBJECTS = $(TEST_COMMON_LINK_OBJECTS) $(OBJDIR)/app_core.o \
+		$(OBJDIR)/app_mode.o $(OBJDIR)/app_file_manager.o $(OBJDIR)/app_file_manager_render.o
 PREVIEW_GRID_TEST_LINK_OBJECTS = $(OBJDIR)/app_preview_grid.o $(OBJDIR)/ui_render_utils.o $(OBJDIR)/text_utils.o
 BOOK_PREVIEW_TEST_LINK_OBJECTS = $(OBJDIR)/app_preview_book.o $(OBJDIR)/app_book_page_render.o
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ curl -fsSL https://raw.githubusercontent.com/zouyonghe/PixelTerm-C/main/scripts/
 ```
 
 The installer auto-detects `macOS/Linux + amd64/arm64`, downloads the latest GitHub Release binary, and installs `pixelterm` to `/usr/local/bin/pixelterm`. It only uses `sudo` when that directory is not writable.
+The installer downloads `SHA256SUMS` from the release and verifies the binary before installing it. Use `--dry-run` to inspect the resolved asset and destination without changing your system.
 
 Need a custom install directory instead of `/usr/local/bin`?
 
@@ -43,7 +44,7 @@ curl -fsSL https://raw.githubusercontent.com/zouyonghe/PixelTerm-C/main/scripts/
 Need a reproducible install? Pin a release tag:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/zouyonghe/PixelTerm-C/main/scripts/install.sh | bash -s -- --version v1.7.26
+curl -fsSL https://raw.githubusercontent.com/zouyonghe/PixelTerm-C/main/scripts/install.sh | bash -s -- --version v1.8.0
 ```
 
 If you prefer a package manager or manual install, use one of these paths:
@@ -56,6 +57,8 @@ yay -S pixelterm-c
 
 # Linux amd64
 wget https://github.com/zouyonghe/PixelTerm-C/releases/latest/download/pixelterm-amd64-linux
+wget https://github.com/zouyonghe/PixelTerm-C/releases/latest/download/SHA256SUMS
+grep ' pixelterm-amd64-linux$' SHA256SUMS | sha256sum -c -
 chmod +x pixelterm-amd64-linux && sudo mv pixelterm-amd64-linux /usr/local/bin/pixelterm
 
 # Linux arm64
@@ -98,10 +101,12 @@ pixelterm /path/to/directory
 pixelterm --help
 ```
 
+Press `?` for in-app help, `Esc` to exit, or `Ctrl+C` to force quit.
+
 Notes:
 
 - If the path you want to open starts with `-`, use `--` first so PixelTerm-C treats it as a path: `pixelterm -- --config=gallery.txt`
-- If you point PixelTerm-C at an unsupported regular file, it falls back to that file's canonical parent directory in file manager mode.
+- If you point PixelTerm-C at an unsupported regular file, it exits with an unsupported file type error.
 
 For more usage examples and options, see [USAGE.md](docs/guides/USAGE.md).
 

--- a/include/app_runtime.h
+++ b/include/app_runtime.h
@@ -4,6 +4,7 @@
 #include "app_state.h"
 
 void app_toggle_preload(PixelTermApp *app);
+void app_prepare_mode_entry(PixelTermApp *app, gboolean clear_preloader_queue);
 ErrorCode app_transition_mode(PixelTermApp *app, AppMode mode);
 void app_set_mode(PixelTermApp *app, AppMode mode);
 gboolean app_should_exit(const PixelTermApp *app);

--- a/include/app_startup.h
+++ b/include/app_startup.h
@@ -9,12 +9,12 @@ typedef enum {
     APP_STARTUP_PATH_DIRECTORY,
     APP_STARTUP_PATH_BOOK,
     APP_STARTUP_PATH_MEDIA,
-    APP_STARTUP_PATH_PARENT_DIRECTORY,
 } AppStartupPathKind;
 
 typedef struct {
     AppStartupPathKind kind;
     gchar *path;
+    gint failure_errno;
 } AppStartupPathDecision;
 
 ErrorCode app_startup_classify_path(const char *requested_path,

--- a/include/app_state.h
+++ b/include/app_state.h
@@ -136,6 +136,7 @@ typedef struct {
     gboolean ui_text_hidden; // Hide all UI text overlays (single/preview)
     gboolean show_fps; // Toggle FPS overlay in video view
     gdouble video_scale; // Scale factor for video render size
+    gboolean video_was_playing_before_resize;
     gboolean clear_workaround_enabled; // Enable double-clear workaround on full refresh
     gboolean preload_enabled;
     gboolean dither_enabled;

--- a/include/input.h
+++ b/include/input.h
@@ -256,9 +256,9 @@ gint input_read_key(InputHandler *handler);
  * It's generally used when a character is expected immediately.
  * 
  * @param handler A pointer to the `InputHandler` instance.
- * @return The character read, or 0 if an error occurs.
+ * @return The byte read as 0..255, or 0 if an error occurs.
  */
-gchar input_read_char(InputHandler *handler);
+gint input_read_char(InputHandler *handler);
 /**
  * @brief Reads a single character from terminal input with a specified timeout.
  * 
@@ -268,10 +268,10 @@ gchar input_read_char(InputHandler *handler);
  * 
  * @param handler A pointer to the `InputHandler` instance.
  * @param timeout_ms The maximum time (in milliseconds) to wait for input.
- * @return The character read, or 0 if no input is available within the timeout
+ * @return The byte read as 0..255, or 0 if no input is available within the timeout
  *         or an error occurs.
  */
-gchar input_read_char_with_timeout(InputHandler *handler, gint timeout_ms);
+gint input_read_char_with_timeout(InputHandler *handler, gint timeout_ms);
 gboolean input_probe_sixel_support(InputHandler *handler, gint timeout_ms);
 gboolean input_probe_kitty_support(InputHandler *handler, gint timeout_ms);
 gboolean input_probe_iterm2_support(InputHandler *handler, gint timeout_ms);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -263,7 +263,12 @@ parse_args() {
         exit 0
         ;;
       *)
-        die "Unknown argument: $1"
+        printf 'Error: Unknown argument: %s\n' "$1" >&2
+        if [ "$1" = "--prefix" ]; then
+          printf 'Use --bin-dir to choose the install directory.\n' >&2
+        fi
+        printf 'Run: bash install.sh --help\n' >&2
+        exit 1
         ;;
     esac
   done

--- a/scripts/test_install_script.py
+++ b/scripts/test_install_script.py
@@ -156,6 +156,14 @@ class InstallScriptCLITest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertEqual(result.stdout.strip(), "/usr/local/bin/pixelterm")
 
+    def test_unknown_argument_points_to_help(self) -> None:
+        result = run_script("--prefix", "/tmp/pixelterm")
+
+        self.assertNotEqual(result.returncode, 0, msg=result.stdout)
+        self.assertIn("Unknown argument: --prefix", result.stderr)
+        self.assertIn("Run: bash install.sh --help", result.stderr)
+        self.assertIn("Use --bin-dir to choose the install directory", result.stderr)
+
     def test_dry_run_reports_download_url_and_destination(self) -> None:
         result = run_script(
             "--dry-run",

--- a/src/app_cli.c
+++ b/src/app_cli.c
@@ -301,7 +301,9 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         }
         AppProtocolMode mode = APP_PROTOCOL_AUTO;
         if (!parse_protocol_mode(value, &mode)) {
-            fprintf(stderr, "Invalid 'protocol' in config file '%s': %s\n", path, value);
+            fprintf(stderr,
+                    "Invalid 'protocol' in config file '%s' group '[%s]': %s (expected auto, text, sixel, kitty, or iterm2)\n",
+                    path, group, value);
             g_free(value);
             return FALSE;
         }
@@ -320,7 +322,9 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         }
         TextSymbolMode mode = TEXT_SYMBOL_MODE_AUTO;
         if (!parse_text_symbol_mode(value, &mode)) {
-            fprintf(stderr, "Invalid 'text_symbols' in config file '%s': %s\n", path, value);
+            fprintf(stderr,
+                    "Invalid 'text_symbols' in config file '%s' group '[%s]': %s (expected auto, half, or quarter)\n",
+                    path, group, value);
             g_free(value);
             return FALSE;
         }
@@ -339,7 +343,9 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         }
         ColorEnhanceMode mode = COLOR_ENHANCE_OFF;
         if (!parse_color_enhance_mode(value, &mode)) {
-            fprintf(stderr, "Invalid 'color_enhance' in config file '%s': %s\n", path, value);
+            fprintf(stderr,
+                    "Invalid 'color_enhance' in config file '%s' group '[%s]': %s (expected off or vivid)\n",
+                    path, group, value);
             g_free(value);
             return FALSE;
         }
@@ -358,7 +364,9 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         }
         KittyTransferMode mode = KITTY_TRANSFER_AUTO;
         if (!parse_kitty_transfer_mode(value, &mode)) {
-            fprintf(stderr, "Invalid 'kitty_transfer' in config file '%s': %s\n", path, value);
+            fprintf(stderr,
+                    "Invalid 'kitty_transfer' in config file '%s' group '[%s]': %s (expected auto, direct, or shm)\n",
+                    path, group, value);
             g_free(value);
             return FALSE;
         }
@@ -757,7 +765,7 @@ ErrorCode app_parse_arguments(int argc, char *argv[], char **path, AppConfig *co
             case 1000: { // --preload
                 gboolean value = TRUE;
                 if (!app_parse_boolean(optarg, &value)) {
-                    fprintf(stderr, "Invalid --preload value: %s (expected true/false)\n",
+                    fprintf(stderr, "Invalid --preload value: %s (expected true/false, yes/no, on/off, or 1/0)\n",
                             optarg ? optarg : "");
                     return ERROR_INVALID_ARGS;
                 }
@@ -770,7 +778,7 @@ ErrorCode app_parse_arguments(int argc, char *argv[], char **path, AppConfig *co
             case 1002: { // --alt-screen
                 gboolean value = FALSE;
                 if (!app_parse_boolean(optarg, &value)) {
-                    fprintf(stderr, "Invalid --alt-screen value: %s (expected true/false)\n",
+                    fprintf(stderr, "Invalid --alt-screen value: %s (expected true/false, yes/no, on/off, or 1/0)\n",
                             optarg ? optarg : "");
                     return ERROR_INVALID_ARGS;
                 }
@@ -798,7 +806,8 @@ ErrorCode app_parse_arguments(int argc, char *argv[], char **path, AppConfig *co
             case 1005: { // --protocol
                 AppProtocolMode mode = APP_PROTOCOL_AUTO;
                 if (!parse_protocol_mode(optarg, &mode)) {
-                    fprintf(stderr, "Unknown protocol: %s\n", optarg ? optarg : "");
+                    fprintf(stderr, "Invalid --protocol value: %s (expected auto, text, sixel, kitty, or iterm2)\n",
+                            optarg ? optarg : "");
                     return ERROR_INVALID_ARGS;
                 }
                 config->protocol_mode = mode;
@@ -825,7 +834,8 @@ ErrorCode app_parse_arguments(int argc, char *argv[], char **path, AppConfig *co
             case 1008: { // --text-symbols
                 TextSymbolMode mode = TEXT_SYMBOL_MODE_AUTO;
                 if (!parse_text_symbol_mode(optarg, &mode)) {
-                    fprintf(stderr, "Unknown text symbol mode: %s\n", optarg ? optarg : "");
+                    fprintf(stderr, "Invalid --text-symbols value: %s (expected auto, half, or quarter)\n",
+                            optarg ? optarg : "");
                     return ERROR_INVALID_ARGS;
                 }
                 config->text_symbol_mode = mode;
@@ -834,7 +844,8 @@ ErrorCode app_parse_arguments(int argc, char *argv[], char **path, AppConfig *co
             case 1009: { // --color-enhance
                 ColorEnhanceMode mode = COLOR_ENHANCE_OFF;
                 if (!parse_color_enhance_mode(optarg, &mode)) {
-                    fprintf(stderr, "Unknown color enhancement mode: %s\n", optarg ? optarg : "");
+                    fprintf(stderr, "Invalid --color-enhance value: %s (expected off or vivid)\n",
+                            optarg ? optarg : "");
                     return ERROR_INVALID_ARGS;
                 }
                 config->color_enhance = mode;
@@ -843,7 +854,8 @@ ErrorCode app_parse_arguments(int argc, char *argv[], char **path, AppConfig *co
             case 1010: { // --kitty-transfer
                 KittyTransferMode mode = KITTY_TRANSFER_AUTO;
                 if (!parse_kitty_transfer_mode(optarg, &mode)) {
-                    fprintf(stderr, "Unknown kitty transfer mode: %s\n", optarg ? optarg : "");
+                    fprintf(stderr, "Invalid --kitty-transfer value: %s (expected auto, direct, or shm)\n",
+                            optarg ? optarg : "");
                     return ERROR_INVALID_ARGS;
                 }
                 config->kitty_transfer = mode;
@@ -872,6 +884,13 @@ ErrorCode app_parse_arguments(int argc, char *argv[], char **path, AppConfig *co
     // Get path from remaining arguments
     if (optind < argc) {
         *path = g_strdup(argv[optind]);
+        if (optind + 1 < argc) {
+            fprintf(stderr, "Unexpected argument: %s\n", argv[optind + 1]);
+            fprintf(stderr, "Use --help for usage information\n");
+            g_free(*path);
+            *path = NULL;
+            return ERROR_INVALID_ARGS;
+        }
     }
 
     return ERROR_NONE;

--- a/src/app_core.c
+++ b/src/app_core.c
@@ -144,20 +144,38 @@ ErrorCode app_load_single_file(PixelTermApp *app, const char *filepath) {
         return error;
     }
 
-    // Find the specific file in the list (single pass)
+    // Find the specific file in the list by full canonical path first.
+    gchar *target_canonical = g_canonicalize_filename(filepath, NULL);
     gchar *target_basename = g_path_get_basename(filepath);
     gboolean found = FALSE;
     gint idx = 0;
     for (GList *cur = app->image_files; cur; cur = cur->next, idx++) {
-        gchar *current_basename = g_path_get_basename((gchar*)cur->data);
-        if (g_strcmp0(current_basename, target_basename) == 0) {
+        gchar *current_path = (gchar*)cur->data;
+        gchar *current_canonical = g_canonicalize_filename(current_path, NULL);
+        gboolean full_path_match = g_strcmp0(current_canonical, target_canonical) == 0;
+        g_free(current_canonical);
+
+        if (full_path_match) {
             app->current_index = idx;
             found = TRUE;
-            g_free(current_basename);
             break;
         }
-        g_free(current_basename);
     }
+
+    if (!found) {
+        idx = 0;
+        for (GList *cur = app->image_files; cur; cur = cur->next, idx++) {
+            gchar *current_basename = g_path_get_basename((gchar*)cur->data);
+            if (g_strcmp0(current_basename, target_basename) == 0) {
+                app->current_index = idx;
+                found = TRUE;
+                g_free(current_basename);
+                break;
+            }
+            g_free(current_basename);
+        }
+    }
+    g_free(target_canonical);
     g_free(target_basename);
 
     // If file was found and loaded successfully, mark for redraw

--- a/src/app_core.c
+++ b/src/app_core.c
@@ -151,9 +151,17 @@ ErrorCode app_load_single_file(PixelTermApp *app, const char *filepath) {
     gint idx = 0;
     for (GList *cur = app->image_files; cur; cur = cur->next, idx++) {
         gchar *current_path = (gchar*)cur->data;
-        gchar *current_canonical = g_canonicalize_filename(current_path, NULL);
-        gboolean full_path_match = g_strcmp0(current_canonical, target_canonical) == 0;
-        g_free(current_canonical);
+        gboolean full_path_match = g_strcmp0(current_path, target_canonical) == 0;
+
+        if (!full_path_match) {
+            gchar *current_basename = g_path_get_basename(current_path);
+            if (g_strcmp0(current_basename, target_basename) == 0) {
+                gchar *current_canonical = g_canonicalize_filename(current_path, NULL);
+                full_path_match = g_strcmp0(current_canonical, target_canonical) == 0;
+                g_free(current_canonical);
+            }
+            g_free(current_basename);
+        }
 
         if (full_path_match) {
             app->current_index = idx;

--- a/src/app_file_manager.c
+++ b/src/app_file_manager.c
@@ -711,7 +711,8 @@ ErrorCode app_file_manager_refresh(PixelTermApp *app) {
     if (!dir) {
         if (previous_directory) {
             g_free(app->file_manager.directory);
-            app->file_manager.directory = g_strdup(previous_directory);
+            app->file_manager.directory = previous_directory;
+            previous_directory = NULL;
         }
         g_free(previous_directory);
         g_free(current_dir);

--- a/src/app_file_manager.c
+++ b/src/app_file_manager.c
@@ -352,13 +352,7 @@ ErrorCode app_enter_file_manager(PixelTermApp *app) {
         return ERROR_MEMORY_ALLOC;
     }
 
-    // Stop GIF playback if active
-    if (app->gif_player) {
-        gif_player_stop(app->gif_player);
-    }
-    if (app->video_player) {
-        video_player_stop(app->video_player);
-    }
+    app_prepare_mode_entry(app, FALSE);
 
     (void)app_transition_mode(app, APP_MODE_FILE_MANAGER);
     app->file_manager.selected_entry = 0;
@@ -688,14 +682,6 @@ ErrorCode app_file_manager_refresh(PixelTermApp *app) {
         }
     }
 
-    // Clear existing entries
-    if (app->file_manager.entries) {
-        g_list_free_full(app->file_manager.entries, (GDestroyNotify)g_free);
-        app->file_manager.entries = NULL;
-    }
-    app->file_manager.entries_count = 0;
-    app_file_manager_invalidate_selection_cache(app);
-
     // Resolve directory to display: prefer file manager dir, then viewer dir, then cwd
     gchar *base_dir_dup = NULL;
     if (app->file_manager.directory) {
@@ -719,18 +705,32 @@ ErrorCode app_file_manager_refresh(PixelTermApp *app) {
     gboolean preserve_selection = same_directory &&
                                   app->return_to_mode == RETURN_MODE_NONE &&
                                   had_entries;
-    g_free(previous_directory);
-
-    // Persist canonical directory for consistent rendering/navigation
-    g_free(app->file_manager.directory);
-    app->file_manager.directory = current_dir;
 
     // Open directory
     GDir *dir = g_dir_open(current_dir, 0, NULL);
     if (!dir) {
+        if (previous_directory) {
+            g_free(app->file_manager.directory);
+            app->file_manager.directory = g_strdup(previous_directory);
+        }
+        g_free(previous_directory);
+        g_free(current_dir);
         g_free(previous_selection);
         return ERROR_FILE_NOT_FOUND;
     }
+    g_free(previous_directory);
+
+    // Clear existing entries only after the replacement directory is readable.
+    if (app->file_manager.entries) {
+        g_list_free_full(app->file_manager.entries, (GDestroyNotify)g_free);
+        app->file_manager.entries = NULL;
+    }
+    app->file_manager.entries_count = 0;
+    app_file_manager_invalidate_selection_cache(app);
+
+    // Persist canonical directory for consistent rendering/navigation
+    g_free(app->file_manager.directory);
+    app->file_manager.directory = current_dir;
 
     // Collect all entries
     GList *entries = NULL;

--- a/src/app_mode.c
+++ b/src/app_mode.c
@@ -1,6 +1,9 @@
 #include "app.h"
 
 #include "app_media_session.h"
+#include "gif_player.h"
+#include "preload_control.h"
+#include "video_player.h"
 
 #define APP_MODE_COUNT (APP_MODE_BOOK_PREVIEW + 1)
 #define APP_MODE_ALL_MASK ((1u << APP_MODE_COUNT) - 1u)
@@ -95,6 +98,23 @@ static const AppModeDef k_modes[APP_MODE_COUNT] = {
         .on_exit = app_mode_on_exit_preview,
     },
 };
+
+void app_prepare_mode_entry(PixelTermApp *app, gboolean clear_preloader_queue) {
+    if (!app) {
+        return;
+    }
+
+    if (app->gif_player) {
+        gif_player_stop(app->gif_player);
+    }
+    if (app->video_player) {
+        video_player_stop(app->video_player);
+    }
+    app->info_visible = FALSE;
+    if (clear_preloader_queue) {
+        app_preloader_clear_queue(app);
+    }
+}
 
 ErrorCode app_transition_mode(PixelTermApp *app, AppMode mode) {
     if (!app) {

--- a/src/app_preview_book.c
+++ b/src/app_preview_book.c
@@ -734,12 +734,7 @@ ErrorCode app_enter_book_preview(PixelTermApp *app) {
         return ERROR_INVALID_IMAGE;
     }
 
-    if (app->gif_player) {
-        gif_player_stop(app->gif_player);
-    }
-    if (app->video_player) {
-        video_player_stop(app->video_player);
-    }
+    app_prepare_mode_entry(app, TRUE);
 
     (void)app_transition_mode(app, APP_MODE_BOOK_PREVIEW);
     app->book.preview_selected = app->book.page >= 0 ? app->book.page : 0;
@@ -747,10 +742,7 @@ ErrorCode app_enter_book_preview(PixelTermApp *app) {
         app->book.preview_selected = MAX(0, app->book.page_count - 1);
     }
     app->book.preview_scroll = 0;
-    app->info_visible = FALSE;
     app->needs_screen_clear = TRUE;
-
-    app_preloader_clear_queue(app);
     return ERROR_NONE;
 }
 
@@ -764,19 +756,11 @@ ErrorCode app_enter_book_page(PixelTermApp *app, gint page_index) {
         page_index = MAX(0, app->book.page_count - 1);
     }
 
-    if (app->gif_player) {
-        gif_player_stop(app->gif_player);
-    }
-    if (app->video_player) {
-        video_player_stop(app->video_player);
-    }
+    app_prepare_mode_entry(app, TRUE);
 
     app->book.page = page_index;
     (void)app_transition_mode(app, APP_MODE_BOOK);
-    app->info_visible = FALSE;
     app->needs_redraw = TRUE;
-
-    app_preloader_clear_queue(app);
     return ERROR_NONE;
 }
 

--- a/src/app_preview_grid.c
+++ b/src/app_preview_grid.c
@@ -588,13 +588,7 @@ ErrorCode app_enter_preview(PixelTermApp *app) {
         return ERROR_INVALID_IMAGE;
     }
 
-    // Stop GIF playback if active
-    if (app->gif_player) {
-        gif_player_stop(app->gif_player);
-    }
-    if (app->video_player) {
-        video_player_stop(app->video_player);
-    }
+    app_prepare_mode_entry(app, TRUE);
 
     (void)app_transition_mode(app, APP_MODE_PREVIEW);
     app_preview_set_selected_index(app, app->current_index >= 0 ? app->current_index : 0);
@@ -604,14 +598,12 @@ ErrorCode app_enter_preview(PixelTermApp *app) {
         app_preview_set_selected_index(app, 0);
     }
 
-    app->info_visible = FALSE;
     app->needs_redraw = TRUE;
 
     // Clear screen on mode entry to avoid ghosting
     ui_clear_screen_for_refresh(app);
     fflush(stdout);
 
-    app_preloader_clear_queue(app);
     return ERROR_NONE;
 }
 

--- a/src/app_single_render.c
+++ b/src/app_single_render.c
@@ -332,7 +332,7 @@ ErrorCode app_render_current_image(PixelTermApp *app) {
                                                            app->video_player,
                                                            filepath);
             if (load_result != ERROR_NONE) {
-                is_video = FALSE;
+                return load_result;
             }
         }
     }

--- a/src/app_startup.c
+++ b/src/app_startup.c
@@ -1,12 +1,17 @@
 #include "app_startup.h"
 
-static ErrorCode validate_path(const char *path, gboolean *is_directory) {
+#include <errno.h>
+
+static ErrorCode validate_path(const char *path, gboolean *is_directory, gint *failure_errno) {
     if (!path) {
         return ERROR_FILE_NOT_FOUND;
     }
 
     struct stat st;
     if (stat(path, &st) != 0) {
+        if (failure_errno) {
+            *failure_errno = errno;
+        }
         return ERROR_FILE_NOT_FOUND;
     }
 
@@ -18,6 +23,7 @@ ErrorCode app_startup_classify_path(const char *requested_path,
                                     AppStartupPathDecision *decision) {
     g_autofree gchar *current_dir = NULL;
     gboolean is_directory = FALSE;
+    gint failure_errno = 0;
     const char *path = requested_path;
 
     if (!decision) {
@@ -26,14 +32,16 @@ ErrorCode app_startup_classify_path(const char *requested_path,
 
     decision->kind = APP_STARTUP_PATH_DIRECTORY;
     decision->path = NULL;
+    decision->failure_errno = 0;
 
     if (!path) {
         current_dir = g_get_current_dir();
         path = current_dir;
     }
 
-    ErrorCode error = validate_path(path, &is_directory);
+    ErrorCode error = validate_path(path, &is_directory, &failure_errno);
     if (error != ERROR_NONE) {
+        decision->failure_errno = failure_errno;
         return error;
     }
 
@@ -55,8 +63,5 @@ ErrorCode app_startup_classify_path(const char *requested_path,
         return ERROR_NONE;
     }
 
-    g_autofree gchar *parent_dir = g_path_get_dirname(path);
-    decision->kind = APP_STARTUP_PATH_PARENT_DIRECTORY;
-    decision->path = g_canonicalize_filename(parent_dir, NULL);
-    return ERROR_NONE;
+    return ERROR_INVALID_IMAGE;
 }

--- a/src/input.c
+++ b/src/input.c
@@ -5,11 +5,31 @@
 #include <fcntl.h>
 #include <sys/time.h>
 #include <sys/select.h>
+#include <errno.h>
 #include <string.h>
 #include <stdlib.h>
 
 static gboolean input_discard_kitty_apc(InputHandler *handler);
 static gboolean g_scroll_coalesce_active = FALSE;
+
+static gboolean input_parse_sgr_int(const gchar *text, gint min_value, gint max_value, gint *out_value) {
+    if (!text || !out_value) {
+        return FALSE;
+    }
+
+    errno = 0;
+    char *end = NULL;
+    long value = strtol(text, &end, 10);
+    if (errno != 0 || end == text || (end && *end != '\0')) {
+        return FALSE;
+    }
+    if (value < min_value || value > max_value) {
+        return FALSE;
+    }
+
+    *out_value = (gint)value;
+    return TRUE;
+}
 static InputRawModeObserverForTest g_input_enable_raw_mode_observer_for_test = NULL;
 static InputRawModeObserverForTest g_input_disable_raw_mode_observer_for_test = NULL;
 static gpointer g_input_enable_raw_mode_observer_user_data = NULL;
@@ -297,9 +317,9 @@ ErrorCode input_get_event(InputHandler *handler, InputEvent *event) {
 
                 // Read the sequence until we hit a terminator
                 while (buf_idx < sizeof(buffer) - 1) {
-                    gchar ch = input_read_char_with_timeout(handler, 50);
+                    gint ch = input_read_char_with_timeout(handler, 50);
                     if (ch != 0) {
-                        buffer[buf_idx++] = ch;
+                        buffer[buf_idx++] = (gchar)ch;
                         // Stop reading if we hit a terminator (letter, ~, M, m)
                         if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || ch == '~' || ch == 'M' || ch == 'm') {
                             terminator = ch;
@@ -329,9 +349,16 @@ ErrorCode input_get_event(InputHandler *handler, InputEvent *event) {
                         gchar *btn_str = params[0];
                         if (btn_str[0] == '<') btn_str++;
                         
-                        gint button = atoi(btn_str);
-                        gint x = atoi(params[1]);
-                        gint y = atoi(params[2]);
+                        gint button = 0;
+                        gint x = 0;
+                        gint y = 0;
+                        if (!input_parse_sgr_int(btn_str, 0, 255, &button) ||
+                            !input_parse_sgr_int(params[1], 1, G_MAXINT, &x) ||
+                            !input_parse_sgr_int(params[2], 1, G_MAXINT, &y)) {
+                            event->type = INPUT_KEY_PRESS;
+                            event->key_code = KEY_UNKNOWN;
+                            goto finish_event;
+                        }
 
                         event->mouse_button = (MouseButton)button;
                         event->mouse_x = x;
@@ -566,18 +593,18 @@ gint input_read_key(InputHandler *handler) {
 
 
 // Read a single character
-gchar input_read_char(InputHandler *handler) {
+gint input_read_char(InputHandler *handler) {
     if (!handler) {
         return 0;
     }
 
-    gchar c;
+    unsigned char c;
     ssize_t n = read(STDIN_FILENO, &c, 1);
     return (n == 1) ? c : 0;
 }
 
 // Read a single character with timeout (in milliseconds)
-gchar input_read_char_with_timeout(InputHandler *handler, gint timeout_ms) {
+gint input_read_char_with_timeout(InputHandler *handler, gint timeout_ms) {
     if (!handler) {
         return 0;
     }
@@ -596,7 +623,7 @@ gchar input_read_char_with_timeout(InputHandler *handler, gint timeout_ms) {
     }
     
     if (FD_ISSET(STDIN_FILENO, &fds)) {
-        gchar c;
+        unsigned char c;
         ssize_t n = read(STDIN_FILENO, &c, 1);
         return (n == 1) ? c : 0;
     }
@@ -611,7 +638,7 @@ static gboolean input_discard_kitty_apc(InputHandler *handler) {
 
     const gint64 deadline = g_get_monotonic_time() + 100000;
     while (g_get_monotonic_time() < deadline) {
-        gchar ch = input_read_char_with_timeout(handler, 0);
+        gint ch = input_read_char_with_timeout(handler, 0);
         if (ch == 0) {
             return FALSE;
         }

--- a/src/input.c
+++ b/src/input.c
@@ -12,6 +12,8 @@
 static gboolean input_discard_kitty_apc(InputHandler *handler);
 static gboolean g_scroll_coalesce_active = FALSE;
 
+#define INPUT_SGR_MOUSE_BUTTON_MAX 255
+
 static gboolean input_parse_sgr_int(const gchar *text, gint min_value, gint max_value, gint *out_value) {
     if (!text || !out_value) {
         return FALSE;
@@ -348,11 +350,17 @@ ErrorCode input_get_event(InputHandler *handler, InputEvent *event) {
                         // Skip '<' if present in first parameter (SGR format)
                         gchar *btn_str = params[0];
                         if (btn_str[0] == '<') btn_str++;
+                        if (params[2]) {
+                            gsize y_len = strlen(params[2]);
+                            if (y_len > 0 && (params[2][y_len - 1] == 'M' || params[2][y_len - 1] == 'm')) {
+                                params[2][y_len - 1] = '\0';
+                            }
+                        }
                         
                         gint button = 0;
                         gint x = 0;
                         gint y = 0;
-                        if (!input_parse_sgr_int(btn_str, 0, 255, &button) ||
+                        if (!input_parse_sgr_int(btn_str, 0, INPUT_SGR_MOUSE_BUTTON_MAX, &button) ||
                             !input_parse_sgr_int(params[1], 1, G_MAXINT, &x) ||
                             !input_parse_sgr_int(params[2], 1, G_MAXINT, &y)) {
                             event->type = INPUT_KEY_PRESS;

--- a/src/input.c
+++ b/src/input.c
@@ -347,9 +347,13 @@ ErrorCode input_get_event(InputHandler *handler, InputEvent *event) {
                     }
 
                     if (param_count >= 3) {
-                        // Skip '<' if present in first parameter (SGR format)
                         gchar *btn_str = params[0];
-                        if (btn_str[0] == '<') btn_str++;
+                        if (btn_str[0] != '<') {
+                            event->type = INPUT_KEY_PRESS;
+                            event->key_code = KEY_UNKNOWN;
+                            goto finish_event;
+                        }
+                        btn_str++;
                         if (params[2]) {
                             gsize y_len = strlen(params[2]);
                             if (y_len > 0 && (params[2][y_len - 1] == 'M' || params[2][y_len - 1] == 'm')) {

--- a/src/input_dispatch_core.c
+++ b/src/input_dispatch_core.c
@@ -31,10 +31,14 @@ static void app_pause_video_for_resize(PixelTermApp *app) {
         return;
     }
     if (!input_dispatch_current_is_video(app)) {
+        app->video_was_playing_before_resize = FALSE;
         return;
     }
     if (video_player_is_playing(app->video_player)) {
+        app->video_was_playing_before_resize = TRUE;
         video_player_pause(app->video_player);
+    } else {
+        app->video_was_playing_before_resize = FALSE;
     }
 }
 

--- a/src/input_dispatch_core.c
+++ b/src/input_dispatch_core.c
@@ -37,8 +37,6 @@ static void app_pause_video_for_resize(PixelTermApp *app) {
     if (video_player_is_playing(app->video_player)) {
         app->video_was_playing_before_resize = TRUE;
         video_player_pause(app->video_player);
-    } else {
-        app->video_was_playing_before_resize = FALSE;
     }
 }
 

--- a/src/input_dispatch_key_single.c
+++ b/src/input_dispatch_key_single.c
@@ -175,11 +175,12 @@ static void handle_video_scale_change(PixelTermApp *app, gdouble delta) {
         return;
     }
     app->video_scale = next_scale;
+    gboolean was_playing = app->video_player && video_player_is_playing(app->video_player);
     if (app->video_player) {
         video_player_stop(app->video_player);
     }
     app_render_current_image(app);
-    if (app->video_player) {
+    if (was_playing && app->video_player) {
         video_player_play(app->video_player);
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -120,9 +120,14 @@ static ErrorCode run_application(PixelTermApp *app, gboolean alt_screen_enabled)
 
         if (resize_pending) {
             resize_pending = FALSE;
+            gboolean resume_video_after_resize = app->video_was_playing_before_resize;
+            app->video_was_playing_before_resize = FALSE;
             get_terminal_size(&app->term_width, &app->term_height);
             app->suppress_full_clear = FALSE;
             app_render_by_mode(app);
+            if (resume_video_after_resize && app->video_player) {
+                video_player_play(app->video_player);
+            }
             continue;
         }
         
@@ -216,7 +221,16 @@ int main(int argc, char *argv[]) {
     // Validate and classify startup path
     error = app_startup_classify_path(path, &startup);
     if (error != ERROR_NONE) {
-        fprintf(stderr, "Error: Path '%s' not found or inaccessible\n", path);
+        const char *display_path = path ? path : "current directory";
+        if (startup.failure_errno != 0) {
+            fprintf(stderr, "Error: Cannot open '%s': %s\n",
+                    display_path,
+                    g_strerror(startup.failure_errno));
+        } else if (error == ERROR_INVALID_IMAGE) {
+            fprintf(stderr, "Unsupported file type: %s\n", display_path);
+        } else {
+            fprintf(stderr, "Error: Path '%s' not found or inaccessible\n", display_path);
+        }
         app_destroy(g_app);
         g_free(path);
         return 1;
@@ -227,8 +241,7 @@ int main(int argc, char *argv[]) {
 
     gboolean is_directory = startup.kind == APP_STARTUP_PATH_DIRECTORY;
 
-    if (startup.kind == APP_STARTUP_PATH_DIRECTORY ||
-        startup.kind == APP_STARTUP_PATH_PARENT_DIRECTORY) {
+    if (startup.kind == APP_STARTUP_PATH_DIRECTORY) {
         error = app_load_directory(g_app, path);
         if (error == ERROR_NONE) {
             // Always start in file manager for directories

--- a/tests/test_app_cli.c
+++ b/tests/test_app_cli.c
@@ -684,6 +684,62 @@ static void test_cli_text_symbols_argument_parses_supported_modes(AppCliFixture 
     }
 }
 
+static void test_cli_protocol_argument_rejects_unknown_mode(AppCliFixture *fixture,
+                                                            gconstpointer user_data) {
+    (void)fixture;
+    (void)user_data;
+
+    AppConfig config;
+    gchar *path = NULL;
+    AppCliParseInvocation invocation = {0};
+    app_config_init(&config);
+
+    char *argv[] = {"pixelterm", "--protocol", "foo", NULL};
+
+    invocation.argv = argv;
+    invocation.path_out = &path;
+    invocation.config = &config;
+
+    gchar *stderr_output = capture_stderr(invoke_parse_cli_args, &invocation);
+
+    g_assert_cmpint(invocation.error, ==, ERROR_INVALID_ARGS);
+    g_assert_null(path);
+    g_assert_cmpstr(stderr_output,
+                    ==,
+                    "Invalid --protocol value: foo (expected auto, text, sixel, kitty, or iterm2)\n");
+
+    g_free(stderr_output);
+    g_free(path);
+}
+
+static void test_cli_text_symbols_argument_rejects_unknown_mode(AppCliFixture *fixture,
+                                                                gconstpointer user_data) {
+    (void)fixture;
+    (void)user_data;
+
+    AppConfig config;
+    gchar *path = NULL;
+    AppCliParseInvocation invocation = {0};
+    app_config_init(&config);
+
+    char *argv[] = {"pixelterm", "--text-symbols", "ascii", NULL};
+
+    invocation.argv = argv;
+    invocation.path_out = &path;
+    invocation.config = &config;
+
+    gchar *stderr_output = capture_stderr(invoke_parse_cli_args, &invocation);
+
+    g_assert_cmpint(invocation.error, ==, ERROR_INVALID_ARGS);
+    g_assert_null(path);
+    g_assert_cmpstr(stderr_output,
+                    ==,
+                    "Invalid --text-symbols value: ascii (expected auto, half, or quarter)\n");
+
+    g_free(stderr_output);
+    g_free(path);
+}
+
 static void test_cli_help_mentions_xdg_and_home_config_defaults(AppCliFixture *fixture,
                                                                 gconstpointer user_data) {
     (void)fixture;
@@ -1434,8 +1490,12 @@ void register_app_cli_tests(void) {
     add_app_cli_test("/app_cli/parse/help_mentions_xdg_and_home_config_defaults",
                      test_cli_help_mentions_xdg_and_home_config_defaults);
     add_app_cli_test("/app_cli/parse/protocol", test_cli_protocol_argument_parses_supported_modes);
+    add_app_cli_test("/app_cli/parse/protocol_rejects_unknown_mode",
+                     test_cli_protocol_argument_rejects_unknown_mode);
     add_app_cli_test("/app_cli/parse/text_symbols",
                      test_cli_text_symbols_argument_parses_supported_modes);
+    add_app_cli_test("/app_cli/parse/text_symbols_rejects_unknown_mode",
+                     test_cli_text_symbols_argument_rejects_unknown_mode);
     add_app_cli_test("/app_cli/parse/color_enhance",
                       test_cli_color_enhance_argument_parses_supported_modes);
     add_app_cli_test("/app_cli/parse/color_enhance_invalid",

--- a/tests/test_app_cli.c
+++ b/tests/test_app_cli.c
@@ -611,11 +611,11 @@ static void test_cli_invalid_boolean_values_return_error(AppCliFixture *fixture,
         if (strcmp(cases[i].option, "--preload") == 0) {
             g_assert_cmpstr(stderr_output,
                             ==,
-                            "Invalid --preload value: maybe (expected true/false)\n");
+                            "Invalid --preload value: maybe (expected true/false, yes/no, on/off, or 1/0)\n");
         } else {
             g_assert_cmpstr(stderr_output,
                             ==,
-                            "Invalid --alt-screen value: 2 (expected true/false)\n");
+                            "Invalid --alt-screen value: 2 (expected true/false, yes/no, on/off, or 1/0)\n");
         }
         g_free(stderr_output);
         g_free(path);
@@ -809,6 +809,45 @@ static void test_cli_default_config_applies_terminal_specific_precedence(AppCliF
     g_free(default_config_path);
 }
 
+static void test_cli_config_invalid_enum_lists_expected_values(AppCliFixture *fixture,
+                                                              gconstpointer user_data) {
+    (void)fixture;
+    (void)user_data;
+
+    gchar *config_path = write_temp_config_file(
+        "[default]\n"
+        "protocol=sixels\n");
+    AppConfig config;
+    gchar *path = NULL;
+    AppCliParseInvocation invocation = {0};
+    app_config_init(&config);
+
+    char *argv[] = {
+        "pixelterm",
+        "--config",
+        config_path,
+        NULL,
+    };
+
+    invocation.argv = argv;
+    invocation.path_out = &path;
+    invocation.config = &config;
+
+    gchar *stderr_output = capture_stderr(invoke_parse_cli_args, &invocation);
+    gchar *expected = g_strdup_printf(
+        "Invalid 'protocol' in config file '%s' group '[default]': sixels (expected auto, text, sixel, kitty, or iterm2)\n",
+        config_path);
+
+    g_assert_cmpint(invocation.error, ==, ERROR_INVALID_ARGS);
+    g_assert_null(path);
+    g_assert_cmpstr(stderr_output, ==, expected);
+
+    g_free(expected);
+    g_free(stderr_output);
+    g_free(path);
+    g_free(config_path);
+}
+
 static void test_cli_default_config_respects_runtime_xdg_after_glib_cache_prime(void) {
     pixelterm_env_reset_for_test();
     clear_app_cli_env();
@@ -986,12 +1025,23 @@ static void test_cli_kitty_transfer_argument_rejects_unknown_mode(AppCliFixture 
 
     AppConfig config;
     gchar *path = NULL;
+    AppCliParseInvocation invocation = {0};
     app_config_init(&config);
 
     char *argv[] = {"pixelterm", "--kitty-transfer", "pipe", NULL};
 
-    g_assert_cmpint(parse_cli_args(argv, &path, &config), ==, ERROR_INVALID_ARGS);
+    invocation.argv = argv;
+    invocation.path_out = &path;
+    invocation.config = &config;
+
+    gchar *stderr_output = capture_stderr(invoke_parse_cli_args, &invocation);
+
+    g_assert_cmpint(invocation.error, ==, ERROR_INVALID_ARGS);
     g_assert_null(path);
+    g_assert_cmpstr(stderr_output,
+                    ==,
+                    "Invalid --kitty-transfer value: pipe (expected auto, direct, or shm)\n");
+    g_free(stderr_output);
 }
 
 static void test_cli_color_enhance_argument_rejects_unknown_mode(AppCliFixture *fixture,
@@ -1001,12 +1051,23 @@ static void test_cli_color_enhance_argument_rejects_unknown_mode(AppCliFixture *
 
     AppConfig config;
     gchar *path = NULL;
+    AppCliParseInvocation invocation = {0};
     app_config_init(&config);
 
     char *argv[] = {"pixelterm", "--color-enhance", "neon", NULL};
 
-    g_assert_cmpint(parse_cli_args(argv, &path, &config), ==, ERROR_INVALID_ARGS);
+    invocation.argv = argv;
+    invocation.path_out = &path;
+    invocation.config = &config;
+
+    gchar *stderr_output = capture_stderr(invoke_parse_cli_args, &invocation);
+
+    g_assert_cmpint(invocation.error, ==, ERROR_INVALID_ARGS);
     g_assert_null(path);
+    g_assert_cmpstr(stderr_output,
+                    ==,
+                    "Invalid --color-enhance value: neon (expected off or vivid)\n");
+    g_free(stderr_output);
 }
 
 static void test_cli_double_dash_preserves_positional_config_like_path(AppCliFixture *fixture,
@@ -1030,6 +1091,39 @@ static void test_cli_double_dash_preserves_positional_config_like_path(AppCliFix
     g_assert_true(config.preload_enabled);
     g_assert_true(config.alt_screen_enabled);
     g_assert_cmpint(config.protocol_mode, ==, APP_PROTOCOL_AUTO);
+    g_free(path);
+}
+
+static void test_cli_rejects_extra_positional_arguments(AppCliFixture *fixture,
+                                                        gconstpointer user_data) {
+    (void)fixture;
+    (void)user_data;
+
+    AppConfig config;
+    gchar *path = NULL;
+    AppCliParseInvocation invocation = {0};
+    app_config_init(&config);
+
+    char *argv[] = {
+        "pixelterm",
+        "image1.png",
+        "image2.png",
+        NULL,
+    };
+
+    invocation.argv = argv;
+    invocation.path_out = &path;
+    invocation.config = &config;
+
+    gchar *stderr_output = capture_stderr(invoke_parse_cli_args, &invocation);
+
+    g_assert_cmpint(invocation.error, ==, ERROR_INVALID_ARGS);
+    g_assert_null(path);
+    g_assert_cmpstr(stderr_output,
+                    ==,
+                    "Unexpected argument: image2.png\nUse --help for usage information\n");
+
+    g_free(stderr_output);
     g_free(path);
 }
 
@@ -1335,6 +1429,8 @@ void register_app_cli_tests(void) {
     add_app_cli_test("/app_cli/parse/invalid_boolean_values", test_cli_invalid_boolean_values_return_error);
     add_app_cli_test("/app_cli/parse/double_dash_preserves_positional_config_like_path",
                      test_cli_double_dash_preserves_positional_config_like_path);
+    add_app_cli_test("/app_cli/parse/rejects_extra_positional_arguments",
+                     test_cli_rejects_extra_positional_arguments);
     add_app_cli_test("/app_cli/parse/help_mentions_xdg_and_home_config_defaults",
                      test_cli_help_mentions_xdg_and_home_config_defaults);
     add_app_cli_test("/app_cli/parse/protocol", test_cli_protocol_argument_parses_supported_modes);
@@ -1367,5 +1463,7 @@ void register_app_cli_tests(void) {
     add_app_cli_test("/app_cli/config/apply_runtime_copies_app_fields",
                      test_cli_apply_runtime_copies_app_owned_config_fields);
     add_app_cli_test("/app_cli/config/default_file_terminal_precedence", test_cli_default_config_applies_terminal_specific_precedence);
+    add_app_cli_test("/app_cli/config/invalid_enum_lists_expected_values",
+                     test_cli_config_invalid_enum_lists_expected_values);
     add_app_cli_test("/app_cli/config/cli_overrides_loaded_values", test_cli_flags_override_loaded_config_values);
 }

--- a/tests/test_app_file_manager.c
+++ b/tests/test_app_file_manager.c
@@ -12,6 +12,7 @@
 static const guint8 k_png_data[] = {
     0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A
 };
+static GList *g_browser_test_files = NULL;
 
 typedef void (*RenderCaptureFunc)(gpointer user_data);
 
@@ -48,7 +49,7 @@ static void render_file_manager_capture(gpointer user_data) {
 }
 
 FileBrowser *browser_create(void) {
-    return NULL;
+    return (FileBrowser *)0x1;
 }
 
 void browser_destroy(FileBrowser *browser) {
@@ -63,12 +64,12 @@ ErrorCode browser_scan_directory(FileBrowser *browser, const char *directory) {
 
 GList *browser_get_all_files(const FileBrowser *browser) {
     (void)browser;
-    return NULL;
+    return g_browser_test_files;
 }
 
 gint browser_get_total_files(const FileBrowser *browser) {
     (void)browser;
-    return 0;
+    return g_list_length(g_browser_test_files);
 }
 
 BookDocument *book_open(const char *filepath, ErrorCode *out_error) {
@@ -177,6 +178,21 @@ static gchar *write_file_in_dir(const gchar *dir, const gchar *name, const guint
     return path;
 }
 
+static gchar *write_png_file_in_dir(const gchar *dir, const gchar *name) {
+    static const gchar k_png_base64[] =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNg"
+        "YAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+    gsize len = 0;
+    guchar *data = g_base64_decode(k_png_base64, &len);
+    if (!data || len == 0) {
+        g_error("Failed to decode PNG data");
+    }
+
+    gchar *path = write_file_in_dir(dir, name, data, len);
+    g_free(data);
+    return path;
+}
+
 static gchar *create_dir_in_dir(const gchar *dir, const gchar *name) {
     gchar *path = g_build_filename(dir, name, NULL);
     g_assert_cmpint(g_mkdir(path, 0700), ==, 0);
@@ -202,6 +218,12 @@ static void cleanup_file_manager_app(PixelTermApp *app) {
         app->file_manager.entries = NULL;
     }
     g_clear_pointer(&app->file_manager.directory, g_free);
+}
+
+static void clear_browser_test_files(gpointer data) {
+    (void)data;
+    g_list_free_full(g_browser_test_files, g_free);
+    g_browser_test_files = NULL;
 }
 
 static const gchar *selected_path(const PixelTermApp *app) {
@@ -341,6 +363,39 @@ static void test_refresh_preserves_explicit_parent_selection(void) {
     g_assert_cmpstr(basename, ==, "..");
 
     g_free(basename);
+    cleanup_file_manager_app(&app);
+    g_free(a_png);
+    g_free(dir);
+}
+
+static void test_refresh_failure_preserves_previous_directory_and_entries(void) {
+    gchar *dir = create_temp_dir();
+    gchar *a_png = write_file_in_dir(dir, "a.png", k_png_data, sizeof(k_png_data));
+    gchar *missing_dir = g_build_filename(dir, "missing", NULL);
+    PixelTermApp app = {0};
+    gchar *old_directory = NULL;
+    GList *old_entries = NULL;
+    gint old_entries_count = 0;
+
+    init_file_manager_app(&app, dir, 24);
+
+    g_assert_cmpint(app_file_manager_refresh(&app), ==, ERROR_NONE);
+    g_assert_cmpint(app_file_manager_select_path(&app, a_png), ==, ERROR_NONE);
+    old_directory = g_strdup(app.file_manager.directory);
+    old_entries = app.file_manager.entries;
+    old_entries_count = app.file_manager.entries_count;
+
+    g_free(app.file_manager.directory);
+    app.file_manager.directory = g_strdup(missing_dir);
+
+    g_assert_cmpint(app_file_manager_refresh(&app), ==, ERROR_FILE_NOT_FOUND);
+    g_assert_cmpstr(app.file_manager.directory, ==, old_directory);
+    g_assert_true(app.file_manager.entries == old_entries);
+    g_assert_cmpint(app.file_manager.entries_count, ==, old_entries_count);
+    g_assert_cmpstr(selected_path(&app), ==, a_png);
+
+    g_free(old_directory);
+    g_free(missing_dir);
     cleanup_file_manager_app(&app);
     g_free(a_png);
     g_free(dir);
@@ -494,6 +549,32 @@ static void test_enter_parent_entry_selects_directory_just_left(void) {
     g_free(dir);
 }
 
+static void test_load_single_file_matches_full_canonical_path_before_basename(void) {
+    gchar *target_dir = create_temp_dir();
+    gchar *other_dir = create_temp_dir();
+    gchar *target_png = write_png_file_in_dir(target_dir, "same.png");
+    gchar *other_png = write_png_file_in_dir(other_dir, "same.png");
+    PixelTermApp app = {0};
+
+    clear_browser_test_files(NULL);
+    g_test_queue_destroy(clear_browser_test_files, NULL);
+    g_browser_test_files = g_list_append(g_browser_test_files, g_strdup(other_png));
+    g_browser_test_files = g_list_append(g_browser_test_files, g_strdup(target_png));
+
+    app.preload_enabled = FALSE;
+    app.preview.selected_link_index = -1;
+
+    g_assert_cmpint(app_load_single_file(&app, target_png), ==, ERROR_NONE);
+    g_assert_cmpstr((const gchar *)g_list_nth_data(app.image_files, app.current_index), ==, target_png);
+
+    g_list_free_full(app.image_files, g_free);
+    g_free(app.current_directory);
+    g_free(target_png);
+    g_free(other_png);
+    g_free(target_dir);
+    g_free(other_dir);
+}
+
 static void test_render_selected_row_uses_full_width_highlight_with_size(void) {
     gchar *dir = create_temp_dir();
     gchar *a_png = write_file_in_dir(dir, "a.png", k_png_data, sizeof(k_png_data));
@@ -555,6 +636,8 @@ int main(int argc, char **argv) {
                     test_refresh_adjusts_selection_after_selected_file_is_removed);
     g_test_add_func("/app_file_manager/refresh/preserves_explicit_parent_selection",
                     test_refresh_preserves_explicit_parent_selection);
+    g_test_add_func("/app_file_manager/refresh/failure_preserves_previous_directory_and_entries",
+                    test_refresh_failure_preserves_previous_directory_and_entries);
     g_test_add_func("/app_file_manager/toggle_hidden/preserves_visible_selection",
                     test_toggle_hidden_preserves_visible_selection);
     g_test_add_func("/app_file_manager/toggle_hidden/clamps_selection_when_hidden_entry_disappears_after_preview_return",
@@ -565,6 +648,8 @@ int main(int argc, char **argv) {
                     test_enter_child_directory_defaults_to_first_real_entry);
     g_test_add_func("/app_file_manager/enter/parent_entry_selects_directory_just_left",
                     test_enter_parent_entry_selects_directory_just_left);
+    g_test_add_func("/app_core/load_single_file/matches_full_canonical_path_before_basename",
+                    test_load_single_file_matches_full_canonical_path_before_basename);
     g_test_add_func("/app_file_manager/render/selected_row_uses_full_width_highlight_with_size",
                     test_render_selected_row_uses_full_width_highlight_with_size);
     g_test_add_func("/app_file_manager/render/marks_directory_containing_media",

--- a/tests/test_app_single_render_integration.c
+++ b/tests/test_app_single_render_integration.c
@@ -16,6 +16,7 @@ typedef struct {
     gint video_load_calls;
     gint video_play_calls;
     gint renderer_render_file_calls;
+    ErrorCode video_load_result;
     gboolean last_force_text;
     gboolean last_force_kitty;
     gboolean last_force_iterm2;
@@ -102,6 +103,7 @@ static const AppSingleRenderTestHooks k_app_single_render_test_hooks = {
 
 static void app_single_render_reset_stubs(void) {
     memset(&g_app_single_render_stub_state, 0, sizeof(g_app_single_render_stub_state));
+    g_app_single_render_stub_state.video_load_result = ERROR_NONE;
 }
 
 static void destroy_render_test_app(PixelTermApp *app) {
@@ -197,6 +199,25 @@ static void test_single_view_render_switches_media_players(void) {
     g_assert_false(app.video_player->is_playing);
     g_assert_false(app.gif_player->is_playing);
     g_assert_cmpint(g_app_single_render_stub_state.renderer_render_file_calls, ==, 2);
+
+    destroy_render_test_app(&app);
+}
+
+static void test_single_view_video_load_failure_does_not_fallback_to_image_render(void) {
+    PixelTermApp app = {0};
+    if (!init_render_test_app(&app)) {
+        g_test_skip("media players unavailable");
+        return;
+    }
+
+    app_single_render_reset_stubs();
+    g_app_single_render_stub_state.video_load_result = ERROR_INVALID_IMAGE;
+    app.current_index = 0;
+
+    g_assert_cmpint(app_render_current_image(&app), ==, ERROR_INVALID_IMAGE);
+    g_assert_cmpint(g_app_single_render_stub_state.video_load_calls, ==, 1);
+    g_assert_cmpint(g_app_single_render_stub_state.video_play_calls, ==, 0);
+    g_assert_cmpint(g_app_single_render_stub_state.renderer_render_file_calls, ==, 0);
 
     destroy_render_test_app(&app);
 }
@@ -517,6 +538,8 @@ void register_app_single_render_integration_tests(void) {
                     test_file_size_display_clamps_missing_values);
     g_test_add_func("/app_single_render/single_view/switches_media_players",
                     test_single_view_render_switches_media_players);
+    g_test_add_func("/app_single_render/single_view/video_load_failure_does_not_fallback_to_image_render",
+                    test_single_view_video_load_failure_does_not_fallback_to_image_render);
     g_test_add_func("/app_single_render/single_view/visible_shell_preserves_current_layout_contract",
                     test_single_view_visible_shell_preserves_current_layout_contract);
     g_test_add_func("/app_single_render/info_overlay/preserves_visibility_on_redraw",
@@ -648,7 +671,7 @@ static ErrorCode test_video_player_load(VideoPlayer *player, const gchar *filepa
     player->filepath = g_strdup(filepath);
     player->has_video = TRUE;
     g_app_single_render_stub_state.video_load_calls++;
-    return ERROR_NONE;
+    return g_app_single_render_stub_state.video_load_result;
 }
 
 static ErrorCode test_video_player_play(VideoPlayer *player) {

--- a/tests/test_app_startup.c
+++ b/tests/test_app_startup.c
@@ -1,5 +1,6 @@
 #include <glib.h>
 #include <glib/gstdio.h>
+#include <errno.h>
 #include <unistd.h>
 
 #include "app_startup.h"
@@ -112,6 +113,7 @@ static void test_classify_path_rejects_missing_path(void) {
 
     g_assert_cmpint(error, ==, ERROR_FILE_NOT_FOUND);
     g_assert_null(decision.path);
+    g_assert_cmpint(decision.failure_errno, ==, ENOENT);
 
     g_free(missing_path);
 }
@@ -166,7 +168,7 @@ static void test_classify_path_media_returns_media_target(void) {
     g_free(temp_dir);
 }
 
-static void test_classify_path_non_media_file_falls_back_to_parent_directory(void) {
+static void test_classify_path_rejects_non_media_file(void) {
     static const guint8 k_text[] = {'n', 'o', 't', 'e'};
     AppStartupPathDecision decision = {0};
     gchar *temp_dir = make_temp_dir();
@@ -174,16 +176,15 @@ static void test_classify_path_non_media_file_falls_back_to_parent_directory(voi
 
     ErrorCode error = app_startup_classify_path(text_path, &decision);
 
-    g_assert_cmpint(error, ==, ERROR_NONE);
-    g_assert_cmpint(decision.kind, ==, APP_STARTUP_PATH_PARENT_DIRECTORY);
-    g_assert_cmpstr(decision.path, ==, temp_dir);
+    g_assert_cmpint(error, ==, ERROR_INVALID_IMAGE);
+    g_assert_null(decision.path);
 
     g_free(decision.path);
     g_free(text_path);
     g_free(temp_dir);
 }
 
-static void test_classify_relative_non_media_file_returns_canonical_parent_directory(void) {
+static void test_classify_relative_non_media_file_is_rejected(void) {
     static const guint8 k_text[] = {'n', 'o', 't', 'e'};
     AppStartupPathDecision decision = {0};
     gchar *original_dir = g_get_current_dir();
@@ -199,19 +200,16 @@ static void test_classify_relative_non_media_file_returns_canonical_parent_direc
 
     g_assert_cmpint(g_chdir(temp_dir), ==, 0);
     current_dir = g_get_current_dir();
-    expected_dir = g_build_filename(current_dir, "nested", NULL);
     text_path = write_temp_file(nested_dir, "note.txt", k_text, sizeof(k_text));
     (void)text_path;
 
     ErrorCode error = app_startup_classify_path("nested/note.txt", &decision);
 
-    g_assert_cmpint(error, ==, ERROR_NONE);
-    g_assert_cmpint(decision.kind, ==, APP_STARTUP_PATH_PARENT_DIRECTORY);
-    g_assert_cmpstr(decision.path, ==, expected_dir);
+    g_assert_cmpint(error, ==, ERROR_INVALID_IMAGE);
+    g_assert_null(decision.path);
 
     g_assert_cmpint(g_chdir(original_dir), ==, 0);
     g_free(current_dir);
-    g_free(expected_dir);
     g_free(nested_dir);
     g_free(original_dir);
     g_free(decision.path);
@@ -230,8 +228,8 @@ void register_app_startup_tests(void) {
                     test_classify_path_book_returns_book_target);
     g_test_add_func("/app_startup/classify/media",
                     test_classify_path_media_returns_media_target);
-    g_test_add_func("/app_startup/classify/non_media_parent_directory",
-                    test_classify_path_non_media_file_falls_back_to_parent_directory);
-    g_test_add_func("/app_startup/classify/relative_non_media_parent_directory",
-                    test_classify_relative_non_media_file_returns_canonical_parent_directory);
+    g_test_add_func("/app_startup/classify/non_media_rejected",
+                    test_classify_path_rejects_non_media_file);
+    g_test_add_func("/app_startup/classify/relative_non_media_rejected",
+                    test_classify_relative_non_media_file_is_rejected);
 }

--- a/tests/test_input_dispatch_core.c
+++ b/tests/test_input_dispatch_core.c
@@ -247,6 +247,7 @@ static void test_pause_video_for_resize_records_playing_state(void) {
 
     app.mode = APP_MODE_SINGLE;
     app.video_player = &player;
+    g_mutex_init(&player.state_mutex);
     player.has_video = TRUE;
     player.is_playing = TRUE;
 
@@ -257,6 +258,8 @@ static void test_pause_video_for_resize_records_playing_state(void) {
 
     g_assert_false(player.is_playing);
     g_assert_true(app.video_was_playing_before_resize);
+
+    g_mutex_clear(&player.state_mutex);
 }
 
 static void test_pause_video_for_resize_does_not_record_paused_video(void) {
@@ -265,6 +268,7 @@ static void test_pause_video_for_resize_does_not_record_paused_video(void) {
 
     app.mode = APP_MODE_SINGLE;
     app.video_player = &player;
+    g_mutex_init(&player.state_mutex);
     player.has_video = TRUE;
     player.is_playing = FALSE;
 
@@ -275,6 +279,30 @@ static void test_pause_video_for_resize_does_not_record_paused_video(void) {
 
     g_assert_false(player.is_playing);
     g_assert_false(app.video_was_playing_before_resize);
+
+    g_mutex_clear(&player.state_mutex);
+}
+
+static void test_pause_video_for_resize_keeps_playing_state_across_repeated_resize_events(void) {
+    PixelTermApp app = {0};
+    VideoPlayer player = {0};
+
+    app.mode = APP_MODE_SINGLE;
+    app.video_player = &player;
+    g_mutex_init(&player.state_mutex);
+    player.has_video = TRUE;
+    player.is_playing = TRUE;
+
+    input_dispatch_test_reset_stubs();
+    g_input_dispatch_stub_state.current_is_video = TRUE;
+
+    input_dispatch_core_pause_video_for_resize(&app);
+    input_dispatch_core_pause_video_for_resize(&app);
+
+    g_assert_false(player.is_playing);
+    g_assert_true(app.video_was_playing_before_resize);
+
+    g_mutex_clear(&player.state_mutex);
 }
 
 void register_input_dispatch_core_tests(void) {
@@ -302,4 +330,6 @@ void register_input_dispatch_core_tests(void) {
                     test_pause_video_for_resize_records_playing_state);
     g_test_add_func("/input_dispatch_core/resize/pause_video_does_not_record_paused_video",
                     test_pause_video_for_resize_does_not_record_paused_video);
+    g_test_add_func("/input_dispatch_core/resize/pause_video_keeps_playing_state_across_repeated_resize_events",
+                    test_pause_video_for_resize_keeps_playing_state_across_repeated_resize_events);
 }

--- a/tests/test_input_dispatch_core.c
+++ b/tests/test_input_dispatch_core.c
@@ -241,6 +241,42 @@ static void test_mouse_closing_help_resets_input_timing_state(void) {
     g_assert_cmpint(input_handler.ignore_input_until_us, ==, 0);
 }
 
+static void test_pause_video_for_resize_records_playing_state(void) {
+    PixelTermApp app = {0};
+    VideoPlayer player = {0};
+
+    app.mode = APP_MODE_SINGLE;
+    app.video_player = &player;
+    player.has_video = TRUE;
+    player.is_playing = TRUE;
+
+    input_dispatch_test_reset_stubs();
+    g_input_dispatch_stub_state.current_is_video = TRUE;
+
+    input_dispatch_core_pause_video_for_resize(&app);
+
+    g_assert_false(player.is_playing);
+    g_assert_true(app.video_was_playing_before_resize);
+}
+
+static void test_pause_video_for_resize_does_not_record_paused_video(void) {
+    PixelTermApp app = {0};
+    VideoPlayer player = {0};
+
+    app.mode = APP_MODE_SINGLE;
+    app.video_player = &player;
+    player.has_video = TRUE;
+    player.is_playing = FALSE;
+
+    input_dispatch_test_reset_stubs();
+    g_input_dispatch_stub_state.current_is_video = TRUE;
+
+    input_dispatch_core_pause_video_for_resize(&app);
+
+    g_assert_false(player.is_playing);
+    g_assert_false(app.video_was_playing_before_resize);
+}
+
 void register_input_dispatch_core_tests(void) {
     g_test_add_func("/input_dispatch_core/process_animations/only_runs_one_iteration_per_call",
                     test_process_animations_only_runs_one_iteration_per_call);
@@ -262,4 +298,8 @@ void register_input_dispatch_core_tests(void) {
                     test_any_key_closes_help_overlay_without_mode_action);
     g_test_add_func("/input_dispatch_core/help_key/mouse_closing_help_resets_input_timing_state",
                     test_mouse_closing_help_resets_input_timing_state);
+    g_test_add_func("/input_dispatch_core/resize/pause_video_records_playing_state",
+                    test_pause_video_for_resize_records_playing_state);
+    g_test_add_func("/input_dispatch_core/resize/pause_video_does_not_record_paused_video",
+                    test_pause_video_for_resize_does_not_record_paused_video);
 }

--- a/tests/test_input_dispatch_key_single.c
+++ b/tests/test_input_dispatch_key_single.c
@@ -348,6 +348,18 @@ static void test_input_rejects_malformed_sgr_mouse_parameters(void) {
     g_assert_cmpint(event.key_code, ==, KEY_UNKNOWN);
 }
 
+static void test_input_rejects_mouse_sequence_without_sgr_prefix(void) {
+    static const gchar malformed_mouse[] = "\033[0;12;7M";
+    InputHandler input_handler = {0};
+    InputEvent event = {0};
+
+    redirect_stdin_bytes(malformed_mouse, sizeof(malformed_mouse) - 1);
+
+    g_assert_cmpint(input_get_event(&input_handler, &event), ==, ERROR_NONE);
+    g_assert_cmpint(event.type, ==, INPUT_KEY_PRESS);
+    g_assert_cmpint(event.key_code, ==, KEY_UNKNOWN);
+}
+
 static void test_input_parses_sgr_mouse_press_with_terminator(void) {
     static const gchar mouse_press[] = "\033[<0;12;7M";
     InputHandler input_handler = {0};
@@ -427,6 +439,8 @@ void register_input_dispatch_key_single_tests(void) {
                     test_input_maps_fullwidth_tilde_to_zen_key);
     g_test_add_func("/input/rejects_malformed_sgr_mouse_parameters",
                     test_input_rejects_malformed_sgr_mouse_parameters);
+    g_test_add_func("/input/rejects_mouse_sequence_without_sgr_prefix",
+                    test_input_rejects_mouse_sequence_without_sgr_prefix);
     g_test_add_func("/input/parses_sgr_mouse_press_with_terminator",
                     test_input_parses_sgr_mouse_press_with_terminator);
 }

--- a/tests/test_input_dispatch_key_single.c
+++ b/tests/test_input_dispatch_key_single.c
@@ -348,6 +348,20 @@ static void test_input_rejects_malformed_sgr_mouse_parameters(void) {
     g_assert_cmpint(event.key_code, ==, KEY_UNKNOWN);
 }
 
+static void test_input_parses_sgr_mouse_press_with_terminator(void) {
+    static const gchar mouse_press[] = "\033[<0;12;7M";
+    InputHandler input_handler = {0};
+    InputEvent event = {0};
+
+    redirect_stdin_bytes(mouse_press, sizeof(mouse_press) - 1);
+
+    g_assert_cmpint(input_get_event(&input_handler, &event), ==, ERROR_NONE);
+    g_assert_cmpint(event.type, ==, INPUT_MOUSE_PRESS);
+    g_assert_cmpint(event.mouse_button, ==, MOUSE_BUTTON_LEFT);
+    g_assert_cmpint(event.mouse_x, ==, 12);
+    g_assert_cmpint(event.mouse_y, ==, 7);
+}
+
 typedef struct {
     PixelTermApp *app;
 } ToggleVideoFpsCall;
@@ -413,4 +427,6 @@ void register_input_dispatch_key_single_tests(void) {
                     test_input_maps_fullwidth_tilde_to_zen_key);
     g_test_add_func("/input/rejects_malformed_sgr_mouse_parameters",
                     test_input_rejects_malformed_sgr_mouse_parameters);
+    g_test_add_func("/input/parses_sgr_mouse_press_with_terminator",
+                    test_input_parses_sgr_mouse_press_with_terminator);
 }

--- a/tests/test_input_dispatch_key_single.c
+++ b/tests/test_input_dispatch_key_single.c
@@ -263,6 +263,30 @@ static void test_video_up_and_down_keep_media_switching(void) {
     input_dispatch_key_single_set_video_seek_for_test(NULL);
 }
 
+static void test_video_scale_keeps_paused_video_paused(void) {
+    VideoPlayer player = {0};
+    PixelTermApp app = make_single_app(&player);
+    InputEvent event = make_key_event((KeyCode)'-');
+
+    app.term_width = 120;
+    app.term_height = 40;
+    app.video_scale = 1.0;
+    player.filepath = g_strdup("clip.mp4");
+    player.is_playing = FALSE;
+
+    input_dispatch_test_reset_stubs();
+    g_input_dispatch_stub_state.current_is_video = TRUE;
+    input_dispatch_key_single_set_video_seek_for_test(input_dispatch_test_video_seek);
+
+    input_dispatch_handle_key_press_single(&app, NULL, &event);
+
+    g_assert_cmpfloat_with_epsilon(app.video_scale, 0.9, 0.0001);
+    g_assert_false(player.is_playing);
+
+    g_free(player.filepath);
+    input_dispatch_key_single_set_video_seek_for_test(NULL);
+}
+
 static void test_navigation_failure_does_not_refresh_or_advance_queue(void) {
     PixelTermApp app = make_single_app(NULL);
     InputEvent event = make_key_event(KEY_RIGHT);
@@ -298,6 +322,30 @@ static void test_input_maps_fullwidth_question_to_help_key(void) {
     g_assert_cmpint(input_get_event(&input_handler, &event), ==, ERROR_NONE);
     g_assert_cmpint(event.type, ==, INPUT_KEY_PRESS);
     g_assert_cmpint(event.key_code, ==, (KeyCode)'?');
+}
+
+static void test_input_maps_fullwidth_tilde_to_zen_key(void) {
+    static const gchar fullwidth_tilde[] = "\xEF\xBD\x9E";
+    InputHandler input_handler = {0};
+    InputEvent event = {0};
+
+    redirect_stdin_bytes(fullwidth_tilde, sizeof(fullwidth_tilde) - 1);
+
+    g_assert_cmpint(input_get_event(&input_handler, &event), ==, ERROR_NONE);
+    g_assert_cmpint(event.type, ==, INPUT_KEY_PRESS);
+    g_assert_cmpint(event.key_code, ==, (KeyCode)'~');
+}
+
+static void test_input_rejects_malformed_sgr_mouse_parameters(void) {
+    static const gchar malformed_mouse[] = "\033[<9999999999;2;1M";
+    InputHandler input_handler = {0};
+    InputEvent event = {0};
+
+    redirect_stdin_bytes(malformed_mouse, sizeof(malformed_mouse) - 1);
+
+    g_assert_cmpint(input_get_event(&input_handler, &event), ==, ERROR_NONE);
+    g_assert_cmpint(event.type, ==, INPUT_KEY_PRESS);
+    g_assert_cmpint(event.key_code, ==, KEY_UNKNOWN);
 }
 
 typedef struct {
@@ -353,10 +401,16 @@ void register_input_dispatch_key_single_tests(void) {
                     test_video_seek_failure_preserves_queued_repeats_for_retry);
     g_test_add_func("/input_dispatch_key_single/video/up_and_down_keep_media_switching",
                     test_video_up_and_down_keep_media_switching);
+    g_test_add_func("/input_dispatch_key_single/video/scale_keeps_paused_video_paused",
+                    test_video_scale_keeps_paused_video_paused);
     g_test_add_func("/input_dispatch_key_single/video/fps_second_toggle_restores_stats_row",
                     test_video_fps_second_toggle_restores_stats_row);
     g_test_add_func("/input_dispatch_key_single/navigation/failure_does_not_refresh_or_advance_queue",
                     test_navigation_failure_does_not_refresh_or_advance_queue);
     g_test_add_func("/input/input_maps_fullwidth_question_to_help_key",
                     test_input_maps_fullwidth_question_to_help_key);
+    g_test_add_func("/input/input_maps_fullwidth_tilde_to_zen_key",
+                    test_input_maps_fullwidth_tilde_to_zen_key);
+    g_test_add_func("/input/rejects_malformed_sgr_mouse_parameters",
+                    test_input_rejects_malformed_sgr_mouse_parameters);
 }


### PR DESCRIPTION
## Summary
- Reject unsupported startup files instead of silently opening the parent directory, while preserving stat errno for clearer path errors.
- Harden input and CLI edge cases: strict SGR mouse parsing, unsigned input bytes, extra positional arg rejection, and clearer config/CLI enum errors.
- Preserve video pause state across scale/resize flows, keep file-manager refresh failures from corrupting state, and factor common mode-entry cleanup.
- Organize test link objects in the Makefile and document manual checksum verification.

## Review Follow-up
- Fixed incompatible g_test_queue_destroy callback signature in file-manager tests.
- Removed stale APP_STARTUP_PATH_PARENT_DIRECTORY enum after removing fallback behavior.

## Testing
- rtk make test

Co-Authored-By: Warp <agent@warp.dev>

## Summary by Sourcery

在强化启动阶段的校验、输入处理以及视频/文件管理器行为的同时，改进 CLI/配置/安装相关错误信息，并整理共享的测试与链接基础设施。

Bug 修复：
- 拒绝不支持的启动文件，并返回明确、基于 errno 的错误，而不是回退到父目录。
- 确保文件管理器刷新失败时能保留之前的目录、条目以及选中状态。
- 在尺寸调整和缩放操作中保持视频暂停状态不变，并在视频加载失败时避免静默退回到图片渲染。
- 将格式错误的 SGR 鼠标序列和无效输入字节视为未知输入事件，而不是被误解析为鼠标动作。
- 拒绝多余的 CLI 位置参数，并对 protocol、text symbols、color enhance 和 kitty-transfer 等枚举选项进行校验，明确给出期望值。

功能增强：
- 把共享的模式退出清理逻辑抽取到一个辅助函数中，用于停止媒体、隐藏叠加层，并在需要时清空预加载队列。
- 在加载单个文件时优先使用完整的规范路径匹配，以避免跨目录的同名文件冲突。
- 明确 CLI、配置和安装器的错误信息，包括布尔选项的变体说明以及对不支持的安装标志的使用提示。
- 重构 Makefile 中的测试链接对象，将其整理为可复用的、按组件划分的分组，覆盖 common、render、media、input、app 和 terminal 代码。

文档：
- 记录安装器使用 SHA256SUMS 进行校验的流程，并刷新 README 中的使用示例和固定版本说明。

测试：
- 扩展围绕 CLI 解析、配置枚举、启动分类 errno 传播、文件管理器刷新行为、单文件规范路径匹配、视频尺寸调整/缩放流程、输入边界情况以及安装器参数处理的测试用例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden startup validation, input handling, and video/file-manager behavior, while improving CLI/config/install error messages and organizing shared test/link infrastructure.

Bug Fixes:
- Reject unsupported startup files with clear errno-backed errors instead of falling back to parent directories.
- Ensure file-manager refresh failures preserve the previous directory, entries, and selection state.
- Keep paused video state intact across resize and scale operations and avoid silently falling back to image rendering on video load failures.
- Treat malformed SGR mouse sequences and invalid input bytes as unknown input events instead of misparsed mouse actions.
- Reject extra CLI positional arguments and validate enum options for protocol, text symbols, color enhance, and kitty-transfer with explicit expected values.

Enhancements:
- Factor shared mode-entry cleanup into a helper that stops media, hides overlays, and optionally clears the preloader queue.
- Prefer full canonical-path matching when loading a single file to avoid basename clashes across directories.
- Clarify CLI, config, and installer error messages, including boolean option variants and guidance for unsupported install flags.
- Refactor Makefile test link objects into reusable component-based groups for common, render, media, input, app, and terminal code.

Documentation:
- Document installer checksum verification using SHA256SUMS and refresh README usage examples and pinned version guidance.

Tests:
- Expand tests around CLI parsing, config enums, startup classification errno propagation, file-manager refresh behavior, single-file canonical matching, video resize/scale flows, input edge cases, and installer argument handling.

</details>

Bug 修复：
- 拒绝不支持的启动文件，而不是回退到父目录，并在路径错误信息中暴露底层的 errno。
- 确保文件管理器刷新失败时保留之前的目录、条目和选中状态，而不是破坏现有状态。
- 在调整终端大小或更改视频缩放时保留已暂停的视频状态，避免视频在这些操作中被意外恢复播放。
- 防止单视图视频加载失败时默默回退到以图像方式渲染。
- 将格式错误的 SGR 鼠标序列和无效输入字节视为未知输入，而不是被误解析为事件。
- 拒绝多余的 CLI 位置参数，并对 protocol、text symbols、color enhance 和 kitty-transfer 选项的枚举值进行有效性校验。

Enhancements（增强功能）：
- 将通用的模式退出清理逻辑提取为一个辅助函数，用于停止媒体、隐藏叠加层，并在需要时清空预加载队列。
- 在加载单个文件时，优先使用完整规范路径匹配，以避免不同目录之间仅按文件名匹配造成的冲突。
- 明确 CLI、配置和安装程序中的错误信息，提供明确的期望值和使用指导，包括布尔选项的变体说明以及安装参数帮助。
- 重构 Makefile 中测试的链接对象，将其按 common、render、media、input、app 和 terminal 组件分组为可共享的集合。

Documentation（文档）：
- 记录安装程序的校验和验证流程，包括手动使用 SHA256SUMS，并刷新 README 中的示例和使用说明。

Tests（测试）：
- 扩展对 CLI、启动流程、文件管理器、输入、视频、安装程序以及单文件加载的测试覆盖，以捕获新增的边缘情况和错误处理行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在强化启动阶段的校验、输入处理以及视频/文件管理器行为的同时，改进 CLI/配置/安装相关错误信息，并整理共享的测试与链接基础设施。

Bug 修复：
- 拒绝不支持的启动文件，并返回明确、基于 errno 的错误，而不是回退到父目录。
- 确保文件管理器刷新失败时能保留之前的目录、条目以及选中状态。
- 在尺寸调整和缩放操作中保持视频暂停状态不变，并在视频加载失败时避免静默退回到图片渲染。
- 将格式错误的 SGR 鼠标序列和无效输入字节视为未知输入事件，而不是被误解析为鼠标动作。
- 拒绝多余的 CLI 位置参数，并对 protocol、text symbols、color enhance 和 kitty-transfer 等枚举选项进行校验，明确给出期望值。

功能增强：
- 把共享的模式退出清理逻辑抽取到一个辅助函数中，用于停止媒体、隐藏叠加层，并在需要时清空预加载队列。
- 在加载单个文件时优先使用完整的规范路径匹配，以避免跨目录的同名文件冲突。
- 明确 CLI、配置和安装器的错误信息，包括布尔选项的变体说明以及对不支持的安装标志的使用提示。
- 重构 Makefile 中的测试链接对象，将其整理为可复用的、按组件划分的分组，覆盖 common、render、media、input、app 和 terminal 代码。

文档：
- 记录安装器使用 SHA256SUMS 进行校验的流程，并刷新 README 中的使用示例和固定版本说明。

测试：
- 扩展围绕 CLI 解析、配置枚举、启动分类 errno 传播、文件管理器刷新行为、单文件规范路径匹配、视频尺寸调整/缩放流程、输入边界情况以及安装器参数处理的测试用例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden startup validation, input handling, and video/file-manager behavior, while improving CLI/config/install error messages and organizing shared test/link infrastructure.

Bug Fixes:
- Reject unsupported startup files with clear errno-backed errors instead of falling back to parent directories.
- Ensure file-manager refresh failures preserve the previous directory, entries, and selection state.
- Keep paused video state intact across resize and scale operations and avoid silently falling back to image rendering on video load failures.
- Treat malformed SGR mouse sequences and invalid input bytes as unknown input events instead of misparsed mouse actions.
- Reject extra CLI positional arguments and validate enum options for protocol, text symbols, color enhance, and kitty-transfer with explicit expected values.

Enhancements:
- Factor shared mode-entry cleanup into a helper that stops media, hides overlays, and optionally clears the preloader queue.
- Prefer full canonical-path matching when loading a single file to avoid basename clashes across directories.
- Clarify CLI, config, and installer error messages, including boolean option variants and guidance for unsupported install flags.
- Refactor Makefile test link objects into reusable component-based groups for common, render, media, input, app, and terminal code.

Documentation:
- Document installer checksum verification using SHA256SUMS and refresh README usage examples and pinned version guidance.

Tests:
- Expand tests around CLI parsing, config enums, startup classification errno propagation, file-manager refresh behavior, single-file canonical matching, video resize/scale flows, input edge cases, and installer argument handling.

</details>

</details>

Bug Fixes（缺陷修复）:
- 拒绝不支持的启动文件，而不是回退到其父目录，并保留 errno 以获得更清晰的路径错误信息。
- 确保文件管理器刷新失败时保留原有目录、条目和选中状态不变。
- 在窗口尺寸变化和视频缩放变更时保留暂停视频的状态，避免视频被意外恢复播放。
- 防止单视图视频加载失败时默默回退到图片渲染。
- 稳健处理格式异常的 SGR 鼠标输入和全角按键变体，对有效按键进行映射，并将无效序列视为未知输入。
- 拒绝多余的 CLI 位置参数，并对 protocol、text symbols、color enhance 和 kitty-transfer 选项中的枚举值进行校验，明确报告无效枚举值及其允许取值范围。

Enhancements（增强改进）:
- 将模式切换时的清理逻辑集中到共享辅助函数中，用于停止媒体播放、隐藏信息浮层，并在需要时清空预加载队列。
- 在单文件加载时优先按完整规范路径而非仅按文件名进行匹配，以避免跨目录冲突。
- 优化安装脚本行为，对未知参数给出有用的提示，并优先使用 `--bin-dir` 而不是旧标记。
- 明确 CLI、配置和安装器的错误信息，提供详细预期说明和帮助指引。
- 重构 Makefile 中的测试链接对象分组，在各测试套件中共享通用测试依赖。

Documentation（文档）:
- 记录安装器的校验和验证流程和手动使用 SHA256SUMS 的方法，并更新 README 中的使用说明和版本固定示例。

Tests（测试）:
- 增加以下场景的测试覆盖：启动路径 errno 暴露及非媒体文件拒绝、文件管理器刷新失败行为、单文件加载中的规范路径匹配、视频在尺寸/缩放变化流程中的暂停状态保留、严格的 SGR 鼠标解析、全角波浪号映射、CLI 枚举和布尔值校验、额外位置参数处理、视频加载失败行为，以及安装器参数错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在强化启动阶段的校验、输入处理以及视频/文件管理器行为的同时，改进 CLI/配置/安装相关错误信息，并整理共享的测试与链接基础设施。

Bug 修复：
- 拒绝不支持的启动文件，并返回明确、基于 errno 的错误，而不是回退到父目录。
- 确保文件管理器刷新失败时能保留之前的目录、条目以及选中状态。
- 在尺寸调整和缩放操作中保持视频暂停状态不变，并在视频加载失败时避免静默退回到图片渲染。
- 将格式错误的 SGR 鼠标序列和无效输入字节视为未知输入事件，而不是被误解析为鼠标动作。
- 拒绝多余的 CLI 位置参数，并对 protocol、text symbols、color enhance 和 kitty-transfer 等枚举选项进行校验，明确给出期望值。

功能增强：
- 把共享的模式退出清理逻辑抽取到一个辅助函数中，用于停止媒体、隐藏叠加层，并在需要时清空预加载队列。
- 在加载单个文件时优先使用完整的规范路径匹配，以避免跨目录的同名文件冲突。
- 明确 CLI、配置和安装器的错误信息，包括布尔选项的变体说明以及对不支持的安装标志的使用提示。
- 重构 Makefile 中的测试链接对象，将其整理为可复用的、按组件划分的分组，覆盖 common、render、media、input、app 和 terminal 代码。

文档：
- 记录安装器使用 SHA256SUMS 进行校验的流程，并刷新 README 中的使用示例和固定版本说明。

测试：
- 扩展围绕 CLI 解析、配置枚举、启动分类 errno 传播、文件管理器刷新行为、单文件规范路径匹配、视频尺寸调整/缩放流程、输入边界情况以及安装器参数处理的测试用例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden startup validation, input handling, and video/file-manager behavior, while improving CLI/config/install error messages and organizing shared test/link infrastructure.

Bug Fixes:
- Reject unsupported startup files with clear errno-backed errors instead of falling back to parent directories.
- Ensure file-manager refresh failures preserve the previous directory, entries, and selection state.
- Keep paused video state intact across resize and scale operations and avoid silently falling back to image rendering on video load failures.
- Treat malformed SGR mouse sequences and invalid input bytes as unknown input events instead of misparsed mouse actions.
- Reject extra CLI positional arguments and validate enum options for protocol, text symbols, color enhance, and kitty-transfer with explicit expected values.

Enhancements:
- Factor shared mode-entry cleanup into a helper that stops media, hides overlays, and optionally clears the preloader queue.
- Prefer full canonical-path matching when loading a single file to avoid basename clashes across directories.
- Clarify CLI, config, and installer error messages, including boolean option variants and guidance for unsupported install flags.
- Refactor Makefile test link objects into reusable component-based groups for common, render, media, input, app, and terminal code.

Documentation:
- Document installer checksum verification using SHA256SUMS and refresh README usage examples and pinned version guidance.

Tests:
- Expand tests around CLI parsing, config enums, startup classification errno propagation, file-manager refresh behavior, single-file canonical matching, video resize/scale flows, input edge cases, and installer argument handling.

</details>

Bug 修复：
- 拒绝不支持的启动文件，而不是回退到父目录，并在路径错误信息中暴露底层的 errno。
- 确保文件管理器刷新失败时保留之前的目录、条目和选中状态，而不是破坏现有状态。
- 在调整终端大小或更改视频缩放时保留已暂停的视频状态，避免视频在这些操作中被意外恢复播放。
- 防止单视图视频加载失败时默默回退到以图像方式渲染。
- 将格式错误的 SGR 鼠标序列和无效输入字节视为未知输入，而不是被误解析为事件。
- 拒绝多余的 CLI 位置参数，并对 protocol、text symbols、color enhance 和 kitty-transfer 选项的枚举值进行有效性校验。

Enhancements（增强功能）：
- 将通用的模式退出清理逻辑提取为一个辅助函数，用于停止媒体、隐藏叠加层，并在需要时清空预加载队列。
- 在加载单个文件时，优先使用完整规范路径匹配，以避免不同目录之间仅按文件名匹配造成的冲突。
- 明确 CLI、配置和安装程序中的错误信息，提供明确的期望值和使用指导，包括布尔选项的变体说明以及安装参数帮助。
- 重构 Makefile 中测试的链接对象，将其按 common、render、media、input、app 和 terminal 组件分组为可共享的集合。

Documentation（文档）：
- 记录安装程序的校验和验证流程，包括手动使用 SHA256SUMS，并刷新 README 中的示例和使用说明。

Tests（测试）：
- 扩展对 CLI、启动流程、文件管理器、输入、视频、安装程序以及单文件加载的测试覆盖，以捕获新增的边缘情况和错误处理行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在强化启动阶段的校验、输入处理以及视频/文件管理器行为的同时，改进 CLI/配置/安装相关错误信息，并整理共享的测试与链接基础设施。

Bug 修复：
- 拒绝不支持的启动文件，并返回明确、基于 errno 的错误，而不是回退到父目录。
- 确保文件管理器刷新失败时能保留之前的目录、条目以及选中状态。
- 在尺寸调整和缩放操作中保持视频暂停状态不变，并在视频加载失败时避免静默退回到图片渲染。
- 将格式错误的 SGR 鼠标序列和无效输入字节视为未知输入事件，而不是被误解析为鼠标动作。
- 拒绝多余的 CLI 位置参数，并对 protocol、text symbols、color enhance 和 kitty-transfer 等枚举选项进行校验，明确给出期望值。

功能增强：
- 把共享的模式退出清理逻辑抽取到一个辅助函数中，用于停止媒体、隐藏叠加层，并在需要时清空预加载队列。
- 在加载单个文件时优先使用完整的规范路径匹配，以避免跨目录的同名文件冲突。
- 明确 CLI、配置和安装器的错误信息，包括布尔选项的变体说明以及对不支持的安装标志的使用提示。
- 重构 Makefile 中的测试链接对象，将其整理为可复用的、按组件划分的分组，覆盖 common、render、media、input、app 和 terminal 代码。

文档：
- 记录安装器使用 SHA256SUMS 进行校验的流程，并刷新 README 中的使用示例和固定版本说明。

测试：
- 扩展围绕 CLI 解析、配置枚举、启动分类 errno 传播、文件管理器刷新行为、单文件规范路径匹配、视频尺寸调整/缩放流程、输入边界情况以及安装器参数处理的测试用例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden startup validation, input handling, and video/file-manager behavior, while improving CLI/config/install error messages and organizing shared test/link infrastructure.

Bug Fixes:
- Reject unsupported startup files with clear errno-backed errors instead of falling back to parent directories.
- Ensure file-manager refresh failures preserve the previous directory, entries, and selection state.
- Keep paused video state intact across resize and scale operations and avoid silently falling back to image rendering on video load failures.
- Treat malformed SGR mouse sequences and invalid input bytes as unknown input events instead of misparsed mouse actions.
- Reject extra CLI positional arguments and validate enum options for protocol, text symbols, color enhance, and kitty-transfer with explicit expected values.

Enhancements:
- Factor shared mode-entry cleanup into a helper that stops media, hides overlays, and optionally clears the preloader queue.
- Prefer full canonical-path matching when loading a single file to avoid basename clashes across directories.
- Clarify CLI, config, and installer error messages, including boolean option variants and guidance for unsupported install flags.
- Refactor Makefile test link objects into reusable component-based groups for common, render, media, input, app, and terminal code.

Documentation:
- Document installer checksum verification using SHA256SUMS and refresh README usage examples and pinned version guidance.

Tests:
- Expand tests around CLI parsing, config enums, startup classification errno propagation, file-manager refresh behavior, single-file canonical matching, video resize/scale flows, input edge cases, and installer argument handling.

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject unsupported startup files and harden input/CLI handling to make errors clearer and behavior safer. Videos keep their play/pause state across scale changes and repeated resize bursts, and file‑manager refresh errors no longer corrupt state.

- **Bug Fixes**
  - Startup: reject non-media files; include `stat` errno in path errors.
  - Input: read bytes as 0–255; strict SGR mouse parsing (require `<`, strip `M/m`, validate ints); malformed or non‑SGR sequences => `KEY_UNKNOWN`.
  - CLI/config/installer: enum errors list expected values (with group names); reject extra positional args; clearer boolean messages; `install.sh` unknown args point to help and suggest `--bin-dir`.
  - Video: preserve paused/playing state across terminal resize bursts and on scale changes; no fallback to image if video load fails.
  - File manager/core: refresh failure keeps previous directory, entries, and selection; single-file load matches canonical path before basename.

- **Refactors**
  - Added `app_prepare_mode_entry()` for shared mode-entry cleanup; grouped test link objects in the Makefile and added targeted regression tests.

<sup>Written for commit a2bb9d89164edf2e8abb5b8529df8f27d30e507e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zouyonghe/PixelTerm-C/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

