### PR TITLE
fix: close input error and diagnostic gaps

### DIFF
--- a/src/app_cli.c
+++ b/src/app_cli.c
@@ -201,6 +201,17 @@ static gboolean app_parse_boolean(const char *value, gboolean *out_value) {
     return FALSE;
 }
 
+static void app_print_config_error(const char *key,
+                                   const char *path,
+                                   const GError *error) {
+    gchar *safe_path = sanitize_for_terminal(path);
+    gchar *safe_message = sanitize_for_terminal(error ? error->message : "unknown error");
+    fprintf(stderr, "Invalid '%s' in config file '%s': %s\n",
+            key, safe_path, safe_message);
+    g_free(safe_path);
+    g_free(safe_message);
+}
+
 static gboolean app_config_read_boolean(GKeyFile *key_file,
                                         const char *group,
                                         const char *key,
@@ -212,11 +223,7 @@ static gboolean app_config_read_boolean(GKeyFile *key_file,
     GError *error = NULL;
     gboolean value = g_key_file_get_boolean(key_file, group, key, &error);
     if (error) {
-        gchar *safe_path = sanitize_for_terminal(path);
-        gchar *safe_message = sanitize_for_terminal(error->message);
-        fprintf(stderr, "Invalid '%s' in config file '%s': %s\n", key, safe_path, safe_message);
-        g_free(safe_path);
-        g_free(safe_message);
+        app_print_config_error(key, path, error);
         g_error_free(error);
         return FALSE;
     }
@@ -237,11 +244,7 @@ static gboolean app_config_read_integer(GKeyFile *key_file,
     GError *error = NULL;
     gint value = g_key_file_get_integer(key_file, group, key, &error);
     if (error) {
-        gchar *safe_path = sanitize_for_terminal(path);
-        gchar *safe_message = sanitize_for_terminal(error->message);
-        fprintf(stderr, "Invalid '%s' in config file '%s': %s\n", key, safe_path, safe_message);
-        g_free(safe_path);
-        g_free(safe_message);
+        app_print_config_error(key, path, error);
         g_error_free(error);
         return FALSE;
     }
@@ -269,11 +272,7 @@ static gboolean app_config_read_double(GKeyFile *key_file,
     GError *error = NULL;
     gdouble value = g_key_file_get_double(key_file, group, key, &error);
     if (error) {
-        gchar *safe_path = sanitize_for_terminal(path);
-        gchar *safe_message = sanitize_for_terminal(error->message);
-        fprintf(stderr, "Invalid '%s' in config file '%s': %s\n", key, safe_path, safe_message);
-        g_free(safe_path);
-        g_free(safe_message);
+        app_print_config_error(key, path, error);
         g_error_free(error);
         return FALSE;
     }
@@ -316,12 +315,11 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         GError *error = NULL;
         gchar *value = g_key_file_get_string(key_file, group, "protocol", &error);
         if (error) {
-            gchar *safe_message = sanitize_for_terminal(error->message);
-            fprintf(stderr, "Invalid 'protocol' in config file '%s': %s\n", safe_path, safe_message);
-            g_free(safe_message);
+            app_print_config_error("protocol", path, error);
             g_error_free(error);
             g_free(value);
             g_free(safe_path);
+            g_free(safe_group);
             return FALSE;
         }
         AppProtocolMode mode = APP_PROTOCOL_AUTO;
@@ -344,12 +342,11 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         GError *error = NULL;
         gchar *value = g_key_file_get_string(key_file, group, "text_symbols", &error);
         if (error) {
-            gchar *safe_message = sanitize_for_terminal(error->message);
-            fprintf(stderr, "Invalid 'text_symbols' in config file '%s': %s\n", safe_path, safe_message);
-            g_free(safe_message);
+            app_print_config_error("text_symbols", path, error);
             g_error_free(error);
             g_free(value);
             g_free(safe_path);
+            g_free(safe_group);
             return FALSE;
         }
         TextSymbolMode mode = TEXT_SYMBOL_MODE_AUTO;
@@ -372,12 +369,11 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         GError *error = NULL;
         gchar *value = g_key_file_get_string(key_file, group, "color_enhance", &error);
         if (error) {
-            gchar *safe_message = sanitize_for_terminal(error->message);
-            fprintf(stderr, "Invalid 'color_enhance' in config file '%s': %s\n", safe_path, safe_message);
-            g_free(safe_message);
+            app_print_config_error("color_enhance", path, error);
             g_error_free(error);
             g_free(value);
             g_free(safe_path);
+            g_free(safe_group);
             return FALSE;
         }
         ColorEnhanceMode mode = COLOR_ENHANCE_OFF;
@@ -400,12 +396,11 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         GError *error = NULL;
         gchar *value = g_key_file_get_string(key_file, group, "kitty_transfer", &error);
         if (error) {
-            gchar *safe_message = sanitize_for_terminal(error->message);
-            fprintf(stderr, "Invalid 'kitty_transfer' in config file '%s': %s\n", safe_path, safe_message);
-            g_free(safe_message);
+            app_print_config_error("kitty_transfer", path, error);
             g_error_free(error);
             g_free(value);
             g_free(safe_path);
+            g_free(safe_group);
             return FALSE;
         }
         KittyTransferMode mode = KITTY_TRANSFER_AUTO;

--- a/src/app_cli.c
+++ b/src/app_cli.c
@@ -212,6 +212,18 @@ static void app_print_config_error(const char *key,
     g_free(safe_message);
 }
 
+static void app_print_config_enum_error(const char *key,
+                                        const char *safe_path,
+                                        const char *safe_group,
+                                        const char *value,
+                                        const char *expected) {
+    gchar *safe_value = sanitize_for_terminal(value);
+    fprintf(stderr,
+            "Invalid '%s' in config file '%s' group '[%s]': %s (expected %s)\n",
+            key, safe_path, safe_group, safe_value, expected);
+    g_free(safe_value);
+}
+
 static gboolean app_config_read_boolean(GKeyFile *key_file,
                                         const char *group,
                                         const char *key,
@@ -324,12 +336,9 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         }
         AppProtocolMode mode = APP_PROTOCOL_AUTO;
         if (!parse_protocol_mode(value, &mode)) {
-            gchar *safe_value = sanitize_for_terminal(value);
-            fprintf(stderr,
-                    "Invalid 'protocol' in config file '%s' group '[%s]': %s (expected auto, text, sixel, kitty, or iterm2)\n",
-                    safe_path, safe_group, safe_value);
+            app_print_config_enum_error("protocol", safe_path, safe_group, value,
+                                        "auto, text, sixel, kitty, or iterm2");
             g_free(value);
-            g_free(safe_value);
             g_free(safe_path);
             g_free(safe_group);
             return FALSE;
@@ -351,12 +360,9 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         }
         TextSymbolMode mode = TEXT_SYMBOL_MODE_AUTO;
         if (!parse_text_symbol_mode(value, &mode)) {
-            gchar *safe_value = sanitize_for_terminal(value);
-            fprintf(stderr,
-                    "Invalid 'text_symbols' in config file '%s' group '[%s]': %s (expected auto, half, or quarter)\n",
-                    safe_path, safe_group, safe_value);
+            app_print_config_enum_error("text_symbols", safe_path, safe_group, value,
+                                        "auto, half, or quarter");
             g_free(value);
-            g_free(safe_value);
             g_free(safe_path);
             g_free(safe_group);
             return FALSE;
@@ -378,12 +384,9 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         }
         ColorEnhanceMode mode = COLOR_ENHANCE_OFF;
         if (!parse_color_enhance_mode(value, &mode)) {
-            gchar *safe_value = sanitize_for_terminal(value);
-            fprintf(stderr,
-                    "Invalid 'color_enhance' in config file '%s' group '[%s]': %s (expected off or vivid)\n",
-                    safe_path, safe_group, safe_value);
+            app_print_config_enum_error("color_enhance", safe_path, safe_group, value,
+                                        "off or vivid");
             g_free(value);
-            g_free(safe_value);
             g_free(safe_path);
             g_free(safe_group);
             return FALSE;
@@ -405,12 +408,9 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         }
         KittyTransferMode mode = KITTY_TRANSFER_AUTO;
         if (!parse_kitty_transfer_mode(value, &mode)) {
-            gchar *safe_value = sanitize_for_terminal(value);
-            fprintf(stderr,
-                    "Invalid 'kitty_transfer' in config file '%s' group '[%s]': %s (expected auto, direct, or shm)\n",
-                    safe_path, safe_group, safe_value);
+            app_print_config_enum_error("kitty_transfer", safe_path, safe_group, value,
+                                        "auto, direct, or shm");
             g_free(value);
-            g_free(safe_value);
             g_free(safe_path);
             g_free(safe_group);
             return FALSE;

--- a/src/app_cli.c
+++ b/src/app_cli.c
@@ -213,8 +213,10 @@ static gboolean app_config_read_boolean(GKeyFile *key_file,
     gboolean value = g_key_file_get_boolean(key_file, group, key, &error);
     if (error) {
         gchar *safe_path = sanitize_for_terminal(path);
-        fprintf(stderr, "Invalid '%s' in config file '%s': %s\n", key, safe_path, error->message);
+        gchar *safe_message = sanitize_for_terminal(error->message);
+        fprintf(stderr, "Invalid '%s' in config file '%s': %s\n", key, safe_path, safe_message);
         g_free(safe_path);
+        g_free(safe_message);
         g_error_free(error);
         return FALSE;
     }
@@ -236,8 +238,10 @@ static gboolean app_config_read_integer(GKeyFile *key_file,
     gint value = g_key_file_get_integer(key_file, group, key, &error);
     if (error) {
         gchar *safe_path = sanitize_for_terminal(path);
-        fprintf(stderr, "Invalid '%s' in config file '%s': %s\n", key, safe_path, error->message);
+        gchar *safe_message = sanitize_for_terminal(error->message);
+        fprintf(stderr, "Invalid '%s' in config file '%s': %s\n", key, safe_path, safe_message);
         g_free(safe_path);
+        g_free(safe_message);
         g_error_free(error);
         return FALSE;
     }
@@ -266,8 +270,10 @@ static gboolean app_config_read_double(GKeyFile *key_file,
     gdouble value = g_key_file_get_double(key_file, group, key, &error);
     if (error) {
         gchar *safe_path = sanitize_for_terminal(path);
-        fprintf(stderr, "Invalid '%s' in config file '%s': %s\n", key, safe_path, error->message);
+        gchar *safe_message = sanitize_for_terminal(error->message);
+        fprintf(stderr, "Invalid '%s' in config file '%s': %s\n", key, safe_path, safe_message);
         g_free(safe_path);
+        g_free(safe_message);
         g_error_free(error);
         return FALSE;
     }
@@ -293,6 +299,7 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         return TRUE;
     }
     gchar *safe_path = sanitize_for_terminal(path);
+    gchar *safe_group = sanitize_for_terminal(group);
 
     if (!app_config_read_boolean(key_file, group, "preload", path, &config->preload_enabled) ||
         !app_config_read_boolean(key_file, group, "dither", path, &config->dither_enabled) ||
@@ -301,6 +308,7 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
                                  &config->clear_workaround_enabled) ||
         !app_config_read_integer(key_file, group, "work_factor", path, 1, 9, &config->work_factor)) {
         g_free(safe_path);
+        g_free(safe_group);
         return FALSE;
     }
 
@@ -308,7 +316,9 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         GError *error = NULL;
         gchar *value = g_key_file_get_string(key_file, group, "protocol", &error);
         if (error) {
-            fprintf(stderr, "Invalid 'protocol' in config file '%s': %s\n", safe_path, error->message);
+            gchar *safe_message = sanitize_for_terminal(error->message);
+            fprintf(stderr, "Invalid 'protocol' in config file '%s': %s\n", safe_path, safe_message);
+            g_free(safe_message);
             g_error_free(error);
             g_free(value);
             g_free(safe_path);
@@ -316,11 +326,14 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         }
         AppProtocolMode mode = APP_PROTOCOL_AUTO;
         if (!parse_protocol_mode(value, &mode)) {
+            gchar *safe_value = sanitize_for_terminal(value);
             fprintf(stderr,
                     "Invalid 'protocol' in config file '%s' group '[%s]': %s (expected auto, text, sixel, kitty, or iterm2)\n",
-                    safe_path, group, value);
+                    safe_path, safe_group, safe_value);
             g_free(value);
+            g_free(safe_value);
             g_free(safe_path);
+            g_free(safe_group);
             return FALSE;
         }
         config->protocol_mode = mode;
@@ -331,7 +344,9 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         GError *error = NULL;
         gchar *value = g_key_file_get_string(key_file, group, "text_symbols", &error);
         if (error) {
-            fprintf(stderr, "Invalid 'text_symbols' in config file '%s': %s\n", safe_path, error->message);
+            gchar *safe_message = sanitize_for_terminal(error->message);
+            fprintf(stderr, "Invalid 'text_symbols' in config file '%s': %s\n", safe_path, safe_message);
+            g_free(safe_message);
             g_error_free(error);
             g_free(value);
             g_free(safe_path);
@@ -339,11 +354,14 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         }
         TextSymbolMode mode = TEXT_SYMBOL_MODE_AUTO;
         if (!parse_text_symbol_mode(value, &mode)) {
+            gchar *safe_value = sanitize_for_terminal(value);
             fprintf(stderr,
                     "Invalid 'text_symbols' in config file '%s' group '[%s]': %s (expected auto, half, or quarter)\n",
-                    safe_path, group, value);
+                    safe_path, safe_group, safe_value);
             g_free(value);
+            g_free(safe_value);
             g_free(safe_path);
+            g_free(safe_group);
             return FALSE;
         }
         config->text_symbol_mode = mode;
@@ -354,7 +372,9 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         GError *error = NULL;
         gchar *value = g_key_file_get_string(key_file, group, "color_enhance", &error);
         if (error) {
-            fprintf(stderr, "Invalid 'color_enhance' in config file '%s': %s\n", safe_path, error->message);
+            gchar *safe_message = sanitize_for_terminal(error->message);
+            fprintf(stderr, "Invalid 'color_enhance' in config file '%s': %s\n", safe_path, safe_message);
+            g_free(safe_message);
             g_error_free(error);
             g_free(value);
             g_free(safe_path);
@@ -362,11 +382,14 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         }
         ColorEnhanceMode mode = COLOR_ENHANCE_OFF;
         if (!parse_color_enhance_mode(value, &mode)) {
+            gchar *safe_value = sanitize_for_terminal(value);
             fprintf(stderr,
                     "Invalid 'color_enhance' in config file '%s' group '[%s]': %s (expected off or vivid)\n",
-                    safe_path, group, value);
+                    safe_path, safe_group, safe_value);
             g_free(value);
+            g_free(safe_value);
             g_free(safe_path);
+            g_free(safe_group);
             return FALSE;
         }
         config->color_enhance = mode;
@@ -377,7 +400,9 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         GError *error = NULL;
         gchar *value = g_key_file_get_string(key_file, group, "kitty_transfer", &error);
         if (error) {
-            fprintf(stderr, "Invalid 'kitty_transfer' in config file '%s': %s\n", safe_path, error->message);
+            gchar *safe_message = sanitize_for_terminal(error->message);
+            fprintf(stderr, "Invalid 'kitty_transfer' in config file '%s': %s\n", safe_path, safe_message);
+            g_free(safe_message);
             g_error_free(error);
             g_free(value);
             g_free(safe_path);
@@ -385,11 +410,14 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         }
         KittyTransferMode mode = KITTY_TRANSFER_AUTO;
         if (!parse_kitty_transfer_mode(value, &mode)) {
+            gchar *safe_value = sanitize_for_terminal(value);
             fprintf(stderr,
                     "Invalid 'kitty_transfer' in config file '%s' group '[%s]': %s (expected auto, direct, or shm)\n",
-                    safe_path, group, value);
+                    safe_path, safe_group, safe_value);
             g_free(value);
+            g_free(safe_value);
             g_free(safe_path);
+            g_free(safe_group);
             return FALSE;
         }
         config->kitty_transfer = mode;
@@ -400,6 +428,7 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
         gdouble gamma = config->gamma;
         if (!app_config_read_double(key_file, group, "gamma", path, 0.0, 5.0, &gamma)) {
             g_free(safe_path);
+            g_free(safe_group);
             return FALSE;
         }
         config->gamma = gamma;
@@ -407,6 +436,7 @@ static gboolean app_config_apply_group(GKeyFile *key_file,
     }
 
     g_free(safe_path);
+    g_free(safe_group);
     return TRUE;
 }
 
@@ -426,9 +456,11 @@ static ErrorCode app_config_load_file(AppConfig *config,
             return ERROR_NONE;
         }
         gchar *safe_path = sanitize_for_terminal(path);
+        gchar *safe_message = sanitize_for_terminal(error ? error->message : "unknown error");
         fprintf(stderr, "Failed to load config file '%s': %s\n", safe_path,
-                error ? error->message : "unknown error");
+                safe_message);
         g_free(safe_path);
+        g_free(safe_message);
         if (error) {
             g_error_free(error);
         }

--- a/src/input.c
+++ b/src/input.c
@@ -14,21 +14,21 @@ static gboolean g_scroll_coalesce_active = FALSE;
 
 #define INPUT_SGR_MOUSE_BUTTON_MAX 255
 
-static gboolean input_read_error_is_transient(void) {
-    return errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK;
+static gboolean input_read_error_is_transient(int error_number) {
+    return error_number == EINTR || error_number == EAGAIN || error_number == EWOULDBLOCK;
 }
 
-static void input_handle_select_result(InputHandler *handler, int result) {
-    if (handler && result < 0 && !input_read_error_is_transient()) {
+static void input_handle_select_result(InputHandler *handler, int result, int error_number) {
+    if (handler && result < 0 && !input_read_error_is_transient(error_number)) {
         handler->should_exit = TRUE;
     }
 }
 
-static void input_handle_read_result(InputHandler *handler, ssize_t result) {
+static void input_handle_read_result(InputHandler *handler, ssize_t result, int error_number) {
     if (!handler) {
         return;
     }
-    if (result == 0 || (result < 0 && !input_read_error_is_transient())) {
+    if (result == 0 || (result < 0 && !input_read_error_is_transient(error_number))) {
         handler->should_exit = TRUE;
     }
 }
@@ -593,7 +593,8 @@ gboolean input_has_pending_input(InputHandler *handler) {
     FD_SET(STDIN_FILENO, &fds);
 
     int result = select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv);
-    input_handle_select_result(handler, result);
+    int select_errno = result < 0 ? errno : 0;
+    input_handle_select_result(handler, result, select_errno);
     if (result <= 0) {
         return FALSE;
     }
@@ -601,11 +602,12 @@ gboolean input_has_pending_input(InputHandler *handler) {
     unsigned char byte;
     ssize_t n = read(STDIN_FILENO, &byte, 1);
     if (n == 0) {
-        input_handle_read_result(handler, n);
+        input_handle_read_result(handler, n, 0);
         return FALSE;
     }
     if (n < 0) {
-        input_handle_read_result(handler, n);
+        int read_errno = errno;
+        input_handle_read_result(handler, n, read_errno);
         return FALSE;
     }
     handler->pending_byte = byte;
@@ -665,7 +667,8 @@ gint input_read_char(InputHandler *handler) {
     if (n == 1) {
         return c;
     }
-    input_handle_read_result(handler, n);
+    int read_errno = n < 0 ? errno : 0;
+    input_handle_read_result(handler, n, read_errno);
     return 0;
 }
 
@@ -689,7 +692,8 @@ gint input_read_char_with_timeout(InputHandler *handler, gint timeout_ms) {
     FD_SET(STDIN_FILENO, &fds);
     
     int result = select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv);
-    input_handle_select_result(handler, result);
+    int select_errno = result < 0 ? errno : 0;
+    input_handle_select_result(handler, result, select_errno);
     if (result <= 0) {
         return 0; // Timeout or error
     }
@@ -700,7 +704,8 @@ gint input_read_char_with_timeout(InputHandler *handler, gint timeout_ms) {
         if (n == 1) {
             return c;
         }
-        input_handle_read_result(handler, n);
+        int read_errno = n < 0 ? errno : 0;
+        input_handle_read_result(handler, n, read_errno);
         return 0;
     }
     

--- a/src/input.c
+++ b/src/input.c
@@ -14,6 +14,10 @@ static gboolean g_scroll_coalesce_active = FALSE;
 
 #define INPUT_SGR_MOUSE_BUTTON_MAX 255
 
+static gboolean input_read_error_is_transient(void) {
+    return errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK;
+}
+
 static gboolean input_parse_sgr_int(const gchar *text, gint min_value, gint max_value, gint *out_value) {
     if (!text || !out_value) {
         return FALSE;
@@ -573,7 +577,11 @@ gboolean input_has_pending_input(InputHandler *handler) {
     FD_ZERO(&fds);
     FD_SET(STDIN_FILENO, &fds);
 
-    if (select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv) <= 0) {
+    int result = select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv);
+    if (result < 0 && !input_read_error_is_transient()) {
+        handler->should_exit = TRUE;
+    }
+    if (result <= 0) {
         return FALSE;
     }
 
@@ -584,6 +592,9 @@ gboolean input_has_pending_input(InputHandler *handler) {
         return FALSE;
     }
     if (n < 0) {
+        if (!input_read_error_is_transient()) {
+            handler->should_exit = TRUE;
+        }
         return FALSE;
     }
     handler->pending_byte = byte;
@@ -645,6 +656,8 @@ gint input_read_char(InputHandler *handler) {
     }
     if (n == 0) {
         handler->should_exit = TRUE;
+    } else if (n < 0 && !input_read_error_is_transient()) {
+        handler->should_exit = TRUE;
     }
     return 0;
 }
@@ -669,21 +682,22 @@ gint input_read_char_with_timeout(InputHandler *handler, gint timeout_ms) {
     FD_SET(STDIN_FILENO, &fds);
     
     int result = select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv);
+    if (result < 0 && !input_read_error_is_transient()) {
+        handler->should_exit = TRUE;
+    }
     if (result <= 0) {
         return 0; // Timeout or error
     }
     
     if (FD_ISSET(STDIN_FILENO, &fds)) {
-        if (handler->has_pending_byte) {
-            handler->has_pending_byte = FALSE;
-            return handler->pending_byte;
-        }
         unsigned char c;
         ssize_t n = read(STDIN_FILENO, &c, 1);
         if (n == 1) {
             return c;
         }
         if (n == 0) {
+            handler->should_exit = TRUE;
+        } else if (n < 0 && !input_read_error_is_transient()) {
             handler->should_exit = TRUE;
         }
         return 0;

--- a/src/input.c
+++ b/src/input.c
@@ -18,6 +18,21 @@ static gboolean input_read_error_is_transient(void) {
     return errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK;
 }
 
+static void input_handle_select_result(InputHandler *handler, int result) {
+    if (handler && result < 0 && !input_read_error_is_transient()) {
+        handler->should_exit = TRUE;
+    }
+}
+
+static void input_handle_read_result(InputHandler *handler, ssize_t result) {
+    if (!handler) {
+        return;
+    }
+    if (result == 0 || (result < 0 && !input_read_error_is_transient())) {
+        handler->should_exit = TRUE;
+    }
+}
+
 static gboolean input_parse_sgr_int(const gchar *text, gint min_value, gint max_value, gint *out_value) {
     if (!text || !out_value) {
         return FALSE;
@@ -578,9 +593,7 @@ gboolean input_has_pending_input(InputHandler *handler) {
     FD_SET(STDIN_FILENO, &fds);
 
     int result = select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv);
-    if (result < 0 && !input_read_error_is_transient()) {
-        handler->should_exit = TRUE;
-    }
+    input_handle_select_result(handler, result);
     if (result <= 0) {
         return FALSE;
     }
@@ -588,13 +601,11 @@ gboolean input_has_pending_input(InputHandler *handler) {
     unsigned char byte;
     ssize_t n = read(STDIN_FILENO, &byte, 1);
     if (n == 0) {
-        handler->should_exit = TRUE;
+        input_handle_read_result(handler, n);
         return FALSE;
     }
     if (n < 0) {
-        if (!input_read_error_is_transient()) {
-            handler->should_exit = TRUE;
-        }
+        input_handle_read_result(handler, n);
         return FALSE;
     }
     handler->pending_byte = byte;
@@ -654,11 +665,7 @@ gint input_read_char(InputHandler *handler) {
     if (n == 1) {
         return c;
     }
-    if (n == 0) {
-        handler->should_exit = TRUE;
-    } else if (n < 0 && !input_read_error_is_transient()) {
-        handler->should_exit = TRUE;
-    }
+    input_handle_read_result(handler, n);
     return 0;
 }
 
@@ -682,9 +689,7 @@ gint input_read_char_with_timeout(InputHandler *handler, gint timeout_ms) {
     FD_SET(STDIN_FILENO, &fds);
     
     int result = select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv);
-    if (result < 0 && !input_read_error_is_transient()) {
-        handler->should_exit = TRUE;
-    }
+    input_handle_select_result(handler, result);
     if (result <= 0) {
         return 0; // Timeout or error
     }
@@ -695,11 +700,7 @@ gint input_read_char_with_timeout(InputHandler *handler, gint timeout_ms) {
         if (n == 1) {
             return c;
         }
-        if (n == 0) {
-            handler->should_exit = TRUE;
-        } else if (n < 0 && !input_read_error_is_transient()) {
-            handler->should_exit = TRUE;
-        }
+        input_handle_read_result(handler, n);
         return 0;
     }
     

--- a/tests/test_app_cli.c
+++ b/tests/test_app_cli.c
@@ -915,6 +915,53 @@ static void test_cli_sanitizes_config_path_in_errors(AppCliFixture *fixture,
     g_free(config_path);
 }
 
+static void test_cli_sanitizes_config_group_and_value_in_errors(AppCliFixture *fixture,
+                                                                gconstpointer user_data) {
+    (void)fixture;
+    (void)user_data;
+
+    gchar *config_path = write_temp_config_file(
+        "[bad\033[31mgroup]\n"
+        "protocol=bad\033[32mvalue\n");
+    pixelterm_env_set_for_test("TERM_PROGRAM", "bad\033[31mgroup");
+    AppConfig config;
+    gchar *path = NULL;
+    AppCliParseInvocation invocation = {0};
+    gchar *argv[] = {"pixelterm", "--config", config_path, NULL};
+    app_config_init(&config);
+    invocation.argv = argv;
+    invocation.path_out = &path;
+    invocation.config = &config;
+
+    gchar *stderr_output = capture_stderr(invoke_parse_cli_args, &invocation);
+    g_assert_cmpint(invocation.error, ==, ERROR_INVALID_ARGS);
+    g_assert_null(path);
+    g_assert_null(strchr(stderr_output, '\033'));
+
+    g_free(stderr_output);
+    g_free(path);
+    g_free(config_path);
+
+    config_path = write_temp_config_file(
+        "[default]\n"
+        "protocol=bad\033[32mvalue\n");
+    app_config_init(&config);
+    path = NULL;
+    invocation.argv = argv;
+    invocation.path_out = &path;
+    invocation.config = &config;
+    argv[2] = config_path;
+
+    stderr_output = capture_stderr(invoke_parse_cli_args, &invocation);
+    g_assert_cmpint(invocation.error, ==, ERROR_INVALID_ARGS);
+    g_assert_null(path);
+    g_assert_null(strchr(stderr_output, '\033'));
+
+    g_free(stderr_output);
+    g_free(path);
+    g_free(config_path);
+}
+
 static void test_cli_config_invalid_enum_lists_expected_values(AppCliFixture *fixture,
                                                               gconstpointer user_data) {
     (void)fixture;
@@ -1537,6 +1584,8 @@ void register_app_cli_tests(void) {
                      test_cli_rejects_non_finite_gamma);
     add_app_cli_test("/app_cli/errors/sanitizes_config_path",
                      test_cli_sanitizes_config_path_in_errors);
+    add_app_cli_test("/app_cli/errors/sanitizes_config_group_and_value",
+                     test_cli_sanitizes_config_group_and_value_in_errors);
     add_app_cli_test("/app_cli/parse/double_dash_preserves_positional_config_like_path",
                      test_cli_double_dash_preserves_positional_config_like_path);
     add_app_cli_test("/app_cli/parse/rejects_extra_positional_arguments",

--- a/tests/test_input_dispatch_key_single.c
+++ b/tests/test_input_dispatch_key_single.c
@@ -97,6 +97,19 @@ static void test_input_eof_requests_exit(void) {
     g_assert_true(handler.should_exit);
 }
 
+static void test_input_persistent_read_error_requests_exit(void) {
+    InputHandler handler = {0};
+    InputEvent event = {0};
+    StdinRedirect *redirect = g_new0(StdinRedirect, 1);
+    redirect->saved_stdin_fd = dup(STDIN_FILENO);
+    g_assert_cmpint(redirect->saved_stdin_fd, >=, 0);
+    g_test_queue_destroy(restore_stdin, redirect);
+    close(STDIN_FILENO);
+
+    g_assert_cmpint(input_get_event(&handler, &event), ==, ERROR_INPUT_EOF);
+    g_assert_true(handler.should_exit);
+}
+
 static void assert_previous_navigation(KeyCode key_code) {
     PixelTermApp app = make_single_app(NULL);
     InputEvent event = make_key_event(key_code);
@@ -423,6 +436,8 @@ static void test_video_fps_second_toggle_restores_stats_row(void) {
 
 void register_input_dispatch_key_single_tests(void) {
     g_test_add_func("/input/eof/requests_exit", test_input_eof_requests_exit);
+    g_test_add_func("/input/read_error/requests_exit",
+                    test_input_persistent_read_error_requests_exit);
     g_test_add_func("/input_dispatch_key_single/navigation/left_matches_h",
                     test_left_matches_h_navigation);
     g_test_add_func("/input_dispatch_key_single/navigation/right_matches_l",


### PR DESCRIPTION
## Summary
- remove duplicate pending-byte handling in timed input reads
- treat persistent `select`/`read` errors as terminal shutdown conditions while preserving `EINTR`/`EAGAIN`/`EWOULDBLOCK`
- sanitize config group names, enum values, and parser error messages before stderr output

## Root causes
- `input_read_char_with_timeout` consumed pending bytes at function entry, making its inner branch unreachable
- persistent descriptor errors returned false/zero without setting `should_exit`, allowing repeated polling
- config diagnostics sanitized paths but interpolated untrusted group/value/error text directly

## Verification
- `rtk make test` passed: 308 tests
- `rtk make EXTRA_CFLAGS=-Werror test` passed
- `rtk make debug-test` passed with AddressSanitizer
- `rtk make all` passed
- focused persistent-read-error and config-control-byte regressions pass
- `rtk git diff --check` passed

## Notes
- Existing untracked `.codegraph/`, `.cursor/`, `bin-debug/`, and `obj-debug/` were not staged.
- Sub-agent investigation/review attempts were unavailable because configured `haiku` model was not found; changes were reviewed locally.

## Summary by Sourcery

通过在持续输入错误时干净退出以及对与配置相关的 stderr 输出进行完全净化，加强输入处理和配置诊断的健壮性。

Bug Fixes（错误修复）:
- 确保在持续的 stdin `select/read` 失败以及遇到 EOF 时，将输入处理器标记为请求关闭应用程序，而不是继续进行轮询。
- 移除在限时输入读取中不可达的待处理字节处理逻辑，以便一致地处理缓冲输入。

Enhancements（增强功能）:
- 将输入错误分类和“是否应退出”的更新逻辑集中到共享的辅助函数中，以在所有输入路径上实现一致行为。
- 在将配置文件路径、组名、枚举值和错误消息打印到 stderr 之前进行净化，防止控制字符或转义序列输出到终端。

Tests（测试）:
- 新增回归测试，验证 stderr 中的配置诊断输出会净化路径、组名和值，并且不包含转义字符。
- 新增输入测试，确认持续的 stdin 读取错误会导致输入处理器请求退出应用程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden input handling and configuration diagnostics by exiting cleanly on persistent input errors and fully sanitizing config-related stderr output.

Bug Fixes:
- Ensure persistent stdin select/read failures and EOF mark the input handler to request application shutdown instead of allowing continued polling.
- Remove unreachable pending-byte handling in timed input reads so buffered input is processed consistently.

Enhancements:
- Centralize input error classification and should-exit updates into shared helpers for consistent behavior across input paths.
- Sanitize config file paths, group names, enum values, and error messages before printing to stderr to prevent control characters or escape sequences from reaching the terminal.

Tests:
- Add regression tests verifying stderr config diagnostics sanitize paths, group names, and values and contain no escape characters.
- Add an input test confirming persistent stdin read errors cause the input handler to request application exit.

</details>

Bug 修复：
- 确保输入处理在遇到持续性的 `select`/读取失败和 EOF 时，将其视为请求应用程序退出的终止条件，而不是无限循环。
- 移除定时输入读取中不可达的“待处理字节”消耗逻辑，以确保缓冲输入得到一致的处理。

增强：
- 在打印到 stderr 之前，对配置错误消息、组名和枚举值进行清理，避免泄露控制字符或不安全的终端序列。

测试：
- 添加回归测试，以验证配置错误输出会对路径、组名和值进行清理，并且不包含转义序列。
- 添加一个输入测试，以确认持续的 stdin 读取失败会导致输入处理器请求应用程序退出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在持续输入错误时干净退出以及对与配置相关的 stderr 输出进行完全净化，加强输入处理和配置诊断的健壮性。

Bug Fixes（错误修复）:
- 确保在持续的 stdin `select/read` 失败以及遇到 EOF 时，将输入处理器标记为请求关闭应用程序，而不是继续进行轮询。
- 移除在限时输入读取中不可达的待处理字节处理逻辑，以便一致地处理缓冲输入。

Enhancements（增强功能）:
- 将输入错误分类和“是否应退出”的更新逻辑集中到共享的辅助函数中，以在所有输入路径上实现一致行为。
- 在将配置文件路径、组名、枚举值和错误消息打印到 stderr 之前进行净化，防止控制字符或转义序列输出到终端。

Tests（测试）:
- 新增回归测试，验证 stderr 中的配置诊断输出会净化路径、组名和值，并且不包含转义字符。
- 新增输入测试，确认持续的 stdin 读取错误会导致输入处理器请求退出应用程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden input handling and configuration diagnostics by exiting cleanly on persistent input errors and fully sanitizing config-related stderr output.

Bug Fixes:
- Ensure persistent stdin select/read failures and EOF mark the input handler to request application shutdown instead of allowing continued polling.
- Remove unreachable pending-byte handling in timed input reads so buffered input is processed consistently.

Enhancements:
- Centralize input error classification and should-exit updates into shared helpers for consistent behavior across input paths.
- Sanitize config file paths, group names, enum values, and error messages before printing to stderr to prevent control characters or escape sequences from reaching the terminal.

Tests:
- Add regression tests verifying stderr config diagnostics sanitize paths, group names, and values and contain no escape characters.
- Add an input test confirming persistent stdin read errors cause the input handler to request application exit.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden input handling and config diagnostics: exit on persistent read/select errors, remove unreachable pending-byte logic, and fully sanitize all config error output (paths, groups, values, and messages). Share helpers for consistent behavior across code paths.

- **Bug Fixes**
  - Treat persistent select/read errors and EOF as shutdown; keep `EINTR`/`EAGAIN`/`EWOULDBLOCK` transient.
  - Remove duplicate pending-byte branch in `input_read_char_with_timeout`.
  - Sanitize config path, group name, enum value, and all error messages (including load failures) before stderr output.
  - Add tests for persistent read-error exit and for sanitizing group/value output.

- **Refactors**
  - Centralize input error classification and `should_exit` updates via shared helpers used by select/read callers.
  - Add `app_print_config_error` and `app_print_config_enum_error` for sanitized, consistent config diagnostics.

<sup>Written for commit c0d4d755270357f539c01b2e640323f8e61e6480. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zouyonghe/PixelTerm-C/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

