### PR TITLE
fix: Android (Termux) build and portability fixes

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -502,7 +502,15 @@ const char* get_file_extension(const char *filename) {
     }
 
     const char *dot = strrchr(filename, '.');
-    if (!dot || dot == filename) {
+    const char *slash = strrchr(filename, '/');
+    const char *backslash = strrchr(filename, '\\');
+    const char *separator = slash;
+    if (backslash && (!separator || backslash > separator)) {
+        separator = backslash;
+    }
+    /* No dot, dot at the start of the basename (hidden file), or dot inside
+     * a directory component: no usable extension. */
+    if (!dot || dot == filename || (separator && dot <= separator + 1)) {
         return NULL;
     }
 

--- a/src/kitty_graphics.c
+++ b/src/kitty_graphics.c
@@ -7,6 +7,35 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#ifdef __ANDROID__
+/* Android (bionic) lacks POSIX shm_open/shm_unlink. Emulate them with
+ * regular files in the process temp directory; behavior within this
+ * process is equivalent (named file, ftruncate + MAP_SHARED mmap). */
+static gchar *pixelterm_shm_path(const char *name) {
+    /* shm names start with '/'; use a flat, uniquely prefixed file name
+     * directly inside the temp directory so no subdirectory is needed. */
+    const char *name_ptr = (name && name[0] == '/') ? name + 1 : name;
+    gchar *filename = g_strdup_printf("pixelterm-shm-%s", name_ptr ? name_ptr : "");
+    gchar *path = g_build_filename(g_get_tmp_dir(), filename, NULL);
+    g_free(filename);
+    return path;
+}
+
+static int shm_open(const char *name, int oflag, mode_t mode) {
+    gchar *path = pixelterm_shm_path(name);
+    int fd = open(path, oflag, mode);
+    g_free(path);
+    return fd;
+}
+
+static int shm_unlink(const char *name) {
+    gchar *path = pixelterm_shm_path(name);
+    int result = unlink(path);
+    g_free(path);
+    return result;
+}
+#endif
+
 /* Keep shared-memory transfers bounded; larger frames fall back to direct kitty output. */
 #define KITTY_GRAPHICS_SHM_MAX_PAYLOAD_BYTES (8 * 1024 * 1024)
 

--- a/src/kitty_graphics.c
+++ b/src/kitty_graphics.c
@@ -10,12 +10,18 @@
 #ifdef __ANDROID__
 /* Android (bionic) lacks POSIX shm_open/shm_unlink. Emulate them with
  * regular files in the process temp directory; behavior within this
- * process is equivalent (named file, ftruncate + MAP_SHARED mmap). */
+ * process is equivalent (named file, ftruncate + MAP_SHARED mmap).
+ *
+ * oflag is passed through to open() on a regular file, which preserves
+ * POSIX shm semantics: O_CREAT|O_EXCL still fails with EEXIST when the
+ * file already exists, and O_TRUNC/O_APPEND behave as specified. */
 static gchar *pixelterm_shm_path(const char *name) {
-    /* shm names start with '/'; use a flat, uniquely prefixed file name
-     * directly inside the temp directory so no subdirectory is needed. */
+    /* shm names start with '/'; strip it and normalize any remaining
+     * '/' to '_' so the file is always flat inside the temp directory
+     * and no (possibly missing) subdirectory is ever referenced. */
     const char *name_ptr = (name && name[0] == '/') ? name + 1 : name;
     gchar *filename = g_strdup_printf("pixelterm-shm-%s", name_ptr ? name_ptr : "");
+    g_strdelimit(filename, "/", '_');
     gchar *path = g_build_filename(g_get_tmp_dir(), filename, NULL);
     g_free(filename);
     return path;

--- a/src/video_player_debug.c
+++ b/src/video_player_debug.c
@@ -62,9 +62,11 @@ static void video_player_debug_config_init_unlocked(void) {
 
     const gchar *path_env = pixelterm_getenv("PIXELTERM_DEBUG_VIDEO_LOG");
     if (!path_env || !*path_env) {
-        path_env = "/tmp/pixelterm-video.log";
+        video_player_debug_config.path =
+            g_build_filename(g_get_tmp_dir(), "pixelterm-video.log", NULL);
+    } else {
+        video_player_debug_config.path = g_strdup(path_env);
     }
-    video_player_debug_config.path = g_strdup(path_env);
     video_player_debug_config.initialized = TRUE;
 }
 


### PR DESCRIPTION
Fixes #33.

Three independent fixes that make PixelTerm-C build and pass its full test suite on Android (Termux, aarch64, bionic libc):

1. **`get_file_extension` false positive on dotted directories** (`src/common.c`) — the last dot was searched across the whole path instead of the basename, so files without an extension inside a dotted directory (e.g. Termux's `com.termux` tmp path, or any `my.dir/` on Linux/macOS) got a bogus "extension" and `is_image_file()` never fell back to content sniffing. This bug is platform-independent; Termux merely exposed it in `test_is_image_file_extension_and_content`.

2. **Default video debug log path unwritable on Android** (`src/video_player_debug.c`) — the hardcoded `/tmp/pixelterm-video.log` fallback fails on Android where `/tmp` is not app-writable; now built from `g_get_tmp_dir()`.

3. **Missing `shm_open`/`shm_unlink` on Android** (`src/kitty_graphics.c`) — bionic does not implement POSIX shared memory objects, breaking the build. An `__ANDROID__` shim emulates both calls with a named regular file in the process temp directory (`open` + `ftruncate` + `MAP_SHARED`), equivalent for this in-process use.

## Test plan

- Built on Termux (clang, aarch64) with and without mupdf support
- Full test suite passes: 322/322 GLib tests (TAP) + `scripts/test_install_script.py` (17 tests)
- Smoke-tested image rendering (`--protocol text`) on-device

## 由 Sourcery 提供的总结

通过修复文件扩展名检测、让视频调试日志路径使用系统临时目录，以及为缺失的共享内存 API 提供 Android 补丁，提升了可移植性和 Android（Termux）支持。

错误修复：
- 修正文件扩展名检测逻辑，忽略目录路径中的点号和隐藏文件前缀中的点号，从而正确处理没有真实扩展名的文件。
- 将默认视频调试日志位置更改为系统临时目录下的可写路径，而不是硬编码为 /tmp 路径。
- 添加 Android 特定的 `shm_open` 和 `shm_unlink` 回退实现，在进程临时目录中使用普通文件，从而在 bionic 上恢复 kitty 图形的共享内存支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve portability and Android (Termux) support by fixing file extension detection, making the video debug log path use the system temp directory, and providing Android shims for missing shared-memory APIs.

Bug Fixes:
- Correct file extension detection to ignore dots in directory components and hidden-file prefixes so files without real extensions are handled properly.
- Change the default video debug log location to a writable path under the system temporary directory instead of a hardcoded /tmp path.
- Add Android-specific fallback implementations of shm_open and shm_unlink using regular files in the process temp directory to restore kitty graphics shared-memory support on bionic.

</details>

Bug 修复：
- 修正文件扩展名检测逻辑，忽略目录路径中的点号以及以点开头的隐藏文件名，使得没有实际扩展名的文件也能被正确处理。
- 将默认的视频调试日志路径改为使用系统临时目录，确保在 Android 和其他平台上该路径是可写的。
- 为 Android 上的 `shm_open` 和 `shm_unlink` 提供特定的后备方案，在进程的临时目录中使用普通文件，从而在基于 bionic libc 的系统上恢复 kitty 图形所需的共享内存功能。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

通过修复文件扩展名检测、让视频调试日志路径使用系统临时目录，以及为缺失的共享内存 API 提供 Android 补丁，提升了可移植性和 Android（Termux）支持。

错误修复：
- 修正文件扩展名检测逻辑，忽略目录路径中的点号和隐藏文件前缀中的点号，从而正确处理没有真实扩展名的文件。
- 将默认视频调试日志位置更改为系统临时目录下的可写路径，而不是硬编码为 /tmp 路径。
- 添加 Android 特定的 `shm_open` 和 `shm_unlink` 回退实现，在进程临时目录中使用普通文件，从而在 bionic 上恢复 kitty 图形的共享内存支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve portability and Android (Termux) support by fixing file extension detection, making the video debug log path use the system temp directory, and providing Android shims for missing shared-memory APIs.

Bug Fixes:
- Correct file extension detection to ignore dots in directory components and hidden-file prefixes so files without real extensions are handled properly.
- Change the default video debug log location to a writable path under the system temporary directory instead of a hardcoded /tmp path.
- Add Android-specific fallback implementations of shm_open and shm_unlink using regular files in the process temp directory to restore kitty graphics shared-memory support on bionic.

</details>

</details>

Bug 修复：
- 修正文件扩展名检测逻辑，忽略父目录名称中的点号，确保无扩展名的图像文件也能被正确处理。
- 将默认视频调试日志文件路径改为使用系统临时目录，从而在 `/tmp` 不可写的平台上也能正常记录日志。
- 为 `shm_open` 和 `shm_unlink` 提供兼容 Android 的回退实现，以在 bionic libc 上恢复 kitty 图形的共享内存支持。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

通过修复文件扩展名检测、让视频调试日志路径使用系统临时目录，以及为缺失的共享内存 API 提供 Android 补丁，提升了可移植性和 Android（Termux）支持。

错误修复：
- 修正文件扩展名检测逻辑，忽略目录路径中的点号和隐藏文件前缀中的点号，从而正确处理没有真实扩展名的文件。
- 将默认视频调试日志位置更改为系统临时目录下的可写路径，而不是硬编码为 /tmp 路径。
- 添加 Android 特定的 `shm_open` 和 `shm_unlink` 回退实现，在进程临时目录中使用普通文件，从而在 bionic 上恢复 kitty 图形的共享内存支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve portability and Android (Termux) support by fixing file extension detection, making the video debug log path use the system temp directory, and providing Android shims for missing shared-memory APIs.

Bug Fixes:
- Correct file extension detection to ignore dots in directory components and hidden-file prefixes so files without real extensions are handled properly.
- Change the default video debug log location to a writable path under the system temporary directory instead of a hardcoded /tmp path.
- Add Android-specific fallback implementations of shm_open and shm_unlink using regular files in the process temp directory to restore kitty graphics shared-memory support on bionic.

</details>

Bug 修复：
- 修正文件扩展名检测逻辑，忽略目录路径中的点号以及以点开头的隐藏文件名，使得没有实际扩展名的文件也能被正确处理。
- 将默认的视频调试日志路径改为使用系统临时目录，确保在 Android 和其他平台上该路径是可写的。
- 为 Android 上的 `shm_open` 和 `shm_unlink` 提供特定的后备方案，在进程的临时目录中使用普通文件，从而在基于 bionic libc 的系统上恢复 kitty 图形所需的共享内存功能。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

通过修复文件扩展名检测、让视频调试日志路径使用系统临时目录，以及为缺失的共享内存 API 提供 Android 补丁，提升了可移植性和 Android（Termux）支持。

错误修复：
- 修正文件扩展名检测逻辑，忽略目录路径中的点号和隐藏文件前缀中的点号，从而正确处理没有真实扩展名的文件。
- 将默认视频调试日志位置更改为系统临时目录下的可写路径，而不是硬编码为 /tmp 路径。
- 添加 Android 特定的 `shm_open` 和 `shm_unlink` 回退实现，在进程临时目录中使用普通文件，从而在 bionic 上恢复 kitty 图形的共享内存支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve portability and Android (Termux) support by fixing file extension detection, making the video debug log path use the system temp directory, and providing Android shims for missing shared-memory APIs.

Bug Fixes:
- Correct file extension detection to ignore dots in directory components and hidden-file prefixes so files without real extensions are handled properly.
- Change the default video debug log location to a writable path under the system temporary directory instead of a hardcoded /tmp path.
- Add Android-specific fallback implementations of shm_open and shm_unlink using regular files in the process temp directory to restore kitty graphics shared-memory support on bionic.

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Android (Termux) builds and make the full test suite pass by fixing extension parsing, default debug log path, and missing shared-memory APIs. Fixes #33.

- **Bug Fixes**
  - get_file_extension: only consider dots after the last path separator (`/` or `\`); ignore hidden-file dots; restores content sniffing when no real extension.
  - video_player_debug: build default log path from `g_get_tmp_dir()`; avoids unwritable `/tmp` on Android.
  - kitty_graphics: Android shim for `shm_open`/`shm_unlink` via temp-dir files (`open` + `ftruncate` + `MAP_SHARED`); normalize names (replace `/` with `_`) to avoid nested paths; POSIX-equivalent `oflag` behavior.

<sup>Written for commit 6cb023c13fe67b4ec67f142b872035a58fba3882. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zouyonghe/PixelTerm-C/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

